### PR TITLE
improve color contrast in design sistem palette

### DIFF
--- a/public/design-system/design-system.css
+++ b/public/design-system/design-system.css
@@ -176,10 +176,10 @@ body {
   color: var(--color-text);
 }
 .journey .step-2 h4 {
-  color: var(--color-miriam);
+  color: var(--color-text);
 }
 .journey .step-3 h4 {
-  color: var(--color-cta);
+  color: var(--color-text);
 }
 .journey p {
   font-size: 14px;
@@ -628,7 +628,7 @@ body {
   color: #ffe0d6;
 }
 .code .c-com {
-  color: rgba(245, 239, 230, 0.45);
+  color: #a89ab2;
   font-style: italic;
 }
 
@@ -774,4 +774,8 @@ ul.checklist.dont li::before {
   .ratio-bar {
     width: 80px;
   }
+}
+
+@keyframes ds-spin {
+  to { transform: rotate(360deg); }
 }

--- a/public/design-system/index.html
+++ b/public/design-system/index.html
@@ -12,7 +12,7 @@
     />
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="apple-touch-icon" href="apple-touch-icon.svg" />
-    <meta name="theme-color" content="#A855B5" />
+    <meta name="theme-color" content="#A44DB2" />
     <link rel="stylesheet" href="tokens.css" />
     <link rel="stylesheet" href="design-system.css" />
   </head>
@@ -38,11 +38,11 @@
         <div><b>Idea central</b>Ciencia → humanidad → acción</div>
         <div>
           <b>Identidad</b>Violeta
-          <code style="color: var(--color-miriam)">#A855B5</code>
+          <code style="color: #a44db2">#A44DB2</code>
         </div>
         <div>
           <b>Acción</b>Coral
-          <code style="color: var(--color-cta)">#FF6B47</code>
+          <code style="color: #ff6b47">#FF6B47</code>
         </div>
         <div><b>Lectura</b>~18 min · si tienes prisa, 00 · 01 · 10</div>
       </div>
@@ -69,7 +69,7 @@
               </text>
               <path
                 d="M 12 16 L 12.7 18 L 14.7 18.7 L 12.7 19.4 L 12 21.4 L 11.3 19.4 L 9.3 18.7 L 11.3 18 Z"
-                fill="#A855B5"
+                fill="#A44DB2"
               />
               <path
                 d="M 52 14 L 53 17 L 56 18 L 53 19 L 52 22 L 51 19 L 48 18 L 51 17 Z"
@@ -77,7 +77,7 @@
               />
               <path
                 d="M 50 50 L 50.7 52 L 52.7 52.7 L 50.7 53.4 L 50 55.4 L 49.3 53.4 L 47.3 52.7 L 49.3 52 Z"
-                fill="#A855B5"
+                fill="#A44DB2"
               />
             </svg>
           </div>
@@ -153,7 +153,7 @@
                   font-size: 11px;
                   letter-spacing: 0.1em;
                   text-transform: uppercase;
-                  color: var(--color-miriam);
+                  color: var(--color-text-soft);
                   margin-bottom: 8px;
                 "
               >
@@ -201,7 +201,7 @@
                   font-size: 11px;
                   letter-spacing: 0.1em;
                   text-transform: uppercase;
-                  color: var(--color-miriam);
+                  color: var(--color-text-soft);
                   margin-bottom: 8px;
                 "
               >
@@ -213,7 +213,7 @@
                   style="
                     font-family: var(--font-mono);
                     font-size: 13px;
-                    color: var(--color-miriam);
+                    color: var(--color-text);
                   "
                   >tokens.css</code
                 >.
@@ -276,16 +276,16 @@
                   font-size: 11px;
                   letter-spacing: 0.1em;
                   text-transform: uppercase;
-                  color: var(--color-miriam);
+                  color: var(--color-text-soft);
                   margin-bottom: 8px;
                 "
               >
                 Si redactas o usas IA
               </div>
               <h3 style="margin: 0 0 12px; font-size: 20px">
-                Lee <a href="#voice" style="color: var(--color-miriam)">10</a>,
-                <a href="#do" style="color: var(--color-miriam)">11</a>,
-                <a href="#ai" style="color: var(--color-miriam)">13</a>.
+                Lee <a href="#voice" style="color: var(--color-text)">10</a>,
+                <a href="#do" style="color: var(--color-text)">11</a>,
+                <a href="#ai" style="color: var(--color-text)">13</a>.
               </h3>
               <ul
                 style="
@@ -398,7 +398,7 @@
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)">Versión.</strong> v1.1 ·
+            <strong style="color: var(--color-text)">Versión.</strong> v1.1 ·
             mayo 2026. Si añades una expresión, plantilla, componente o regla
             nueva, anótala con fecha al final del archivo y avisa al equipo. El
             sistema se afina con el uso.
@@ -555,10 +555,10 @@
           <h2>Color.</h2>
           <p class="lede">
             Cinco colores totales.
-            <strong style="color: var(--color-miriam); font-weight: 600"
+            <strong style="color: var(--color-text); font-weight: 600"
               >Violeta = identidad.</strong
             >
-            <strong style="color: var(--color-cta); font-weight: 600"
+            <strong style="color: #2d1b3d; font-weight: 600"
               >Coral = acción.</strong
             >
             Esa distinción es lo que hace que el sistema funcione.
@@ -599,14 +599,14 @@
               </div>
             </div>
             <div class="swatch">
-              <div class="chip" style="background: #a855b5"></div>
+              <div class="chip" style="background: #a44db2"></div>
               <div class="body">
-                <span class="role" style="background: #e8d4ed; color: #a855b5"
+                <span class="role" style="background: #e8d4ed; color: #2d1b3d"
                   >Firma</span
                 >
                 <h4>Violeta Miriam</h4>
                 <div class="hex">
-                  <span>#A855B5</span><span>168 · 85 · 181</span>
+                  <span>#A44DB2</span><span>164 · 77 · 178</span>
                 </div>
                 <p>
                   Identifica AL CASO. El pelo del avatar, badges, anotaciones,
@@ -619,7 +619,7 @@
               <div class="body">
                 <span
                   class="role"
-                  style="background: rgba(255, 107, 71, 0.15); color: #ff6b47"
+                  style="background: rgba(255, 107, 71, 0.15); color: #2d1b3d"
                   >Acción</span
                 >
                 <h4>Coral</h4>
@@ -667,7 +667,7 @@
             <div class="swatch">
               <div class="chip" style="background: #e8d4ed"></div>
               <div class="body">
-                <span class="role" style="background: #e8d4ed; color: #a855b5"
+                <span class="role" style="background: #e8d4ed; color: #2d1b3d"
                   >Badges</span
                 >
                 <h4>Violeta soft</h4>
