### PR TITLE
feat: public donor thank-you wall (/donantes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ Thumbs.db
 
 # data
 public/fundraiser.json
+public/donations.json

--- a/app/components/DonationsWall.vue
+++ b/app/components/DonationsWall.vue
@@ -1,0 +1,85 @@
+<template>
+  <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'gracias-title'">
+    <div class="section-container">
+      <p class="eyebrow mb-3 block">{{ $t('thanksWall.eyebrow') }}</p>
+      <h2
+        id="gracias-title"
+        class="heading-display text-3xl sm:text-4xl text-berenjena mb-3"
+        style="letter-spacing: -0.02em"
+      >
+        {{ $t('thanksWall.title') }}
+      </h2>
+      <p class="text-tinta leading-relaxed mb-6 max-w-2xl">{{ $t('thanksWall.subtitle') }}</p>
+
+      <!-- Tablita sencilla: nombre + importe, anónimos como "Anónimo". -->
+      <div
+        v-if="shown.length"
+        class="rounded-2xl border border-berenjena/10 bg-cream overflow-hidden"
+      >
+        <table class="w-full">
+          <caption class="sr-only">{{ $t('thanksWall.title') }}</caption>
+          <tbody>
+            <tr
+              v-for="d in shown"
+              :key="d.id"
+              class="border-b border-berenjena/[0.07] last:border-b-0"
+            >
+              <td class="py-2.5 px-4 font-display font-semibold text-berenjena">{{ d.name }}</td>
+              <td class="py-2.5 px-4 text-right font-mono text-sm font-semibold text-coral-deep nums whitespace-nowrap">
+                {{ money(d) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p v-else-if="loaded" class="text-tinta text-sm">{{ $t('thanksWall.empty') }}</p>
+
+      <p v-if="limit && donations.length > limit" class="mt-4">
+        <NuxtLink :to="localePath('donantes')" class="link-inline">
+          {{ $t('thanksWall.see_all', { n: donations.length }) }} →
+        </NuxtLink>
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+/**
+ * Muro de gracias — tablita sencilla con las donaciones reales de GoFundMe
+ * (nombre + importe; anónimos como "Anónimo"). Datos de /donations.json
+ * (función Netlify horaria). `limit` recorta para el avance en /colabora;
+ * sin limit (en /donantes) se ven todas.
+ */
+import type { PublicDonation } from '../../utils/fundraiser'
+
+const props = defineProps<{ limit?: number }>()
+const localePath = useLocalePath()
+const { locale } = useI18n()
+
+const donations = ref<PublicDonation[]>([])
+const loaded = ref(false)
+onMounted(async () => {
+  try {
+    donations.value = await $fetch<PublicDonation[]>('/donations.json')
+  } catch {
+    /* sin datos */
+  } finally {
+    loaded.value = true
+  }
+})
+
+const shown = computed(() => {
+  const arr = [...donations.value].sort((a, b) =>
+    (b.createdAt ?? '').localeCompare(a.createdAt ?? '')
+  )
+  return props.limit ? arr.slice(0, props.limit) : arr
+})
+
+function money(d: PublicDonation) {
+  return new Intl.NumberFormat(locale.value === 'es' ? 'es-ES' : 'en-US', {
+    style: 'currency',
+    currency: d.currencyCode || 'EUR',
+    maximumFractionDigits: 0,
+  }).format(d.amount)
+}
+</script>

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -173,6 +173,9 @@
       </div>
     </section>
 
+    <!-- ░░ GRACIAS ░░ avance del muro de donantes (8) + enlace a /donantes. -->
+    <DonationsWall :limit="8" />
+
     <!-- ░░ FINANCIAR ░░ bg-cream · remate destacado (Decisión 3·B: el dinero, al
          final). Único primario coral de la página. -->
     <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'fund-title'">

--- a/app/pages/donantes.vue
+++ b/app/pages/donantes.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <DonationsWall />
+    <div class="section-container pb-16 -mt-6 flex flex-wrap items-center gap-x-6 gap-y-3">
+      <a
+        :href="GOFUNDME_URL"
+        target="_blank"
+        rel="noopener"
+        data-support-cta
+        class="btn-cta"
+        @click="trackSupport('donantes')"
+      >
+        <Icon name="ph:heart-fill" class="heart-beat heart-beat--alive w-4 h-4" aria-hidden="true" />
+        {{ $t('nav.donate') }}
+      </a>
+      <NuxtLink :to="localePath('colabora')" class="link-inline">{{ $t('nav.collaborate') }} →</NuxtLink>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+/** Página pública de agradecimiento: muestra a todas las personas que han
+ *  aportado (tablita sencilla), compartible por cualquiera. */
+const { t } = useI18n()
+const localePath = useLocalePath()
+const { GOFUNDME_URL, trackSupport } = useSupport()
+
+useSeoMeta({
+  title: () => `${t('thanksWall.title')} · helpmiriam.com`,
+  description: () => t('thanksWall.subtitle'),
+  ogTitle: () => t('thanksWall.title'),
+  ogDescription: () => t('thanksWall.subtitle'),
+})
+</script>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -33,6 +33,13 @@
     "label": "days waiting for a new line of treatment",
     "sub": "since the 2nd line (abemaciclib) was stopped, on 30 Apr 2026"
   },
+  "thanksWall": {
+    "eyebrow": "Thank you",
+    "title": "Thanks to those who make it possible",
+    "subtitle": "Everyone who has already contributed to Miriam's case. Thank you for being here — every amount brings the next test closer.",
+    "see_all": "See all {n} people",
+    "empty": "No donations to show yet."
+  },
   "error": {
     "e404_code": "Error 404",
     "e404_label": "Page not found",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -33,6 +33,13 @@
     "label": "días esperando una nueva línea de tratamiento",
     "sub": "desde que se suspendió la 2ª línea (abemaciclib), el 30/04/2026"
   },
+  "thanksWall": {
+    "eyebrow": "Gracias",
+    "title": "Gracias a quienes lo hacen posible",
+    "subtitle": "Todas las personas que ya han aportado al caso de Miriam. Gracias por estar — cada cantidad acerca el siguiente análisis.",
+    "see_all": "Ver a las {n} personas",
+    "empty": "Aún no hay donaciones que mostrar."
+  },
   "error": {
     "e404_code": "Error 404",
     "e404_label": "Página no encontrada",

--- a/netlify/functions/get-fundraiser-function.mts
+++ b/netlify/functions/get-fundraiser-function.mts
@@ -1,10 +1,11 @@
 import type { Config } from '@netlify/functions'
-import { saveFundraiser } from '../../utils/fundraiser'
+import { saveFundraiser, saveDonations } from '../../utils/fundraiser'
 
 export default async (req: Request) => {
   const { next_run } = await req.json()
 
   await saveFundraiser(true)
+  await saveDonations()
 
   console.log('Received event! Next invocation at:', next_run)
 }

--- a/update-fundraiser.ts
+++ b/update-fundraiser.ts
@@ -1,8 +1,9 @@
-import { saveFundraiser } from './utils/fundraiser'
+import { saveFundraiser, saveDonations } from './utils/fundraiser'
 
 try {
   const overwrite = process.argv.includes('--force')
   await saveFundraiser(overwrite)
+  await saveDonations()
 } catch (error) {
   console.error('Error updating fundraiser:', error)
   process.exit(1)

--- a/utils/fundraiser.ts
+++ b/utils/fundraiser.ts
@@ -82,3 +82,79 @@ export async function saveFundraiser(overwrite = false) {
   await fs.writeFile(path, JSON.stringify(fundraiser))
   console.log(`✔ Fundraiser saved to: ${path}`)
 }
+
+// ── Donaciones públicas (muro de gracias · paridad con GoFundMe) ─────────────
+// El feed público de GoFundMe ya muestra nombre + importe + anónimo + fecha.
+// Re-publicamos lo mismo. OPT_OUT: nombres (no anónimos) a excluir si alguien
+// pide quitarse (red de seguridad RGPD). Los anónimos salen como "Anónimo".
+const donationsPath = 'public/donations.json'
+const donationsFeed = `https://gateway.gofundme.com/web-gateway/v1/feed/${variables.slug}/donations`
+const OPT_OUT: string[] = []
+
+export interface PublicDonation {
+  id: number
+  name: string
+  amount: number
+  currencyCode: string
+  createdAt: string
+  anonymous: boolean
+}
+
+// Normaliza nombres a Título (GoFundMe los devuelve en MAYÚS/minús irregular).
+// Unicode-aware (respeta acentos). Primera letra de cada palabra en mayúscula.
+function titleCase(s: string): string {
+  return s
+    .trim()
+    .toLocaleLowerCase('es-ES')
+    .replace(/(^|[\s\-'’.])(\p{L})/gu, (_m, sep: string, ch: string) => sep + ch.toLocaleUpperCase('es-ES'))
+}
+
+export async function getDonations(maxItems = 400): Promise<PublicDonation[]> {
+  const out: PublicDonation[] = []
+  const limit = 20
+  let offset = 0
+  // Paginación por offset (verificada contra el feed); para en has_next=false.
+  for (let guard = 0; guard < 20 && out.length < maxItems; guard++) {
+    const res = await fetch(
+      `${donationsFeed}?limit=${limit}&sort=recent&offset=${offset}`,
+      { headers: { 'User-Agent': headers['User-Agent'] }, signal: AbortSignal.timeout(8000) }
+    )
+    const json = (await res.json()) as {
+      references?: { donations?: Array<Record<string, unknown>> }
+      meta?: { meta?: { has_next?: boolean } }
+    }
+    const list = json.references?.donations ?? []
+    if (list.length === 0) break
+    for (const d of list) {
+      const anonymous = Boolean(d.is_anonymous)
+      const name = anonymous ? 'Anónimo' : titleCase(String(d.name || 'Anónimo')) || 'Anónimo'
+      if (!anonymous && OPT_OUT.includes(name)) continue
+      out.push({
+        id: Number(d.donation_id),
+        name,
+        amount: Number(d.amount),
+        currencyCode: String(d.currencycode || 'EUR'),
+        createdAt: String(d.created_at),
+        anonymous,
+      })
+    }
+    if (!json.meta?.meta?.has_next) break
+    offset += limit
+  }
+  return out
+}
+
+export async function saveDonations() {
+  try {
+    const donations = await getDonations()
+    if (donations.length === 0) {
+      console.log('No donations fetched; keeping existing file.')
+      return
+    }
+    await fs.writeFile(donationsPath, JSON.stringify(donations))
+    console.log(`✔ Donations saved (${donations.length}) to: ${donationsPath}`)
+  } catch (error) {
+    // No bloquear el build/dev ni sobrescribir con vacío si el feed falla.
+    console.warn('Donations fetch failed; keeping existing file.', error)
+  }
+}


### PR DESCRIPTION
Public, shareable thank-you page listing all GoFundMe donors in a simple table (name + amount; anonymous as "Anonymous"; names title-cased). Auto-updated hourly by the Netlify function from GoFundMe public feed. 8-item preview on /colabora with a "see all" link. ES + EN. donations.json is gitignored (real names not committed); OPT_OUT list for GDPR.

Clean branch off main — only the donor wall (no B2/P7/counter/clinical changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)