### PR TITLE
fix: fix design system overflow

### DIFF
--- a/public/design-system/design-system.css
+++ b/public/design-system/design-system.css
@@ -2,7 +2,7 @@
    Imports tokens.css for variables and base components. */
 
 /* Prevent horizontal overflow globally */
-html, body { overflow-x: hidden; max-width: 100%; }
+body { overflow-x: hidden; max-width: 100%; }
 
 /* Layout shell */
 .ds-shell {


### PR DESCRIPTION
## 📋 Pull Request

### Description
Prevents weird behavior caused by clipping the root element (`<html>`). #9 accidentally broke the sticky navigation and I didn't notice.

### Testing

- [x] Tested on mobile viewport - Still responsive
- [x] Tested on desktop viewport - Sticky works!
- [x] No console errors