@@ -723,7 +723,7 @@
 <span class="c-key">--color-cta-hover</span>: <span class="c-val">#E5573A</span>;
 
 <span class="c-com">/* Específicas del Caso Miriam */</span>
-<span class="c-key">--color-miriam</span>:      <span class="c-val">#A855B5</span>;
+<span class="c-key">--color-miriam</span>:      <span class="c-val">#A44DB2</span>;
 <span class="c-key">--color-miriam-soft</span>: <span class="c-val">#E8D4ED</span>;</pre>
 
           <h3 style="margin-top: 40px">Notas modernas (2026)</h3>
@@ -742,7 +742,7 @@
                 style="
                   font-family: var(--font-mono);
                   font-size: 12px;
-                  color: var(--color-miriam);
+                  color: var(--color-text);
                 "
                 >color-mix(in oklab, var(--color-miriam) 20%, transparent)</code
               >
@@ -804,7 +804,7 @@
                 style="
                   font-family: var(--font-mono);
                   font-size: 11px;
-                  color: rgba(45, 27, 61, 0.6);
+                  color: #3a3340;
                   margin-top: 8px;
                 "
               >
@@ -834,7 +834,7 @@
                   font-family: var(--font-display);
                   font-weight: 600;
                   font-size: 40px;
-                  color: #a855b5;
+                  color: #a44db2;
                   line-height: 1;
                 "
               >
@@ -844,7 +844,7 @@
                 style="
                   font-family: var(--font-mono);
                   font-size: 11px;
-                  color: rgba(45, 27, 61, 0.6);
+                  color: #a44db2;
                   margin-top: 8px;
                 "
               >
@@ -858,23 +858,18 @@
                   color: var(--color-text-soft);
                 "
               >
-                Violeta s/ crema · firma del caso
+                Violeta s/ crema · AA cualquier tamaño · no sobre crema-card
               </div>
             </div>
             <div
-              style="
-                background: #faf6f0;
-                border-radius: 10px;
-                padding: 24px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-              "
+              style="background: #ff6b47; border-radius: 10px; padding: 24px"
             >
               <div
                 style="
                   font-family: var(--font-display);
                   font-weight: 600;
                   font-size: 40px;
-                  color: #ff6b47;
+                  color: #2d1b3d;
                   line-height: 1;
                 "
               >
@@ -884,7 +879,7 @@
                 style="
                   font-family: var(--font-mono);
                   font-size: 11px;
-                  color: rgba(45, 27, 61, 0.6);
+                  color: #2d1b3d;
                   margin-top: 8px;
                 "
               >
@@ -895,10 +890,10 @@
                   margin-top: 16px;
                   font-family: var(--font-mono);
                   font-size: 10px;
-                  color: var(--color-text-soft);
+                  color: #2d1b3d;
                 "
               >
-                Coral s/ crema · acción / urgencia
+                Berenjena s/ coral · surface CTA
               </div>
             </div>
             <div
@@ -1019,23 +1014,26 @@
             "
           >
             <li>
-              <strong>Violeta firma sobre berenjena.</strong> Contraste
-              insuficiente — el dato se apaga. Si necesitas violeta sobre fondo
-              oscuro, usa
+              <strong>Coral sobre crema para texto.</strong> Falla incluso para
+              texto grande. El coral solo es legible sobre berenjena o tinta.
+              El botón primario debe llevar texto berenjena, no crema.
+            </li>
+            <li>
+              <strong>Violeta firma sobre berenjena en texto pequeño.</strong>
+              Pasa solo en titulares grandes (≥24px / ≥18.67px bold). Para
+              texto de cuerpo o eyebrow sobre berenjena, usa
               <code style="font-family: var(--font-mono); font-size: 12px"
                 >--color-miriam-soft</code
               >
