### PR TITLE
feature: add basic plausible integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ Have a good idea or noticed something that could be improved?
 - [x] ~~Migrate timeline to `.md`~~ → Migrated to YAML in `content/es|en/timeline.yml`
 - [ ] ~~Configure custom domain~~ → **helpmiriam.com**
 - [ ] Consider adding an RSS feed for timeline updates
-- [ ] Analytics (Plausible or similar, not Google Analytics — consistency with privacy message)
+- [x] ~~Analytics~~ → `@nuxtjs/plausible` 3.0.2 (privacy-first, ignores localhost, consistent with privacy message)
 
 ### SEO
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An informational website about Miriam González Pérez's case: metastatic breast
 - **@nuxtjs/seo** — SEO meta, OG images, robots, sitemap, schema.org
 - **@nuxtjs/sitemap** — XML sitemap with i18n hreflang
 - **nuxt-ai-ready** — AI/LLM readiness (`/llms.txt`)
+- **@nuxtjs/plausible** — privacy-first analytics (ignores localhost)
 - **Tailwind CSS** — styles
 - **@nuxt/icon** — icons (Phosphor Icons via Iconify)
 - **Netlify Forms** — contact form (no backend)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
 export default defineNuxtConfig({
   compatibilityDate: '2025-04-01',
 
-  modules: ['@nuxtjs/tailwindcss', '@nuxtjs/i18n', '@nuxt/icon', '@nuxtjs/seo', '@nuxtjs/sitemap', '@nuxt/content', 'nuxt-ai-ready'],
+  modules: ['@nuxtjs/tailwindcss', '@nuxtjs/i18n', '@nuxt/icon', '@nuxtjs/seo', '@nuxtjs/sitemap', '@nuxt/content', 'nuxt-ai-ready', '@nuxtjs/plausible'],
 
   site: {
     url: 'https://helpmiriam.com',
@@ -22,6 +22,10 @@ export default defineNuxtConfig({
         },
       ],
     },
+  },
+
+  plausible: {
+    ignoredHostnames: ['localhost'],
   },
 
   i18n: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@nuxt/content": "^3.13.0",
     "@nuxtjs/i18n": "^10.3.0",
+    "@nuxtjs/plausible": "3.0.2",
     "@nuxtjs/robots": "^6.0.8",
     "@nuxtjs/seo": "5.1.3",
     "@nuxtjs/sitemap": "^8.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@nuxtjs/i18n':
         specifier: ^10.3.0
         version: 10.3.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@vue/compiler-dom@3.5.34)(db0@0.3.4(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(better-sqlite3@12.9.0)))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(magicast@0.5.2)(rollup@4.60.3)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      '@nuxtjs/plausible':
+        specifier: 3.0.2
+        version: 3.0.2(magicast@0.5.2)
       '@nuxtjs/robots':
         specifier: ^6.0.8
         version: 6.0.8(@nuxt/schema@4.4.4)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(better-sqlite3@12.9.0)))(drizzle-orm@0.45.2(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.1)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4))(yaml@2.8.4))(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))(zod@3.25.76)
@@ -1377,6 +1380,9 @@ packages:
   '@nuxtjs/mdc@0.21.1':
     resolution: {integrity: sha512-DIeUD7IahWVUSoZExysxH9dX51Io6hcQYgGJODq0cMTGqaoDD32lRfHBJxYUmy+sUCV1+1hfa2ixspgJgEd2GA==}
 
+  '@nuxtjs/plausible@3.0.2':
+    resolution: {integrity: sha512-6z01a7XbggSmI4CTWCkDDmLHQNm7wob2dx1QnvpIoo+YEV19298+GsuvlBclXVxXSk7op8r8qJpw25xKo8mzQQ==}
+
   '@nuxtjs/robots@6.0.8':
     resolution: {integrity: sha512-oVP4p3TbolnP+Ky3sFFU6Y19pecz8jtb2AxnrQa8hSj3auqVmJUxexjbFEBnA8+yeWCWAEcXCqlnz5mmJmLCSQ==}
     peerDependencies:
@@ -2400,6 +2406,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@plausible-analytics/tracker@0.4.5':
+    resolution: {integrity: sha512-6BfAGejXY+YA3Cw6LYT2Zpn4hTxDtPQAawFsYUsQCOg78wIS5C4deAGXTfJffa5VleMWITv5lpJ/EYuQBl1tPA==}
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -9032,6 +9041,15 @@ snapshots:
       - magicast
       - supports-color
 
+  '@nuxtjs/plausible@3.0.2(magicast@0.5.2)':
+    dependencies:
+      '@nuxt/kit': 4.4.4(magicast@0.5.2)
+      '@plausible-analytics/tracker': 0.4.5
+      defu: 6.1.7
+      ufo: 1.6.4
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxtjs/robots@6.0.8(@nuxt/schema@4.4.4)(magicast@0.5.2)(nuxt@4.4.4(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.6.2)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(better-sqlite3@12.9.0)))(drizzle-orm@0.45.2(better-sqlite3@12.9.0))(eslint@10.3.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.60.3))(rollup@4.60.3)(srvx@0.11.15)(terser@5.47.1)(typescript@5.9.3)(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4))(yaml@2.8.4))(vite@7.3.3(@types/node@25.6.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))(zod@3.25.76)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
@@ -9716,6 +9734,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@plausible-analytics/tracker@0.4.5': {}
 
   '@polka/url@1.0.0-next.29': {}
 


### PR DESCRIPTION


## 📋 Pull Request

### Description
This PR adds Plausible privacy-friendly tracking.

Holding off of a more complete solution until we get the redesign, which might change some things and what we track.

The setup works well. Note that some adblockers won't run the script at all.

### Changes
- Adds the Plausible Nuxt module. It requires no config
- Disabled localhost tracking
- [x] Code changes follow the project's coding standards
### Testing
Tested network calls and Plausible is returning HTTP 200.

- [x] Tested on mobile viewport
- [x] Tested on desktop viewport
- [x] No console errors (if adblock is disabled, but nothing we can realistically do about it)
