### PR TITLE
feat(analytics): per-button conversion breakdown in Plausible

### DIFF
--- a/app/composables/useSupport.ts
+++ b/app/composables/useSupport.ts
@@ -19,7 +19,12 @@ export function useSupport() {
     const plausible = nuxtApp.$plausible as
       | { trackEvent?: (name: string, opts?: { props?: Record<string, string> }) => void }
       | undefined
+    // Doble evento: «Apoyar» = total de conversiones (un solo número), y
+    // «Apoyar: <botón>» = desglose por ubicación sin custom properties (de
+    // pago en Plausible). Cada nombre tiene su goal en el panel. El props se
+    // mantiene por si algún día se activa el plan con propiedades.
     plausible?.trackEvent?.('Apoyar', { props: { location } })
+    plausible?.trackEvent?.(`Apoyar: ${location}`)
   }
 
   return { GOFUNDME_URL, trackSupport }


### PR DESCRIPTION
Follow-up to #23 (the v2.0 redesign). This single commit was pushed to the redesign branch **after** #23 was merged, so it never reached `main`.

Each support click now sends two Plausible events:
- `Apoyar` — a single total, for overall conversion.
- `Apoyar: <location>` — one goal per button (hero, header, mobile bar, expenses, etc.), so you can see **which button converts** without paying for Plausible's custom properties.

The `props` payload is kept on the `Apoyar` event in case custom properties get enabled later.

Only change: +5 lines in `app/composables/useSupport.ts`. Lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