-              (#E8D4ED).
+              (#E8D4ED) que sí pasa.
             </li>
             <li>
-              <strong>Coral sobre violeta firma o coral-soft.</strong> Vibra y
-              cansa la vista. El coral solo respira sobre crema o berenjena.
+              <strong>Violeta firma sobre tinta #3A3340.</strong> No pasa
+              contraste. No usar en ningún tamaño.
             </li>
             <li>
-              <strong>Coral sobre coral suave</strong> (texto coral en card de
-              fondo coral 10%). Funciona como acento de marca pero no como dato
-              — contraste por debajo de AA. Si quieres ese ambiente, usa
-              berenjena para el número.
+              <strong>Coral sobre violeta firma.</strong> Vibra y cansa la
+              vista. El coral solo respira sobre berenjena o tinta.
             </li>
             <li>
               <strong>Dos acentos en la misma tarjeta.</strong> Violeta y coral
@@ -1078,7 +1076,7 @@
                   font-family: var(--font-mono);
                   font-size: 11px;
                   letter-spacing: 0.08em;
-                  color: rgba(45, 27, 61, 0.55);
+                  color: #3a3340;
                   text-transform: uppercase;
                 "
               >
@@ -1118,7 +1116,7 @@
                 "
               >
                 crema #FAF6F0 + berenjena #2D1B3D &middot;
-                <strong style="color: #2d1b3d">14.8:1</strong> &middot; AAA
+                <strong style="color: #2d1b3d">14.6:1</strong> &middot; AAA
               </div>
             </div>
 
@@ -1171,7 +1169,7 @@
                 "
               >
                 berenjena #2D1B3D + crema #FAF6F0 &middot;
-                <strong style="color: #faf6f0">14.8:1</strong> &middot; AAA
+                <strong style="color: #faf6f0">14.6:1</strong> &middot; AAA
               </div>
             </div>
 
@@ -1224,8 +1222,8 @@
                 "
               >
                 berenjena + violeta-soft
-                <strong style="color: #e8d4ed">7.6:1</strong> + crema
-                <strong style="color: #faf6f0">14.8:1</strong> &middot; AAA
+                <strong style="color: #e8d4ed">11.28:1</strong> + crema
+                <strong style="color: #faf6f0">14.6:1</strong> &middot; AAA
               </div>
             </div>
 
@@ -1243,7 +1241,7 @@
                   font-family: var(--font-mono);
                   font-size: 11px;
                   letter-spacing: 0.08em;
-                  color: rgba(45, 27, 61, 0.55);
+                  color: #3a3340;
                   text-transform: uppercase;
                 "
               >
@@ -1275,7 +1273,7 @@
               <button
                 style="
                   background: #ff6b47;
-                  color: #faf6f0;
+                  color: #2d1b3d;
                   border: none;
                   padding: 12px 20px;
                   border-radius: 8px;
@@ -1297,9 +1295,8 @@
                   color: var(--color-text-soft);
                 "
               >
-                crema + berenjena
-                <strong style="color: #2d1b3d">14.8:1</strong> · botón coral +
-                crema <strong style="color: #ff6b47">3.7:1</strong> ≥ AA UI
+                crema + berenjena · botón: coral + berenjena — coral +
+                crema falla
               </div>
             </div>
 
@@ -1312,7 +1309,7 @@
                   font-family: var(--font-mono);
                   font-size: 11px;
                   letter-spacing: 0.08em;
-                  color: rgba(45, 27, 61, 0.6);
+                  color: #2d1b3d;
                   text-transform: uppercase;
                 "
               >
@@ -1349,11 +1346,11 @@
                   border-top: 1px solid rgba(45, 27, 61, 0.15);
                   font-family: var(--font-mono);
                   font-size: 10px;
-                  color: rgba(45, 27, 61, 0.55);
+                  color: #2d1b3d;
                 "
               >
                 violeta-soft #E8D4ED + berenjena
-                <strong style="color: #2d1b3d">12.3:1</strong> · AAA
+                <strong style="color: #2d1b3d">11.28:1</strong> · AAA
               </div>
             </div>
 
@@ -1366,7 +1363,7 @@
                   font-family: var(--font-mono);
                   font-size: 11px;
                   letter-spacing: 0.08em;
-                  color: rgba(45, 27, 61, 0.55);
+                  color: #3a3340;
                   text-transform: uppercase;
                 "
               >
@@ -1403,11 +1400,11 @@
                   border-top: 1px solid rgba(45, 27, 61, 0.1);
                   font-family: var(--font-mono);
                   font-size: 10px;
-                  color: rgba(45, 27, 61, 0.6);
+                  color: #3a3340;
                 "
               >
                 crema-card #F5EFE6 + berenjena
-                <strong style="color: #2d1b3d">14.0:1</strong> · AAA
+                <strong style="color: #2d1b3d">13.75:1</strong> · AAA
               </div>
             </div>
           </div>
@@ -1454,7 +1451,7 @@
                   text-transform: uppercase;
                 "
               >
-                Falla
+                Falla en texto pequeño
               </div>
               <div
                 style="
@@ -1465,14 +1462,14 @@
                   text-transform: uppercase;
                 "
               >
-                Violeta firma s/ berenjena
+                Violeta firma s/ berenjena en body
               </div>
               <h4
                 style="
                   font-family: var(--font-display);
                   font-weight: 500;
                   font-size: 28px;
-                  color: #a855b5;
+                  color: #a44db2;
                   margin: 8px 0 12px;
                   line-height: 1.15;
                 "
@@ -1483,20 +1480,14 @@
                 style="
                   font-size: 14px;
                   line-height: 1.55;
-                  color: rgba(250, 246, 240, 0.7);
+                  color: #a44db2;
                   margin: 0;
                 "
               >
-                El violeta firma se apaga sobre berenjena. Para firma en oscuro
-                usar siempre
-                <code
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 12px;
-                    color: #e8d4ed;
-                  "
-                  >--color-miriam-soft</code
-                >.
+                Este cuerpo de texto (14px) con violeta sobre berenjena falla
+                AA para texto normal (necesita ≥4.5:1). Solo es válido en
+                titulares ≥24px. Para texto corrido sobre berenjena, usa
+                crema.
               </p>
               <div
                 style="
@@ -1508,9 +1499,7 @@
                   color: rgba(250, 246, 240, 0.5);
                 "
               >
-                berenjena + violeta firma
-                <strong style="color: #ff6b47">2.3:1</strong> · ✗ por debajo de
-                AA
+                berenjena + violeta firma · ✗ texto normal · ✓ solo titular ≥24px
               </div>
             </div>
 
@@ -1572,9 +1561,9 @@
                   margin: 0;
                 "
               >
-                El coral tiñe titular y cuerpo. Tono telethon. Contraste 3.7:1 —
-                pasa para texto grande, falla para texto pequeño. Y agota la
-                vista en 5 segundos.
+                El coral tiñe titular y cuerpo. Tono telethon. Contraste
+                2.62:1 — falla incluso para texto grande (necesita ≥3:1). Y
+                agota la vista en 5 segundos.
               </p>
               <div
                 style="
@@ -1586,8 +1575,8 @@
                   color: rgba(45, 27, 61, 0.6);
                 "
               >
-                coral en cuerpo <strong style="color: #ff6b47">3.7:1</strong> ·
-                ✗ AA solo en grande, ✗ slop visual
+                coral en cuerpo <strong style="color: #ff6b47">2.62:1</strong> ·
+                ✗ falla en todo tamaño · ✗ slop visual
               </div>
             </div>
 
@@ -1623,7 +1612,7 @@
                   font-family: var(--font-mono);
                   font-size: 11px;
                   letter-spacing: 0.08em;
-                  color: #a855b5;
+                  color: #a44db2;
                   text-transform: uppercase;
                 "
               >
@@ -1639,7 +1628,7 @@
                   line-height: 1.15;
                 "
               >
-                Caso <span style="color: #a855b5">único</span> · ayuda
+                Caso <span style="color: #a44db2">único</span> · ayuda
                 <span style="color: #ff6b47">urgente</span>.
               </h4>
               <p
@@ -1740,7 +1729,7 @@
                 "
               >
                 violeta-soft + coral
-                <strong style="color: #ff6b47">2.9:1</strong> · ✗ AA falla y
+                <strong style="color: #ff6b47">2.02:1</strong> · ✗ AA falla y
                 vibra
               </div>
             </div>
@@ -1785,7 +1774,7 @@
                       color: var(--color-text-soft);
                     "
                   >
-                    Titular / cuerpo
+                    Texto cualquier tamaño (≥4.5:1)
                   </th>
                   <th
                     style="
@@ -1798,7 +1787,7 @@
                       color: var(--color-text-soft);
                     "
                   >
-                    Eyebrow / firma
+                    Solo titular ≥24px (≥3:1)
                   </th>
                   <th
                     style="
@@ -1811,7 +1800,7 @@
                       color: var(--color-text-soft);
                     "
                   >
-                    Acento / CTA
+                    Nota
                   </th>
                 </tr>
               </thead>
@@ -1830,15 +1819,18 @@
                         margin-right: 8px;
                       "
                     ></span
-                    >crema #FAF6F0
+                    >Crema #FAF6F0
                   </td>
-                  <td style="padding: 12px">berenjena #2D1B3D</td>
-                  <td style="padding: 12px">violeta firma #A855B5</td>
                   <td style="padding: 12px">
-                    coral #FF6B47
-                    <em style="color: var(--color-text-soft); font-size: 12px"
-                      >(solo botón)</em
-                    >
+                    berenjena #2D1B3D<br />
+                    tinta #3A3340<br />
+                    violeta #A44DB2
+                  </td>
+                  <td style="padding: 12px">
+                    <em style="color: var(--color-text-soft); font-size: 12px">—</em>
+                  </td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Fondo universal. Coral aquí falla.
                   </td>
                 </tr>
                 <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
@@ -1855,11 +1847,16 @@
                         margin-right: 8px;
                       "
                     ></span
-                    >crema-card #F5EFE6
+                    >Crema profunda #F5EFE6
                   </td>
-                  <td style="padding: 12px">berenjena #2D1B3D</td>
-                  <td style="padding: 12px">violeta firma #A855B5</td>
-                  <td style="padding: 12px">coral #FF6B47</td>
+                  <td style="padding: 12px">
+                    berenjena #2D1B3D<br />
+                    tinta #3A3340
+                  </td>
+                  <td style="padding: 12px">violeta #A44DB2</td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Cards y bloques. Mismas reglas que crema.
+                  </td>
                 </tr>
                 <tr
                   style="
@@ -1879,18 +1876,46 @@
                         margin-right: 8px;
                       "
                     ></span
-                    >berenjena #2D1B3D
+                    >Berenjena #2D1B3D
                   </td>
-                  <td style="padding: 12px">crema #FAF6F0</td>
                   <td style="padding: 12px">
-                    <strong>violeta-soft #E8D4ED</strong>
+                    crema #FAF6F0<br />
+                    coral #FF6B47
+                  </td>
+                  <td style="padding: 12px">violeta #A44DB2</td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Énfasis oscuro. Eyebrow: usar violeta-soft.
+                  </td>
+                </tr>
+                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
+                  <td style="padding: 12px">
+                    <span
+                      style="
+                        display: inline-block;
+                        width: 14px;
+                        height: 14px;
+                        background: #a44db2;
+                        border-radius: 3px;
+                        vertical-align: middle;
+                        margin-right: 8px;
+                      "
+                    ></span
+                    >Violeta #A44DB2
+                  </td>
+                  <td style="padding: 12px">
                     <em style="color: var(--color-text-soft); font-size: 12px"
-                      >(no firma)</em
+                      >ninguno pasa para texto normal</em
                     >
                   </td>
-                  <td style="padding: 12px">coral #FF6B47</td>
+                  <td style="padding: 12px">
+                    crema #FAF6F0<br />
+                    berenjena #2D1B3D
+                  </td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Solo surface de firma. TODO el texto ≥24px.
+                  </td>
                 </tr>
-                <tr>
+                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
                   <td style="padding: 12px">
                     <span
                       style="
@@ -1903,14 +1928,57 @@
                         margin-right: 8px;
                       "
                     ></span
-                    >violeta-soft #E8D4ED
+                    >Violeta soft #E8D4ED
+                  </td>
+                  <td style="padding: 12px">
+                    berenjena #2D1B3D<br />
+                    tinta #3A3340
+                  </td>
+                  <td style="padding: 12px">violeta #A44DB2</td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Badges, callouts. No usar coral aquí.
+                  </td>
+                </tr>
+                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
+                  <td style="padding: 12px">
+                    <span
+                      style="
+                        display: inline-block;
+                        width: 14px;
+                        height: 14px;
+                        background: #ff6b47;
+                        border-radius: 3px;
+                        vertical-align: middle;
+                        margin-right: 8px;
+                      "
+                    ></span
+                    >Coral #FF6B47
                   </td>
                   <td style="padding: 12px">berenjena #2D1B3D</td>
-                  <td style="padding: 12px">berenjena al 60%</td>
+                  <td style="padding: 12px">tinta #3A3340</td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Solo botón CTA. Texto: berenjena. Crema falla.
+                  </td>
+                </tr>
+                <tr>
                   <td style="padding: 12px">
-                    <em style="color: var(--color-text-soft); font-size: 12px"
-                      >no usar coral aquí</em
-                    >
+                    <span
+                      style="
+                        display: inline-block;
+                        width: 14px;
+                        height: 14px;
+                        background: #3a3340;
+                        border-radius: 3px;
+                        vertical-align: middle;
+                        margin-right: 8px;
+                      "
+                    ></span
+                    >Tinta #3A3340
+                  </td>
+                  <td style="padding: 12px">crema #FAF6F0</td>
+                  <td style="padding: 12px">coral #FF6B47</td>
+                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
+                    Captions y metadatos elevados a fondo.
                   </td>
                 </tr>
               </tbody>
@@ -1929,7 +1997,7 @@
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)"
+            <strong style="color: var(--color-text)"
               >Regla de los tres colores por tarjeta.</strong
             >
             Cuenta los colores que ves en una card antes de aprobarla: fondo +
@@ -2096,7 +2164,7 @@
           <p style="font-size: 14px; color: var(--color-text-soft)">
             Ancho de columna óptimo:
             <code
-              style="font-family: var(--font-mono); color: var(--color-miriam)"
+              style="font-family: var(--font-mono); color: var(--color-text)"
               >65–75ch</code
             >
             (~65–75 caracteres por línea para texto corrido).
@@ -2116,9 +2184,9 @@
             relleno (no outline),
             <strong style="color: var(--color-text)">berenjena #2D1B3D</strong>
             como masa principal y
-            <strong style="color: var(--color-cta)">coral #FF6B47</strong> como
+            <strong style="color: #2d1b3d">coral #FF6B47</strong> como
             único acento por icono. En Miriam el acento alterna coral (acción) o
-            <strong style="color: var(--color-miriam)">violeta #A855B5</strong>
+            <strong style="color: var(--color-text)">violeta #A44DB2</strong>
             (firma).
           </p>
 
@@ -2238,10 +2306,10 @@
           >
             <strong style="color: var(--color-text)">Mapa de uso.</strong>
             <em>caso, equipo, historia, ia, datos, prensa</em> usan acento
-            <strong style="color: var(--color-miriam)">violeta firma</strong>
+            <strong style="color: var(--color-text)">violeta firma</strong>
             (identidad, contenido).
             <em>ayudar, donar, compartir, contacto</em> usan acento
-            <strong style="color: var(--color-cta)">coral</strong> (acción,
+            <strong style="color: #2d1b3d">coral</strong> (acción,
             conversión). Formato SVG vectorial, escalable de 24 a 256 px sin
             pérdida.
           </p>
@@ -2337,9 +2405,9 @@
               acento de color por icono.
             </li>
             <li>
-              Acento <strong style="color: var(--color-cta)">coral</strong> =
+              Acento <strong style="color: #2d1b3d">coral</strong> =
               acción (donar, compartir, contactar). Acento
-              <strong style="color: var(--color-miriam)">violeta</strong> =
+              <strong style="color: var(--color-text)">violeta</strong> =
               identidad/firma del caso.
             </li>
             <li>
@@ -2364,7 +2432,7 @@
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-cta)"
+            <strong style="color: #2d1b3d"
               >Sin set de iconos lineales propios.</strong
             >
             Miriam usa <strong>solo</strong> el set BTP (sección anterior) —
@@ -2524,7 +2592,7 @@
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)"
+            <strong style="color: var(--color-text)"
               >Honestidad de proceso.</strong
             >
             Estas herramientas evolucionan rápido — lo que hoy funciona con
@@ -2547,7 +2615,7 @@
   &lt;<span class="c-key">g</span> fill=<span class="c-val">"none"</span> stroke=<span class="c-val">"#2D1B3D"</span> stroke-width=<span class="c-val">"48"</span>
      stroke-linecap=<span class="c-val">"round"</span> stroke-linejoin=<span class="c-val">"round"</span>&gt;
     <span class="c-com">&lt;!-- contenido del icono --&gt;</span>
-    <span class="c-com">&lt;!-- acento: violeta #A855B5 (firma) o coral #FF6B47 (acción) --&gt;</span>
+    <span class="c-com">&lt;!-- acento: violeta #A44DB2 (firma) o coral #FF6B47 (acción) --&gt;</span>
   &lt;/<span class="c-key">g</span>&gt;
 &lt;/<span class="c-key">svg</span>&gt;</pre>
         </section>
@@ -2581,7 +2649,7 @@
                 <!-- Hair (violet) -->
                 <path
                   d="M 60 130 C 60 80, 100 50, 160 50 C 220 50, 260 80, 260 130 C 268 145, 270 165, 262 185 C 274 195, 274 215, 262 230 C 270 240, 264 256, 252 260 C 252 280, 240 290, 232 290 L 88 290 C 80 290, 68 280, 68 260 C 56 256, 50 240, 58 230 C 46 215, 46 195, 58 185 C 50 165, 52 145, 60 130 Z"
-                  fill="#A855B5"
+                  fill="#A44DB2"
                 />
                 <!-- Curl details on hair -->
                 <path
@@ -2727,7 +2795,7 @@
                   + pecas + camiseta negra sólida — siempre.
                 </li>
                 <li>
-                  Solo el pelo lleva color (violeta Miriam #A855B5). Todo lo
+                  Solo el pelo lleva color (violeta Miriam #A44DB2). Todo lo
                   demás es tinta negra sobre crema.
                 </li>
                 <li>
@@ -2761,7 +2829,7 @@
                   border-radius: 0 6px 6px 0;
                 "
               >
-                <strong style="color: var(--color-miriam)"
+                <strong style="color: var(--color-text)"
                   >Referencia canónica.</strong
                 >
                 Para nuevas piezas, mantén el estilo: tinta + pelo violeta +
@@ -3040,7 +3108,7 @@
 <span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"icon"</span> <span class="c-val">type</span>=<span class="c-val">"image/png"</span> <span class="c-val">sizes</span>=<span class="c-val">"32x32"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon-32.png"</span><span class="c-key">&gt;</span>
 <span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"icon"</span> <span class="c-val">type</span>=<span class="c-val">"image/png"</span> <span class="c-val">sizes</span>=<span class="c-val">"16x16"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon-16.png"</span><span class="c-key">&gt;</span>
 <span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"apple-touch-icon"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon-180.png"</span><span class="c-key">&gt;</span>
-<span class="c-key">&lt;meta</span> <span class="c-val">name</span>=<span class="c-val">"theme-color"</span> <span class="c-val">content</span>=<span class="c-val">"#A855B5"</span><span class="c-key">&gt;</span></pre>
+<span class="c-key">&lt;meta</span> <span class="c-val">name</span>=<span class="c-val">"theme-color"</span> <span class="c-val">content</span>=<span class="c-val">"#A44DB2"</span><span class="c-key">&gt;</span></pre>
 
           <p
             style="
@@ -3054,7 +3122,7 @@
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)"
+            <strong style="color: var(--color-text)"
               >Cuando regenerar.</strong
             >
             Si cambias la m, el peso de Fraunces o la disposición de las
@@ -3093,9 +3161,47 @@
             </button>
             <button
               class="btn btn-primary"
-              style="background: var(--color-cta-hover)"
+              style="box-shadow: 0 0 0 2px var(--color-text); transform: translateY(-1px)"
             >
               Hover state
+            </button>
+          </div>
+          <div class="show">
+            <div class="show-meta" style="width: 100%">
+              Primario · estados loading / disabled
+            </div>
+            <button
+              disabled
+              aria-busy="true"
+              aria-label="Procesando donación"
+              class="btn btn-primary"
+              style="cursor: wait; opacity: 1"
+            >
+              <span
+                style="
+                  display: inline-block;
+                  width: 14px;
+                  height: 14px;
+                  border: 2px solid rgba(45, 27, 61, 0.25);
+                  border-top-color: #2d1b3d;
+                  border-radius: 50%;
+                  animation: ds-spin 700ms linear infinite;
+                  flex-shrink: 0;
+                "
+                aria-hidden="true"
+              ></span>
+              Procesando…
+            </button>
+            <button
+              disabled
+              class="btn btn-primary"
+              style="
+                background: rgba(45, 27, 61, 0.12);
+                color: rgba(45, 27, 61, 0.4);
+                cursor: not-allowed;
+              "
+            >
+              Donar ahora
             </button>
           </div>
           <div class="show">
@@ -3133,10 +3239,16 @@
                 Amplificación FGFR1 detectada en biopsia
               </div>
             </div>
-            <div>
-              <div class="show-meta">Cifra de campaña · coral</div>
+            <div
+              style="
+                background: #2d1b3d;
+                border-radius: 12px;
+                padding: 20px 24px;
+              "
+            >
+              <div class="show-meta" style="color: #faf6f0">Cifra de campaña · coral sobre berenjena</div>
               <div class="stat-number stat-number--cta">32.383&nbsp;€</div>
-              <div class="stat-label">Recaudado · 1.247 personas</div>
+              <div class="stat-label" style="color: #faf6f0">Recaudado · 1.247 personas</div>
             </div>
             <div>
               <div class="show-meta">Cifra neutra · berenjena</div>
@@ -3160,7 +3272,7 @@
           <pre class="code">
 .<span class="c-key">badge-genomic</span> {
   background: <span class="c-val">#E8D4ED</span>;
-  color:      <span class="c-val">#A855B5</span>;
+  color:      <span class="c-val">#A44DB2</span>;
   border-radius: <span class="c-val">9999px</span>;
   padding: <span class="c-val">4px 12px</span>;
   font-family: <span class="c-val">JetBrains Mono</span>, monospace;
@@ -3392,7 +3504,7 @@
             <div>
               <h3
                 style="
-                  color: var(--color-cta);
+                  color: #2d1b3d;
                   border-bottom-color: rgba(255, 107, 71, 0.2);
                 "
               >
@@ -3427,7 +3539,7 @@
             copys vacíos, "empoderamiento", iconos genéricos. Esta sección es el
             manual para que cualquier IA — Claude, GPT, asistente de diseño —
             escriba y diseñe
-            <strong style="color: var(--color-miriam)">como Miriam</strong>, no
+            <strong style="color: var(--color-text)">como Miriam</strong>, no
             como un blog corporativo.
           </p>
 
@@ -3523,7 +3635,7 @@
           </p>
           <pre class="code">
 <span class="c-key">Paleta</span>: <span class="c-val">#FAF6F0</span> crema (fondo), <span class="c-val">#2D1B3D</span> berenjena (texto),
-        <span class="c-val">#A855B5</span> violeta (firma — solo para "Miriam"),
+        <span class="c-val">#A44DB2</span> violeta (firma — solo para "Miriam"),
         <span class="c-val">#FF6B47</span> coral (CTA — solo botones de donar),
         <span class="c-val">#E8D4ED</span> violeta soft (badges genómicos).
         <span class="c-com">// No inventar colores. No degradados. No glassmorphism.</span>
@@ -3711,7 +3823,7 @@ No reescribas la voz — corrige sin reformular.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)">Regla de oro.</strong>
+            <strong style="color: var(--color-text)">Regla de oro.</strong>
             Una IA es buena reescribiendo dentro de un sistema, mala
             inventándolo. Tu trabajo no es delegar la decisión — es darle el
             sistema completo y validar que no se desvíe.
@@ -3747,7 +3859,7 @@ No reescribas la voz — corrige sin reformular.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-cta)"
+            <strong style="color: #2d1b3d"
               >Idioma del prompt — regla práctica.</strong
             >
             Plantillas <strong>A, B, C</strong> (texto y mocks de UI) →
@@ -3773,7 +3885,7 @@ No reescribas la voz — corrige sin reformular.</pre>
 <span class="c-key">paper</span>: warm cream <span class="c-val">#FAF6F0</span> background, slightly off-white.
        Subtle paper grain visible. No drop shadows.
 <span class="c-key">color</span>: monochrome black ink + ONE accent per piece —
-       <span class="c-val">#A855B5</span> violet (concept of Miriam, the patient, identity),
+       <span class="c-val">#A44DB2</span> violet (concept of Miriam, the patient, identity),
        <span class="c-val">#FF6B47</span> coral (action, urgency, donate, click),
        never both in same piece, never any other accent.
 <span class="c-key">composition</span>: a single object/scene centered with breathing room.
@@ -3807,7 +3919,7 @@ Constraints:
 — Black ink only. No color accent (accent is added in CSS).
 — Recognizable at 32×32 px. Detail reduced to the minimum needed.
 — Optional small handwritten label naming the concept.
-— If the concept is abstract (e.g. "hope"), <strong style="color:var(--color-miriam)">reject and ask for a concrete one</strong>.
+— If the concept is abstract (e.g. "hope"), <strong style="color: #faf6f0">reject and ask for a concrete one</strong>.
 
 Return 4 variants with distinct compositions — not 4 cosmetic
 versions of the same idea.</pre>
@@ -3836,7 +3948,7 @@ Output: 2000 px long edge, cream background <span class="c-val">#FAF6F0</span>.
 
 Allowed in this format:
 — Handwritten annotations with thin arrows pointing to parts.
-— Color accent: ONE subtle area in violet <span class="c-val">#A855B5</span> OR coral <span class="c-val">#FF6B47</span>.
+— Color accent: ONE subtle area in violet <span class="c-val">#A44DB2</span> OR coral <span class="c-val">#FF6B47</span>.
 — Small diluted watercolor / wash patches if they add texture.
 — Maximum 2–3 elements in the scene. Do not crowd.
 
@@ -3872,7 +3984,7 @@ Style (aligned with existing team set):
 — Black ink, parallel-hatching shading.
 — Identifiable, specific face — not "a type of person", THIS person.
 — One subtle color patch somewhere (hair streak, accessory, shirt
-  collar) — violet <span class="c-val">#A855B5</span> if patient/family,
+  collar) — violet <span class="c-val">#A44DB2</span> if patient/family,
   coral <span class="c-val">#FF6B47</span> if medical/operations team.
 — Optional small handwritten role label below the portrait.
 
@@ -3925,7 +4037,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-cta)">Test de coherencia.</strong>
+            <strong style="color: #2d1b3d">Test de coherencia.</strong>
             Pon la imagen nueva al lado de un icono BTP existente o un retrato
             del equipo. Si parece de otro proyecto — descartar. El sistema solo
             funciona si <em>todas</em> las piezas se reconocen como hermanas.
@@ -3984,7 +4096,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   style="
                     font-family: var(--font-mono);
                     font-size: 12px;
-                    color: var(--color-miriam);
+                    color: var(--color-text);
                   "
                   >prefers-reduced-motion</code
                 >
@@ -4014,7 +4126,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               <strong>Contraste ≥ 4.5:1</strong> para texto, ≥ 3:1 para texto
               grande (≥24 px) y elementos UI. Berenjena #2D1B3D sobre crema
               #FAF6F0 =
-              <strong style="color: var(--color-miriam)">14.8:1</strong> ✓.
+              <strong style="color: var(--color-text)">14.6:1</strong> ✓.
             </li>
             <li>
               <strong>Tamaño base 16 px mínimo</strong>; 17 px en cuerpo de la
@@ -4198,7 +4310,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)">Regla de oro.</strong> Si
+            <strong style="color: var(--color-text)">Regla de oro.</strong> Si
             una decisión de diseño solo se sostiene cuando el usuario está al
             100%, no sirve. Miriam se diseña para el peor día — no para el
             mejor.
@@ -4297,7 +4409,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               align-items: baseline;
             "
           >
-            <span style="color: var(--color-miriam)">/web</span>
+            <span style="color: var(--color-text)">/web</span>
             <span
               style="
                 font-family: var(--font-body);
@@ -4305,7 +4417,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               "
               >— sitio público (Astro). Donde el lector llega.</span
             >
-            <span style="color: var(--color-miriam)">/design-system</span>
+            <span style="color: var(--color-text)">/design-system</span>
             <span
               style="
                 font-family: var(--font-body);
@@ -4314,7 +4426,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               >— este documento. Fuente única de verdad para voz, color,
               tipografía y reglas.</span
             >
-            <span style="color: var(--color-miriam)">/clinical</span>
+            <span style="color: var(--color-text)">/clinical</span>
             <span
               style="
                 font-family: var(--font-body);
@@ -4323,7 +4435,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               >— informe AP, perfil molecular, traducciones legibles. Lo que
               cita la web.</span
             >
-            <span style="color: var(--color-miriam)">/illustrations</span>
+            <span style="color: var(--color-text)">/illustrations</span>
             <span
               style="
                 font-family: var(--font-body);
@@ -4332,7 +4444,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               >— set "Beyond the Protocol": iconos, retratos del equipo,
               openers. PNG + originales.</span
             >
-            <span style="color: var(--color-miriam)">/prompts</span>
+            <span style="color: var(--color-text)">/prompts</span>
             <span
               style="
                 font-family: var(--font-body);
@@ -4341,7 +4453,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               >— plantillas A–F en versión <code>.md</code> lista para
               pegar.</span
             >
-            <span style="color: var(--color-miriam)">/social</span>
+            <span style="color: var(--color-text)">/social</span>
             <span
               style="
                 font-family: var(--font-body);
@@ -4435,7 +4547,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)"
+            <strong style="color: var(--color-text)"
               >Una nota sobre el repo público.</strong
             >
             El historial clínico privado no entra aquí — solo lo que ya es
@@ -4489,7 +4601,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   color: #2d1b3d;
                 "
               >
-                Miriam<span style="color: #a855b5">.</span>
+                Miriam<span style="color: #a44db2">.</span>
               </h3>
               <p
                 style="
@@ -4623,7 +4735,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 line-height: 1;
               "
             >
-              Miriam<span style="color: #a855b5">.</span>
+              Miriam<span style="color: #a44db2">.</span>
             </div>
           </div>
           <ul
@@ -4646,13 +4758,13 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 style="
                   font-family: var(--font-mono);
                   font-size: 12px;
-                  color: var(--color-miriam);
+                  color: var(--color-text);
                 "
                 >.</code
               >
               en color firma
               <code style="font-family: var(--font-mono); font-size: 12px"
-                >#A855B5</code
+                >#A44DB2</code
               >. Es el único elemento gráfico permitido.
             </li>
             <li>
@@ -4669,7 +4781,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 style="
                   font-family: var(--font-mono);
                   font-size: 12px;
-                  color: #e8d4ed;
+                  color: #2d1b3d;
                 "
                 >#E8D4ED</code
               >
@@ -4739,7 +4851,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   <td style="padding: 12px">Cabecera web</td>
                   <td style="padding: 12px">Wordmark</td>
                   <td style="padding: 12px; font-family: var(--font-display)">
-                    Miriam<span style="color: #a855b5">.</span>
+                    Miriam<span style="color: #a44db2">.</span>
                   </td>
                 </tr>
                 <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
@@ -4795,7 +4907,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)">Regla.</strong> Si dudas
+            <strong style="color: var(--color-text)">Regla.</strong> Si dudas
             si algo es marca o dominio, pregúntate:
             <em>¿se hace clic aquí?</em> Si sí, es
             <code style="font-family: var(--font-mono); font-size: 12px"
@@ -4958,7 +5070,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-cta)">Test rápido.</strong> Pon la
+            <strong style="color: #2d1b3d">Test rápido.</strong> Pon la
             foto en blanco y negro mentalmente: ¿sigue funcionando la
             composición? Si la foto solo se sostiene gracias al color saturado o
             al filtro, no es del sistema.
@@ -5003,6 +5115,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 Default
               </div>
               <label
+                for="input-default"
                 style="
                   display: block;
                   font-size: 13px;
@@ -5031,6 +5144,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   >€</span
                 >
                 <input
+                  id="input-default"
                   type="text"
                   value="50"
                   style="
@@ -5069,13 +5183,14 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   font-size: 11px;
                   letter-spacing: 0.06em;
                   text-transform: uppercase;
-                  color: #ff6b47;
+                  color: var(--color-text-soft);
                   margin-bottom: 8px;
                 "
               >
                 Focus
               </div>
               <label
+                for="input-focus"
                 style="
                   display: block;
                   font-size: 13px;
@@ -5100,12 +5215,13 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 <span
                   style="
                     font-family: var(--font-mono);
-                    color: #ff6b47;
+                    color: #2d1b3d;
                     margin-right: 8px;
                   "
                   >€</span
                 >
                 <input
+                  id="input-focus"
                   type="text"
                   value="50"
                   style="
@@ -5151,6 +5267,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 Error
               </div>
               <label
+                for="input-error"
                 style="
                   display: block;
                   font-size: 13px;
@@ -5179,6 +5296,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   >€</span
                 >
                 <input
+                  id="input-error"
                   type="text"
                   value="2"
                   style="
@@ -5224,13 +5342,14 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   font-size: 11px;
                   letter-spacing: 0.06em;
                   text-transform: uppercase;
-                  color: #1f8a5b;
+                  color: #1d8155;
                   margin-bottom: 8px;
                 "
               >
                 Success
               </div>
               <label
+                for="input-success"
                 style="
                   display: block;
                   font-size: 13px;
@@ -5245,7 +5364,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   display: flex;
                   align-items: center;
                   background: #fff;
-                  border: 2px solid #1f8a5b;
+                  border: 2px solid #1d8155;
                   border-radius: 8px;
                   padding: 10px 14px;
                 "
@@ -5253,12 +5372,13 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 <span
                   style="
                     font-family: var(--font-mono);
-                    color: #1f8a5b;
+                    color: #1d8155;
                     margin-right: 8px;
                   "
                   >€</span
                 >
                 <input
+                  id="input-success"
                   type="text"
                   value="50"
                   style="
@@ -5272,12 +5392,12 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   disabled
                 />
                 <span
-                  style="color: #1f8a5b; margin-left: 8px"
+                  style="color: #1d8155; margin-left: 8px"
                   aria-hidden="true"
                   >✓</span
                 >
               </div>
-              <div style="font-size: 12px; color: #1f8a5b; margin-top: 6px">
+              <div style="font-size: 12px; color: #1d8155; margin-top: 6px">
                 Validado. Pasando a la pasarela…
               </div>
             </div>
@@ -5296,9 +5416,9 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               style="
                 font-family: var(--font-mono);
                 font-size: 12px;
-                color: #1f8a5b;
+                color: #1d8155;
               "
-              >#1F8A5B</code
+              >#1D8155</code
             >
             y rojo error
             <code
@@ -5321,7 +5441,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
             <button
               style="
                 background: #ff6b47;
-                color: #faf6f0;
+                color: #2d1b3d;
                 border: none;
                 padding: 12px 24px;
                 border-radius: 8px;
@@ -5336,7 +5456,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               disabled
               style="
                 background: #ff6b47;
-                color: rgba(250, 246, 240, 0.7);
+                color: #2d1b3d;
                 border: none;
                 padding: 12px 24px;
                 border-radius: 8px;
@@ -5354,8 +5474,8 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   display: inline-block;
                   width: 14px;
                   height: 14px;
-                  border: 2px solid rgba(250, 246, 240, 0.4);
-                  border-top-color: #faf6f0;
+                  border: 2px solid rgba(45, 27, 61, 0.25);
+                  border-top-color: #2d1b3d;
                   border-radius: 50%;
                   animation: ds-spin 700ms linear infinite;
                 "
@@ -5442,7 +5562,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               style="
                 font-family: var(--font-mono);
                 font-size: 12px;
-                color: #ff6b47;
+                color: #2d1b3d;
                 text-decoration: underline;
                 text-underline-offset: 3px;
               "
@@ -5479,7 +5599,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
           >
             <div
               style="
-                background: #1f8a5b;
+                background: #1d8155;
                 color: #faf6f0;
                 padding: 14px 18px;
                 border-radius: 8px;
@@ -5789,7 +5909,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   font-family: var(--font-display);
                   font-weight: 600;
                   font-size: 36px;
-                  color: #a855b5;
+                  color: #a44db2;
                   line-height: 1;
                 "
               >
@@ -5819,7 +5939,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   font-family: var(--font-display);
                   font-weight: 600;
                   font-size: 36px;
-                  color: #a855b5;
+                  color: #a44db2;
                   line-height: 1;
                 "
               >
@@ -5849,7 +5969,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                   font-family: var(--font-display);
                   font-weight: 600;
                   font-size: 36px;
-                  color: #a855b5;
+                  color: #a44db2;
                   line-height: 1;
                 "
               >
@@ -5962,7 +6082,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               <a
                 href="mailto:prensa@helpmiriam.com"
                 style="
-                  color: #ff6b47;
+                  color: #2d1b3d;
                   text-decoration: underline;
                   text-underline-offset: 3px;
                 "
@@ -6206,7 +6326,7 @@ Equipo Miriam<span class="c-com">.</span></pre>
               max-width: 72ch;
             "
           >
-            <strong style="color: var(--color-miriam)">Mantenimiento.</strong>
+            <strong style="color: var(--color-text)">Mantenimiento.</strong>
             Estas plantillas están vivas. Cuando uses una y notes que te falta
             algo o sobra, edítala aquí mismo. La fuente única de verdad es esta
             sección — no la copia que tú tengas en tu mail.

--- a/public/design-system/tokens.css
+++ b/public/design-system/tokens.css
@@ -6,12 +6,13 @@
   --color-bg-card: #f5efe6; /* Crema profunda — cards */
   --color-text: #2d1b3d; /* Berenjena — texto principal, trazos */
   --color-text-soft: #3a3340; /* Tinta — texto secundario */
-  --color-miriam: #a855b5; /* Violeta Miriam — FIRMA (identidad) */
+  --color-miriam: #a44db2; /* Violeta — FIRMA. AA s/ crema (#faf6f0) toda talla. Solo titulares s/ crema-card y berenjena */
   --color-miriam-soft: #e8d4ed; /* Violeta soft — badges genómicos */
   --color-cta: #ff6b47; /* Coral — ACCIÓN (CTA único) */
   --color-cta-hover: #e5573a;
 
   /* Aliases semánticos */
+  /* Links sobre crema → violeta. Links sobre crema-card o berenjena → berenjena */
   --color-link: var(--color-miriam);
   --color-emphasis: var(--color-miriam);
   --color-action: var(--color-cta);
@@ -75,11 +76,12 @@ p {
 }
 a {
   color: var(--color-link);
-  text-decoration: none;
-}
-a:hover {
   text-decoration: underline;
   text-underline-offset: 3px;
+  text-decoration-color: rgba(45, 27, 61, 0.35);
+}
+a:hover {
+  text-decoration-color: var(--color-link);
 }
 code,
 kbd,
@@ -107,11 +109,11 @@ samp {
 }
 .btn-primary {
   background: var(--color-cta);
-  color: var(--color-bg);
+  color: var(--color-text);
   padding: 14px 24px;
 }
 .btn-primary:hover {
-  background: var(--color-cta-hover);
+  box-shadow: 0 0 0 2px var(--color-text);
   transform: translateY(-1px);
   text-decoration: none;
 }
@@ -140,7 +142,7 @@ samp {
 .badge-genomic {
   display: inline-block;
   background: var(--color-miriam-soft);
-  color: var(--color-miriam);
+  color: var(--color-text);
   border-radius: var(--radius-pill);
   padding: 4px 12px;
   font-family: var(--font-mono);
@@ -169,6 +171,7 @@ samp {
 .stat-number--firma {
   color: var(--color-miriam);
 }
+/* coral solo pasa sobre berenjena — usar únicamente en superficies oscuras */
 .stat-number--cta {
   color: var(--color-cta);
 }

--- a/public/design-system/tokens.css
+++ b/public/design-system/tokens.css
@@ -12,7 +12,6 @@
   --color-cta-hover: #e5573a;
 
   /* Aliases semánticos */
-  /* Links sobre crema → violeta. Links sobre crema-card o berenjena → berenjena */
   --color-link: var(--color-miriam);
   --color-emphasis: var(--color-miriam);
   --color-action: var(--color-cta);


### PR DESCRIPTION
## 📋 Pull Request

### Description
Design system: add correct color rules and constraints for WCAG 2.2 color contrast criterion

### Changes
* Changes slightly violeta-miriam to at least have a minumum regular text contrast with cream background color

- [x] Code changes follow the project's coding standards
- [x] Mobile-first CSS (Tailwind utilities)
- [x] BEM naming convention for custom CSS
- [x] Accessibility: semantic HTML, proper labels, keyboard navigation
- [x] Both ES and EN languages supported (if applicable)
- [x] `AGENTS.md` updated if architecture, routes, or conventions changed

### Testing
<!-- Describe how you tested the changes -->

- [x] Tested on mobile viewport
- [x] Tested on desktop viewport
- [x] No console errors
<img width="712" height="654" alt="imagen" src="https://github.com/user-attachments/assets/1beb6aaa-b172-4a22-946e-21eb985bd786" />

