### PR TITLE
feat(two-faces): tumor-cell schematic on home + sharpened science

### DIFF
--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -1,7 +1,5 @@
 <template>
   <section :aria-label="$t('twofaces.title')">
-    <!-- En modo compacto (home) el texto de la sección anfitriona ya hace de
-         intro: solo se pinta la página del cuaderno. -->
     <template v-if="!compact">
       <p class="eyebrow mb-2 block">{{ $t('twofaces.eyebrow') }}</p>
       <h2 class="heading-display text-2xl text-berenjena mb-2" style="letter-spacing: -0.02em">
@@ -10,153 +8,112 @@
       <p class="text-sm text-tinta leading-relaxed mb-6 max-w-2xl">{{ $t('twofaces.intro') }}</p>
     </template>
 
-    <!-- Página de cuaderno de laboratorio (ADN gráfico del design system):
-         tinta berenjena, trazo a pluma imperfecto, UN solo acento (coral) sobre
-         las dos certezas que financia la campaña; el lado luminal "conocido" se
-         dibuja por densidad de tinta, no por color. Todo anotado a mano dentro
-         de la página — sin leyenda fuera. La lectura completa va en sr-only. -->
-    <figure ref="root" class="tf2" :class="{ 'tf2-in': inView }">
-      <svg class="tf2__svg" viewBox="0 0 440 384" role="img" :aria-label="ariaLabel">
+    <!-- ESQUEMA (no retrato). Gramática rigurosa de alteraciones:
+         · receptores en la membrana (HR+, HER2 tachado = negativo, SSTR2)
+         · amplificación = copias apiladas + ×N, agrupadas en el clúster 11q13
+         · mutación = rombo (ESR1, en ctDNA)
+         · pérdida = gen roto y tachado (RB1)
+         · gránulos Cg/Syn = lo que define el 80% neuroendocrino.
+         Lo conocido es lo pequeño (mama luminal); lo que manda (80%) apenas se
+         conoce. Bloquéalo por un lado y escapa por el otro → tratarlo entero. -->
+    <figure class="tf2">
+      <svg class="tf2__svg" viewBox="0 0 480 300" role="img" :aria-label="ariaLabel">
         <defs>
-          <filter id="tf2-rough" x="-6%" y="-6%" width="112%" height="112%">
-            <feTurbulence type="fractalNoise" baseFrequency="0.012" numOctaves="2" seed="7" result="n" />
-            <feDisplacementMap in="SourceGraphic" in2="n" scale="2.4" xChannelSelector="R" yChannelSelector="G" />
-          </filter>
-          <filter id="tf2-grain"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" stitchTiles="stitch" /></filter>
           <pattern id="tf2-grid" width="22" height="22" patternUnits="userSpaceOnUse">
             <path d="M22 0 H0 V22" fill="none" stroke="rgba(45,27,61,0.06)" stroke-width="1" />
           </pattern>
-          <marker id="tf2-arrow" markerWidth="7" markerHeight="7" refX="5" refY="3" orient="auto">
-            <path d="M0 0 L6 3 L0 6 Z" fill="#2d1b3d" />
-          </marker>
-          <marker id="tf2-arrow-c" markerWidth="7" markerHeight="7" refX="5" refY="3" orient="auto">
-            <path d="M0 0 L6 3 L0 6 Z" fill="#bb4128" />
-          </marker>
+          <clipPath id="tf2-field"><path :d="fieldPath" /></clipPath>
         </defs>
 
-        <!-- Papel crema + grano sutil + cuadrícula de libreta -->
-        <rect x="2" y="2" width="436" height="380" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
-        <rect x="2" y="2" width="436" height="380" rx="14" fill="url(#tf2-grid)" />
-        <rect x="2" y="2" width="436" height="380" rx="14" filter="url(#tf2-grain)" opacity="0.04" />
+        <rect x="2" y="2" width="476" height="296" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
+        <rect x="2" y="2" width="476" height="296" rx="14" fill="url(#tf2-grid)" />
 
-        <!-- ── Trazo a pluma (con temblor): todo en tinta berenjena ─────── -->
-        <g filter="url(#tf2-rough)">
-          <!-- Membrana de la célula, dibujada a mano (no es un círculo perfecto) -->
-          <path
-            :d="cellPath"
-            fill="none"
-            stroke="#2d1b3d"
-            stroke-width="2.2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <!-- Costura central a lápiz -->
-          <path :d="seamPath" fill="none" stroke="#2d1b3d" stroke-width="1.4" stroke-dasharray="2 5" opacity="0.55" />
-
-          <!-- Lado MAMA: red densa cartografiada (tinta) -->
-          <g class="tf2__web" stroke="#2d1b3d" stroke-width="0.9" stroke-linecap="round" fill="none" opacity="0.8">
-            <path v-for="(l, i) in webLines" :key="'l' + i" :d="l.d" />
-          </g>
-          <g fill="#2d1b3d" stroke="none">
-            <circle
-              v-for="(n, i) in lumNodes"
-              :key="'n' + i"
-              class="tf2__lum-node"
-              :cx="n.x"
-              :cy="n.y"
-              :r="n.r"
-              :style="{ '--o': String(n.o), '--d': (0.02 * i).toFixed(2) + 's' }"
-            />
-          </g>
-
-          <!-- Lado NEUROENDOCRINO: penumbra de puntitos (stippling = lo desconocido) -->
-          <g fill="#2d1b3d" stroke="none" opacity="0.38">
-            <circle v-for="(u, i) in unknownNodes" :key="'u' + i" :cx="u.x" :cy="u.y" :r="u.r" />
-          </g>
-
-          <!-- Puentes coral: las certezas cruzan hacia la red (se tratan juntas) -->
-          <path
-            v-for="(b, i) in bridges"
-            :key="'b' + i"
-            class="tf2__bridge"
-            :d="b.d"
-            fill="none"
-            stroke="#ff6b47"
-            stroke-width="1.2"
-            stroke-dasharray="3 3"
-          />
-
-          <!-- Las dos certezas: punto coral + círculo rodeado a mano (único acento) -->
-          <g class="tf2__known" v-for="(k, i) in knownNodes" :key="'k' + i" :style="{ '--d': (0.9 + 0.35 * i).toFixed(2) + 's' }">
-            <circle :cx="k.x" :cy="k.y" r="4.5" fill="#ff6b47" stroke="none" />
-            <path :d="k.ring" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" />
-          </g>
+        <g clip-path="url(#tf2-field)">
+          <rect :x="FX - RX" :y="FY - RY" :width="BX - (FX - RX)" :height="2 * RY" fill="#9d44ab" opacity="0.08" />
+          <rect :x="BX" :y="FY - RY" :width="FX + RX - BX" :height="2 * RY" fill="#2d1b3d" opacity="0.13" />
         </g>
+        <path :d="fieldPath" fill="none" stroke="rgba(45,27,61,0.45)" stroke-width="2" stroke-linecap="round" />
+        <path :d="seamPath" fill="none" stroke="rgba(45,27,61,0.3)" stroke-width="1.3" stroke-dasharray="2 5" />
 
-        <!-- ── Anotaciones manuscritas (sin filtro, legibles) ──────────── -->
-        <!-- Flechas curvas finas -->
-        <g fill="none" stroke-width="1.3">
-          <path :d="ann.mama.arrow" stroke="#2d1b3d" marker-end="url(#tf2-arrow)" />
-          <path :d="ann.ne.arrow" stroke="#2d1b3d" marker-end="url(#tf2-arrow)" />
-          <path :d="ann.mapped.arrow" stroke="#2d1b3d" opacity="0.7" marker-end="url(#tf2-arrow)" />
-          <path v-for="(k, i) in knownNodes" :key="'ka' + i" :d="k.arrow" stroke="#bb4128" marker-end="url(#tf2-arrow-c)" />
+        <!-- Gránulos Cg/Syn: definen el 80% NE -->
+        <g fill="#2d1b3d" opacity="0.3">
+          <circle v-for="(gr, i) in granules" :key="'gr' + i" :cx="gr.x" :cy="gr.y" :r="gr.r" />
         </g>
-        <!-- Etiquetas -->
-        <g class="tf2__hand" fill="#2d1b3d">
-          <text :x="ann.mama.x" :y="ann.mama.y" :transform="`rotate(-7 ${ann.mama.x} ${ann.mama.y})`" class="tf2__label tf2__up">{{ $t('twofaces.lum_word') }}</text>
-          <text :x="ann.ne.x" :y="ann.ne.y" :transform="`rotate(5 ${ann.ne.x} ${ann.ne.y})`" class="tf2__label tf2__label--sm tf2__up">{{ $t('twofaces.ne_word') }}</text>
-          <text :x="ann.mapped.x" :y="ann.mapped.y" :transform="`rotate(-4 ${ann.mapped.x} ${ann.mapped.y})`" class="tf2__note tf2__up" opacity="0.75">{{ $t('twofaces.note_mapped') }}</text>
-          <text :x="ann.dark.x" :y="ann.dark.y" :transform="`rotate(4 ${ann.dark.x} ${ann.dark.y})`" class="tf2__note tf2__up" opacity="0.6">{{ $t('twofaces.note_dark') }}</text>
-          <!-- ? sobre la penumbra -->
-          <text v-for="(q, i) in qmarks" :key="'q' + i" :x="q.x" :y="q.y" class="tf2__q" opacity="0.4">?</text>
+        <text x="312" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
+        <text x="312" y="168" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
+
+        <!-- LUMINAL · amplicón 11q13 (amplificación = copias apiladas) -->
+        <g>
+          <rect v-for="c in 4" :key="'c' + c" :x="48 + (c - 1) * 3" y="84" width="2" height="9" rx="1" fill="#9d44ab" />
         </g>
-        <!-- Certezas: nombre coral + significado a mano -->
-        <g class="tf2__hand">
-          <template v-for="(k, i) in knownNodes" :key="'kt' + i">
-            <text :x="k.lx" :y="k.ly" class="tf2__label tf2__up" fill="#bb4128" translate="no">{{ k.m }}</text>
-            <text :x="k.lx" :y="k.ly + 16" class="tf2__note" fill="#3a3340">{{ k.note }}</text>
-          </template>
+        <text x="66" y="92" class="tf2__amp-head" translate="no">{{ $t('twofaces.amplicon') }}</text>
+        <text x="48" y="110" class="tf2__amp-g" translate="no">{{ $t('twofaces.amplicon_g1') }}</text>
+        <text x="48" y="126" class="tf2__amp-g" translate="no">{{ $t('twofaces.amplicon_g2') }}</text>
+
+        <!-- LUMINAL · ESR1 (mutación = rombo) -->
+        <path d="M52 146 l5 5 l-5 5 l-5 -5 z" fill="none" stroke="#9d44ab" stroke-width="1.6" />
+        <text x="62" y="155" class="tf2__amp-g" translate="no">{{ $t('twofaces.esr1') }}</text>
+
+        <!-- LUMINAL · receptores HR+ (presente) y HER2 (tachado = negativo) -->
+        <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none">
+          <path :d="hrRec" />
         </g>
-        <!-- Cierre: un mismo tumor, se tratan juntas (subrayado coral a mano) -->
-        <g class="tf2__hand">
-          <text x="220" y="366" text-anchor="middle" class="tf2__together-txt" fill="#2d1b3d">{{ $t('twofaces.together_short') }}</text>
-          <path d="M118 372 Q220 377 322 371" fill="none" stroke="#ff6b47" stroke-width="2" stroke-linecap="round" />
+        <text :x="hr.x - 30" :y="hr.y - 6" class="tf2__rec-lab" translate="no">{{ $t('twofaces.hr') }}</text>
+        <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none" opacity="0.55">
+          <path :d="her2Rec" />
         </g>
+        <path :d="her2Slash" stroke="#bb4128" stroke-width="1.6" stroke-linecap="round" fill="none" />
+        <text :x="her2.x - 44" :y="her2.y + 14" class="tf2__rec-lab tf2__rec-lab--off" translate="no">{{ $t('twofaces.her2') }}</text>
+
+        <!-- NE · RB1 perdido (pérdida = gen roto + tachado) -->
+        <path d="M294 98 h5 M303 98 h5" stroke="#bb4128" stroke-width="2" stroke-linecap="round" />
+        <path d="M292 92 l16 12" stroke="#bb4128" stroke-width="1.6" stroke-linecap="round" />
+        <text x="316" y="95" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
+        <text x="316" y="109" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
+
+        <!-- NE · SSTR2 receptores (sobreexpresados → PRRT) -->
+        <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
+          <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
+        </g>
+        <text x="470" y="236" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
+        <text x="470" y="250" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
+
+        <!-- Títulos (derecha en dos líneas → no chocan en móvil) -->
+        <text x="34" y="26" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
+        <text x="34" y="42" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
+        <text x="470" y="24" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
+        <text x="470" y="40" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
+
+        <!-- Cierre -->
+        <text x="240" y="278" text-anchor="middle" class="tf2__close">{{ $t('twofaces.close1') }}</text>
+        <text x="240" y="295" text-anchor="middle" class="tf2__close tf2__close--coral">{{ $t('twofaces.close2') }}</text>
       </svg>
     </figure>
 
-    <!-- Lectura accesible (lectores de pantalla / SEO): lo que el dibujo cuenta. -->
-    <div class="sr-only">
-      <p>{{ $t('twofaces.lum_label') }}: {{ $t('twofaces.lum_status') }}</p>
-      <p>{{ $t('twofaces.ne_label') }}: {{ $t('twofaces.ne_status') }}</p>
-      <ul>
-        <li v-for="(k, i) in known" :key="i">{{ k.m }} — {{ k.d }}</li>
-      </ul>
-      <p>{{ $t('twofaces.together') }}</p>
-    </div>
+    <p class="sr-only">{{ $t('twofaces.sr') }}</p>
   </section>
 </template>
 
 <script setup lang="ts">
 /**
- * «Las dos caras» — página de cuaderno de laboratorio según el ADN gráfico del
- * design system: ilustración a pluma en tinta berenjena (#2d1b3d), trazo
- * imperfecto, UN solo acento (coral #ff6b47) reservado a las dos certezas que
- * financia la campaña. El lado luminal "conocido" se representa por densidad de
- * tinta (red cartografiada); el neuroendocrino, por penumbra de puntitos
- * (stippling) + las dos certezas rodeadas a mano: RB1 (el motor) y SSTR2 (vía
- * PRRT), documentadas en /ciencia. Todo anotado a mano DENTRO de la página
- * (mayúsculas + flechas curvas), sin leyenda fuera. La lectura completa va en
- * un bloque sr-only (a11y/SEO). Posiciones deterministas (PRNG), mobile-first
- * (viewBox), animaciones con prefers-reduced-motion.
+ * «Un tumor con dos caras» — ESQUEMA de cuaderno (no un retrato de la célula),
+ * riguroso pero aligerado. Gramática de alteraciones: receptores en la
+ * membrana (HR+, HER2 tachado, SSTR2), amplificación = copias apiladas + ×N
+ * agrupadas en el clúster 11q13, mutación = rombo (ESR1, ctDNA), pérdida = gen
+ * roto (RB1), gránulos Cg/Syn = el 80% neuroendocrino. Lo conocido es pequeño;
+ * lo que manda (80%) apenas se conoce → bloquéalo por un lado y escapa por el
+ * otro, hay que tratarlo entero. «Diferenciación neuroendocrina», nunca
+ * «neuroendocrino» a secas. viewBox fijo (mobile-first), texto real en sr-only.
  */
 defineProps<{ compact?: boolean }>()
 
 const { t, tm, rt } = useI18n()
 
-const R = 132
-const cx = 206
-const cy = 178
+const FX = 250
+const FY = 130
+const RX = 190
+const RY = 80
+const BX = 182 // frontera: luminal pequeño, pero con sitio para su genómica
 
 function mulberry32(seed: number) {
   let a = seed
@@ -168,21 +125,6 @@ function mulberry32(seed: number) {
     return ((t2 ^ (t2 >>> 14)) >>> 0) / 4294967296
   }
 }
-function inCell(x: number, y: number, pad = 10) {
-  return (x - cx) ** 2 + (y - cy) ** 2 <= (R - pad) ** 2
-}
-function penLine(x1: number, y1: number, x2: number, y2: number, rnd: () => number) {
-  const mx = (x1 + x2) / 2
-  const my = (y1 + y2) / 2
-  const dx = x2 - x1
-  const dy = y2 - y1
-  const len = Math.hypot(dx, dy) || 1
-  const off = (rnd() * 2 - 1) * Math.min(5, len * 0.16)
-  return `M${x1} ${y1} Q${(mx + (-dy / len) * off).toFixed(1)} ${(my + (dx / len) * off).toFixed(1)} ${x2} ${y2}`
-}
-
-// Cierra una nube de puntos con curvas suaves (Catmull-Rom → Bézier):
-// el wobble queda orgánico, como trazo de boli, no facetado.
 function smoothClosed(pts: { x: number; y: number }[]) {
   const n = pts.length
   const P = (i: number) => pts[((i % n) + n) % n]!
@@ -192,161 +134,85 @@ function smoothClosed(pts: { x: number; y: number }[]) {
     const p1 = P(i)
     const p2 = P(i + 1)
     const p3 = P(i + 2)
-    const c1x = p1.x + (p2.x - p0.x) / 6
-    const c1y = p1.y + (p2.y - p0.y) / 6
-    const c2x = p2.x - (p3.x - p1.x) / 6
-    const c2y = p2.y - (p3.y - p1.y) / 6
-    d += ` C${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${p2.x.toFixed(1)} ${p2.y.toFixed(1)}`
+    d += ` C${(p1.x + (p2.x - p0.x) / 6).toFixed(1)} ${(p1.y + (p2.y - p0.y) / 6).toFixed(1)}, ${(p2.x - (p3.x - p1.x) / 6).toFixed(1)} ${(p2.y - (p3.y - p1.y) / 6).toFixed(1)}, ${p2.x.toFixed(1)} ${p2.y.toFixed(1)}`
   }
   return d + ' Z'
 }
 
-// Célula dibujada a mano: blob suave con radios ligeramente variables.
-const cellPath = computed(() => {
+const fieldPath = computed(() => {
   const rnd = mulberry32(99)
   const pts: { x: number; y: number }[] = []
-  const N = 16
+  const N = 20
   for (let i = 0; i < N; i++) {
-    const ang = (i / N) * Math.PI * 2
-    const rr = R + (rnd() * 2 - 1) * 5
-    pts.push({ x: cx + Math.cos(ang) * rr, y: cy + Math.sin(ang) * rr * 0.98 })
+    const a = (i / N) * Math.PI * 2
+    const rr = 1 + (rnd() * 2 - 1) * 0.035
+    pts.push({ x: FX + Math.cos(a) * RX * rr, y: FY + Math.sin(a) * RY * rr })
   }
   return smoothClosed(pts)
 })
-const seamPath = `M${cx} ${cy - R + 10} Q${cx + 6} ${cy} ${cx - 4} ${cy + R - 10}`
+const seamPath = `M${BX - 2} ${FY - RY + 14} Q${BX + 8} ${FY} ${BX - 6} ${FY + RY - 14}`
 
-interface Node { x: number; y: number; r: number; o: number }
-
-// Las dos certezas: punto, círculo rodeado a mano, flecha y etiqueta+significado.
-const knownNodes = computed(() => {
-  const mk = (x: number, y: number, m: string, note: string, lx: number, ly: number, ax: number, ay: number) => ({
-    x, y, m, note, lx, ly,
-    ring: handRing(x, y, 16, 13),
-    arrow: penLine(ax, ay, x + 13, y - 6, mulberry32(Math.round(x * y))),
-  })
-  return [
-    mk(294, 122, 'RB1', t('twofaces.rb1_note'), 348, 108, 346, 104),
-    mk(286, 244, 'SSTR2', t('twofaces.sstr2_note'), 338, 250, 336, 246),
-  ]
-})
-function handRing(x: number, y: number, rx: number, ry: number) {
-  // Aro rodeado a boli: elipse suave con leve temblor (curvas, no facetas).
-  const pts: { x: number; y: number }[] = []
-  const N = 12
-  const rnd = mulberry32(Math.round(x + y))
-  for (let i = 0; i < N; i++) {
-    const ang = (i / N) * Math.PI * 2 - 0.5
-    pts.push({ x: x + Math.cos(ang) * rx + (rnd() * 2 - 1) * 1.2, y: y + Math.sin(ang) * ry + (rnd() * 2 - 1) * 1.2 })
-  }
-  return smoothClosed(pts)
-}
-
-const geometry = computed(() => {
-  const rnd = mulberry32(20240127)
-  const lumNodes: Node[] = []
-  let guard = 0
-  while (lumNodes.length < 46 && guard < 6000) {
-    guard++
-    const x = cx - R + rnd() * R
-    const y = cy - R + rnd() * (2 * R)
-    if (x < cx - 8 && inCell(x, y)) {
-      lumNodes.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.6 + rnd() * 1.9).toFixed(1), o: +(0.55 + rnd() * 0.4).toFixed(2) })
-    }
-  }
-  const webLines: { d: string }[] = []
-  for (let i = 1; i < lumNodes.length; i++) {
-    let best = -1
-    let bd = Infinity
-    for (let j = 0; j < i; j++) {
-      const dx = lumNodes[i]!.x - lumNodes[j]!.x
-      const dy = lumNodes[i]!.y - lumNodes[j]!.y
-      const d = dx * dx + dy * dy
-      if (d < bd) { bd = d; best = j }
-    }
-    if (best >= 0 && bd < 40 * 40) {
-      webLines.push({ d: penLine(lumNodes[i]!.x, lumNodes[i]!.y, lumNodes[best]!.x, lumNodes[best]!.y, rnd) })
-    }
-  }
-  const unknownNodes: { x: number; y: number; r: number }[] = []
-  guard = 0
-  const kn = knownNodes.value
-  while (unknownNodes.length < 14 && guard < 6000) {
-    guard++
-    const x = cx + rnd() * R
-    const y = cy - R + rnd() * (2 * R)
-    const farFromKnown = kn.every((k) => (k.x - x) ** 2 + (k.y - y) ** 2 > 30 * 30)
-    if (x > cx + 10 && inCell(x, y, 14) && farFromKnown) {
-      unknownNodes.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.6 + rnd() * 1.6).toFixed(1) })
-    }
-  }
-  const bridges = kn.map((k) => {
-    let best = lumNodes[0]!
-    let bd = Infinity
-    for (const n of lumNodes) {
-      const d = (n.x - k.x) ** 2 + (n.y - k.y) ** 2
-      if (d < bd) { bd = d; best = n }
-    }
-    return { d: penLine(k.x, k.y, best.x, best.y, rnd) }
-  })
-  return { lumNodes, webLines, unknownNodes, bridges }
-})
-const lumNodes = computed(() => geometry.value.lumNodes)
-const webLines = computed(() => geometry.value.webLines)
-const unknownNodes = computed(() => geometry.value.unknownNodes)
-const bridges = computed(() => geometry.value.bridges)
-
-// ¿ marcas sobre la penumbra (lo desconocido)
-const qmarks = [
-  { x: 322, y: 150 },
-  { x: 268, y: 196 },
-  { x: 330, y: 210 },
-]
-
-// Anotaciones manuscritas con flecha (posiciones fijas).
-const ann = computed(() => ({
-  mama: { x: 44, y: 60, arrow: 'M70 66 Q92 78 110 104' },
-  ne: { x: 244, y: 44, arrow: 'M298 52 Q318 66 318 92' },
-  mapped: { x: 28, y: 318, arrow: 'M92 310 Q118 288 140 256' },
-  dark: { x: 250, y: 322, arrow: 'M300 316 Q300 296 296 276' },
-}))
-
-interface Known { m: string; d: string }
-const known = computed<Known[]>(() => {
-  const raw = tm('twofaces.ne_known') as unknown
-  if (!Array.isArray(raw)) return []
-  return raw.map((e) => ({ m: rt((e as Record<string, unknown>).m as never), d: rt((e as Record<string, unknown>).d as never) }))
-})
-
-const ariaLabel = computed(() => {
-  const lum = t('twofaces.lum_label') + ': ' + t('twofaces.lum_status')
-  const ne = t('twofaces.ne_label') + ': ' + t('twofaces.ne_status')
-  const certs = known.value.map((k) => `${k.m} (${k.d})`).join(', ')
-  return `${lum} ${ne} ${certs}. ${t('twofaces.together')}`
-})
-
-const root = ref<HTMLElement | null>(null)
-const inView = ref(false)
-let io: IntersectionObserver | null = null
-onMounted(() => {
-  if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
-    inView.value = true
-    return
-  }
-  io = new IntersectionObserver(
-    (entries) => {
-      for (const e of entries) {
-        if (e.isIntersecting) {
-          inView.value = true
-          io?.disconnect()
-          break
-        }
-      }
-    },
-    { threshold: 0.3 }
+// Receptor «Y» en un punto de la membrana, hacia fuera.
+function recPath(px: number, py: number, nx: number, ny: number, len = 8) {
+  const bx = px - nx * 2
+  const by = py - ny * 2
+  const tx = px + nx * len
+  const ty = py + ny * len
+  const perpx = -ny
+  const perpy = nx
+  return (
+    `M${bx.toFixed(1)} ${by.toFixed(1)} L${tx.toFixed(1)} ${ty.toFixed(1)} ` +
+    `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx + perpx * 3.5 - nx).toFixed(1)} ${(ty + perpy * 3.5 - ny).toFixed(1)} ` +
+    `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx - perpx * 3.5 - nx).toFixed(1)} ${(ty - perpy * 3.5 - ny).toFixed(1)}`
   )
-  if (root.value) io.observe(root.value)
+}
+function onArc(deg: number) {
+  const a = (deg * Math.PI) / 180
+  return { x: FX + Math.cos(a) * RX, y: FY + Math.sin(a) * RY, nx: Math.cos(a), ny: Math.sin(a) }
+}
+// HR+ (presente) y HER2 (tachado) sobre la membrana luminal (arco izquierdo)
+const hr = onArc(206)
+const hrRec = recPath(hr.x, hr.y, hr.nx, hr.ny)
+const her2 = onArc(150)
+const her2Rec = recPath(her2.x, her2.y, her2.nx, her2.ny)
+const her2Slash = `M${(her2.x - 6).toFixed(1)} ${(her2.y - 12).toFixed(1)} l12 12`
+
+// SSTR2 receptores sobreexpresados (arco derecho, NE)
+const receptors = computed(() => {
+  const out: string[] = []
+  for (let i = 0; i < 6; i++) {
+    const p = onArc(-46 + i * 18)
+    out.push(recPath(p.x, p.y, p.nx, p.ny))
+  }
+  return out
 })
-onBeforeUnmount(() => io?.disconnect())
+
+// Gránulos Cg/Syn (textura del 80% NE), esquivando RB1, el rótulo y el borde.
+const granules = computed(() => {
+  const rnd = mulberry32(424242)
+  const out: { x: number; y: number; r: number }[] = []
+  let guard = 0
+  while (out.length < 11 && guard < 6000) {
+    guard++
+    const x = BX + 16 + rnd() * (FX + RX - (BX + 34))
+    const y = FY - RY + rnd() * (2 * RY)
+    const inF = ((x - FX) / (RX - 16)) ** 2 + ((y - FY) / (RY - 14)) ** 2 <= 1
+    const farRB1 = (x - 300) ** 2 + (y - 100) ** 2 > 28 * 28
+    const farCenter = Math.abs(x - 312) > 48 || y < 130 || y > 178
+    if (inF && farRB1 && farCenter) {
+      out.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.5 + rnd() * 1).toFixed(1) })
+    }
+  }
+  return out
+})
+
+const neHead = computed(() => {
+  const h = t('twofaces.ne_head')
+  // dos líneas para no chocar con el título izquierdo en móvil
+  return h.includes(' ') ? [h.split(' ')[0]!, h.split(' ').slice(1).join(' ')] : [h, '']
+})
+
+const ariaLabel = computed(() => t('twofaces.sr'))
 </script>
 
 <style scoped>
@@ -356,64 +222,75 @@ onBeforeUnmount(() => io?.disconnect())
 .tf2__svg {
   display: block;
   width: 100%;
-  max-width: 500px;
+  max-width: 540px;
   height: auto;
   margin: 0 auto;
 }
-.tf2__hand {
+.tf2__head {
   font-family: 'Caveat', 'Bradley Hand', cursive;
-}
-.tf2__up {
-  text-transform: uppercase;
-}
-.tf2__label {
-  font-size: 20px;
-  font-weight: 700;
-}
-.tf2__label--sm {
   font-size: 17px;
-}
-.tf2__note {
-  font-size: 15px;
-}
-.tf2__q {
-  font-family: 'Caveat', cursive;
-  font-size: 22px;
   font-weight: 700;
   fill: #2d1b3d;
 }
-.tf2__together-txt {
+.tf2__sub {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 13px;
+  fill: #3a3340;
+}
+.tf2__amp-head {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 13px;
+  font-weight: 700;
+  fill: #6a2475;
+}
+.tf2__amp-g {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 13px;
+  font-weight: 700;
+  fill: #6a2475;
+}
+.tf2__rec-lab {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 13px;
+  font-weight: 700;
+  fill: #6a2475;
+}
+.tf2__rec-lab--off {
+  fill: #3a3340;
+}
+.tf2__known-m {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 16px;
+  font-weight: 700;
+  fill: #bb4128;
+}
+.tf2__known-n {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 12px;
+  fill: #3a3340;
+}
+.tf2__pct {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 34px;
+  font-weight: 700;
+  fill: #2d1b3d;
+  opacity: 0.3;
+}
+.tf2__cgsyn {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 13px;
+  font-weight: 700;
+  fill: #2d1b3d;
+  opacity: 0.4;
+}
+.tf2__close {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 18px;
   font-weight: 700;
+  fill: #2d1b3d;
 }
-
-/* Estado base = visible (lo que ve reduced-motion: nada oculto). */
-.tf2__lum-node { opacity: var(--o, 0.7); }
-.tf2__lum-node,
-.tf2__known {
-  transform-box: fill-box;
-  transform-origin: center;
-}
-
-/* ── Animación: la red se dibuja; las certezas se rodean al final ───── */
-@media (prefers-reduced-motion: no-preference) {
-  .tf2__web { transition: opacity 0.6s ease; }
-  .tf2:not(.tf2-in) .tf2__web { opacity: 0; }
-  .tf2:not(.tf2-in) .tf2__lum-node { opacity: 0; }
-  .tf2-in .tf2__lum-node { animation: tf2-pop 0.4s ease-out var(--d, 0s) backwards; }
-  .tf2:not(.tf2-in) .tf2__known { opacity: 0; }
-  .tf2-in .tf2__known { animation: tf2-ignite 0.8s ease-out var(--d, 0s) backwards; }
-  .tf2:not(.tf2-in) .tf2__bridge { stroke-dasharray: 200; stroke-dashoffset: 200; }
-  .tf2-in .tf2__bridge { animation: tf2-draw 1s ease 1.2s backwards; }
-  @keyframes tf2-pop {
-    from { opacity: 0; transform: scale(0.5); }
-    to { opacity: var(--o, 0.7); transform: scale(1); }
-  }
-  @keyframes tf2-ignite {
-    0% { opacity: 0; }
-    60% { opacity: 1; }
-    100% { opacity: 1; }
-  }
-  @keyframes tf2-draw { to { stroke-dashoffset: 0; } }
+.tf2__close--coral {
+  font-size: 16px;
+  fill: #ff6b47;
 }
 </style>

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -13,7 +13,7 @@
          sobreexpresados (coral). ADN DENTRO: amplificaciones (FGFR1, CCND1) y
          mutación (ESR1). El 80% que manda (Cg/Syn) es lo que falta por conocer;
          RB1 es el freno que se está perdiendo. El detalle riguroso, en /ciencia. -->
-    <figure class="tf2">
+    <figure ref="figEl" class="tf2">
       <svg class="tf2__svg" viewBox="0 0 480 246" role="img" :aria-label="ariaLabel">
         <defs>
           <pattern id="tf2-grid" width="22" height="22" patternUnits="userSpaceOnUse">
@@ -25,67 +25,74 @@
         <rect x="2" y="2" width="476" height="242" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
         <rect x="2" y="2" width="476" height="242" rx="14" fill="url(#tf2-grid)" />
 
-        <g clip-path="url(#tf2-field)">
+        <!-- Territorios (tintes): el luminal con r1, el neuroendocrino con r2,
+             para que cada lado «se encienda» en su turno. -->
+        <g clip-path="url(#tf2-field)" class="tf2__reveal tf2__r1">
           <rect :x="FX - RX" :y="FY - RY" :width="BX - (FX - RX)" :height="2 * RY" fill="#9d44ab" opacity="0.08" />
+        </g>
+        <g clip-path="url(#tf2-field)" class="tf2__reveal tf2__r2">
           <rect :x="BX" :y="FY - RY" :width="FX + RX - BX" :height="2 * RY" fill="#2d1b3d" opacity="0.13" />
         </g>
-        <path :d="fieldPath" fill="none" stroke="rgba(45,27,61,0.45)" stroke-width="2" stroke-linecap="round" />
-        <path :d="seamPath" fill="none" stroke="rgba(45,27,61,0.3)" stroke-width="1.3" stroke-dasharray="2 5" />
 
-        <!-- Gránulos Cg/Syn = el 80% neuroendocrino -->
-        <g fill="#2d1b3d" opacity="0.28">
-          <circle v-for="(gr, i) in granules" :key="'gr' + i" :cx="gr.x" :cy="gr.y" :r="gr.r" />
-        </g>
-        <text x="324" y="170" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
-        <text x="324" y="187" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
+        <!-- La célula se dibuja sola (primer trazo del cuaderno) -->
+        <path :d="fieldPath" class="tf2__outline" pathLength="1" fill="none" stroke="rgba(45,27,61,0.45)" stroke-width="2" stroke-linecap="round" />
+        <path :d="seamPath" class="tf2__reveal tf2__r2" fill="none" stroke="rgba(45,27,61,0.3)" stroke-width="1.3" stroke-dasharray="2 5" />
 
-        <!-- Receptores hormonales HR+ (presentes, lila) en la membrana luminal -->
-        <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none">
-          <path v-for="(r, i) in hrReceptors" :key="'hr' + i" :d="r" />
-        </g>
-        <text x="8" y="206" class="tf2__rec-lab" translate="no">HR+</text>
-        <text x="8" y="220" class="tf2__rec-note">{{ $t('twofaces.hr_note') }}</text>
-        <!-- HER2 negativo = NO lo tiene: receptor ausente. En GRIS (no es diana,
-             no está) y punteado, frente al lila/coral de los que sí hay. -->
-        <path :d="her2Ghost" fill="none" stroke="#8a857e" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" opacity="0.7" />
-        <text x="8" y="110" class="tf2__rec-off" translate="no">HER2−</text>
-
-        <!-- Alteraciones genómicas (dentro): amplificación = círculo doble (copias),
-             mutación = rombo. -->
-        <g v-for="(g, i) in genes" :key="'g' + i">
-          <template v-if="g.t === 'amp'">
-            <circle cx="104" :cy="gy(i)" r="4.5" fill="none" stroke="#9d44ab" stroke-width="1.4" />
-            <circle cx="104" :cy="gy(i)" r="1.7" fill="#9d44ab" />
-          </template>
-          <path v-else :d="diamond(104, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.4" />
-          <text x="116" :y="gy(i) + 4" class="tf2__genes" translate="no">{{ g.n }}</text>
+        <!-- FASE 1 · LADO LUMINAL: lo que conocemos (HR+, HER2−, genes, título) -->
+        <g class="tf2__reveal tf2__r1">
+          <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none">
+            <path v-for="(r, i) in hrReceptors" :key="'hr' + i" :d="r" />
+          </g>
+          <text x="8" y="206" class="tf2__rec-lab" translate="no">HR+</text>
+          <text x="8" y="220" class="tf2__rec-note">{{ $t('twofaces.hr_note') }}</text>
+          <!-- HER2 negativo = NO lo tiene: receptor ausente, en GRIS (no es diana). -->
+          <path :d="her2Ghost" fill="none" stroke="#8a857e" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" opacity="0.7" />
+          <text x="8" y="110" class="tf2__rec-off" translate="no">HER2−</text>
+          <!-- Alteraciones genómicas: amplificación = círculo doble, mutación = rombo. -->
+          <g v-for="(g, i) in genes" :key="'g' + i">
+            <template v-if="g.t === 'amp'">
+              <circle cx="104" :cy="gy(i)" r="4.5" fill="none" stroke="#9d44ab" stroke-width="1.4" />
+              <circle cx="104" :cy="gy(i)" r="1.7" fill="#9d44ab" />
+            </template>
+            <path v-else :d="diamond(104, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.4" />
+            <text x="116" :y="gy(i) + 4" class="tf2__genes" translate="no">{{ g.n }}</text>
+          </g>
+          <text x="34" y="28" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
+          <text x="34" y="44" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
         </g>
 
-        <!-- RB1 = el freno que se está perdiendo (aro ROTO, no entero) -->
-        <circle cx="300" cy="116" r="4.5" fill="#ff6b47" />
-        <path :d="rb1Broken" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" />
-        <text x="320" y="112" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
-        <text x="320" y="126" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
-
-        <!-- SSTR2 = receptores sobreexpresados (coral) en la membrana NE -->
-        <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
-          <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
+        <!-- FASE 2 · EL 80% NEUROENDOCRINO: lo que falta por conocer (gránulos
+             Cg/Syn, el «80%» y el título de la cara desconocida) -->
+        <g class="tf2__reveal tf2__r2">
+          <g fill="#2d1b3d" opacity="0.28">
+            <circle v-for="(gr, i) in granules" :key="'gr' + i" :cx="gr.x" :cy="gr.y" :r="gr.r" />
+          </g>
+          <text x="324" y="170" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
+          <text x="324" y="187" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
+          <text x="470" y="26" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
+          <text x="470" y="43" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
+          <text x="470" y="59" text-anchor="end" class="tf2__sub">{{ $t('twofaces.ne_sub') }}</text>
         </g>
-        <text x="472" y="214" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
-        <text x="472" y="228" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
 
-        <!-- Títulos (derecha en dos líneas + subtítulo, con aire) -->
-        <text x="34" y="28" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
-        <text x="34" y="44" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
-        <text x="470" y="26" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
-        <text x="470" y="43" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
-        <text x="470" y="59" text-anchor="end" class="tf2__sub">{{ $t('twofaces.ne_sub') }}</text>
+        <!-- FASE 3 · lo poco que SÍ sabemos del lado NE: RB1 (freno que se pierde)
+             y SSTR2 (receptores diana de la PRRT) -->
+        <g class="tf2__reveal tf2__r3">
+          <circle cx="300" cy="116" r="4.5" fill="#ff6b47" />
+          <path :d="rb1Broken" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" />
+          <text x="320" y="112" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
+          <text x="320" y="126" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
+          <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
+            <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
+          </g>
+          <text x="472" y="214" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
+          <text x="472" y="228" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
+        </g>
       </svg>
 
       <!-- Leyenda en lenguaje llano (ocupa el hueco del cierre): qué significa
            cada glifo, para que la gente lo entienda. Los mini-iconos mapean al
            dibujo. -->
-      <figcaption class="tf2-legend">
+      <figcaption class="tf2-legend tf2__reveal tf2__r4">
         <!-- Receptores diana: dos colores (lila = HR, coral = SSTR2), los que SÍ hay -->
         <span class="tf2-legend__item">
           <svg class="tf2-legend__g" viewBox="0 0 26 18" aria-hidden="true" style="width: 26px">
@@ -131,11 +138,47 @@
  * El 80% (Cg/Syn) es lo que manda y lo que falta por conocer; RB1 es el freno
  * que se está perdiendo (aro roto). Lo conocido es pequeño; lo dominante,
  * apenas conocido. El detalle riguroso (amplicón 11q13 con ×N, etc.) → /ciencia.
- * viewBox fijo (mobile-first), texto real en sr-only, sin animación (calma).
+ * viewBox fijo (mobile-first), texto real en sr-only.
+ *
+ * Revelado narrativo: al entrar en pantalla se dibuja una sola vez en el orden
+ * de la historia —célula → lado luminal (lo conocido) → el 80% neuroendocrino
+ * (lo que falta) → RB1/SSTR2 → leyenda—. El movimiento «cuenta» el concepto y
+ * reparte la carga cognitiva. Sin bucles; se desactiva con prefers-reduced-motion
+ * y nunca esconde nada si no hay JS (el estado base es visible).
  */
 defineProps<{ compact?: boolean }>()
 
 const { t } = useI18n()
+
+// Revelado por fases al entrar en viewport (una sola vez).
+const figEl = ref<HTMLElement | null>(null)
+onMounted(() => {
+  const el = figEl.value
+  if (!el) return
+  // Respeta la preferencia de movimiento reducido: no marcamos «ready», así el
+  // CSS deja todo visible y no se anima nada.
+  const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+  if (reduce) return
+  el.classList.add('tf2--ready')
+  if (!('IntersectionObserver' in window)) {
+    el.classList.add('is-in')
+    return
+  }
+  const io = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          el.classList.add('is-in')
+          io.disconnect()
+          break
+        }
+      }
+    },
+    { threshold: 0.25 }
+  )
+  io.observe(el)
+  onBeforeUnmount(() => io.disconnect())
+})
 
 const FX = 250
 const FY = 148
@@ -357,5 +400,52 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   width: 18px;
   height: 18px;
   flex-shrink: 0;
+}
+
+/* --- Revelado narrativo: una sola vez, al entrar en viewport ---
+   Estado base (SSR / sin JS / reduce-motion): TODO visible. El ocultado inicial
+   solo se aplica cuando el JS añade .tf2--ready Y se permite movimiento, de modo
+   que nadie se queda sin ver el esquema. */
+@media (prefers-reduced-motion: no-preference) {
+  .tf2--ready .tf2__reveal {
+    opacity: 0;
+  }
+  .tf2--ready .tf2__outline {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+  }
+  .tf2--ready.is-in .tf2__outline {
+    animation: tf2-draw 0.9s ease forwards;
+  }
+  .tf2--ready.is-in .tf2__reveal {
+    animation: tf2-fade 0.6s ease forwards;
+  }
+  /* Orden de la historia: luminal (conocido) → 80% NE (lo que falta) →
+     RB1/SSTR2 → leyenda. */
+  .tf2--ready.is-in .tf2__r1 {
+    animation-delay: 0.45s;
+  }
+  .tf2--ready.is-in .tf2__r2 {
+    animation-delay: 0.85s;
+  }
+  .tf2--ready.is-in .tf2__r3 {
+    animation-delay: 1.1s;
+  }
+  .tf2--ready.is-in .tf2__r4 {
+    animation-delay: 1.3s;
+  }
+}
+@keyframes tf2-draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes tf2-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 </style>

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -33,20 +33,28 @@
         <path :d="fieldPath" fill="none" stroke="rgba(45,27,61,0.45)" stroke-width="2" stroke-linecap="round" />
         <path :d="seamPath" fill="none" stroke="rgba(45,27,61,0.3)" stroke-width="1.3" stroke-dasharray="2 5" />
 
-        <!-- Textura tenue del lado conocido (luminal) -->
-        <g fill="#9d44ab" opacity="0.5">
-          <circle v-for="(d, i) in dots" :key="'d' + i" :cx="d.x" :cy="d.y" :r="d.r" />
-        </g>
         <!-- Gránulos Cg/Syn = el 80% neuroendocrino -->
         <g fill="#2d1b3d" opacity="0.28">
           <circle v-for="(gr, i) in granules" :key="'gr' + i" :cx="gr.x" :cy="gr.y" :r="gr.r" />
         </g>
-        <text x="322" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
-        <text x="322" y="167" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
+        <text x="324" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
+        <text x="324" y="167" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
 
-        <!-- Lo conocido (luminal): marcadores nombrados, en claro -->
-        <text x="50" y="112" class="tf2__genes" translate="no">{{ $t('twofaces.lum_g1') }}</text>
-        <text x="50" y="132" class="tf2__genes" translate="no">{{ $t('twofaces.lum_g2') }}</text>
+        <!-- Lo conocido (luminal): un glifo por tipo de hallazgo —
+             amplificación = círculo doble (copias), mutación = rombo,
+             receptor = «Y» (HER2 tachado por negativo). Nombres legibles. -->
+        <g v-for="(g, i) in genes" :key="'g' + i">
+          <template v-if="g.t === 'amp'">
+            <circle cx="58" :cy="gy(i)" r="4.5" fill="none" stroke="#9d44ab" stroke-width="1.4" />
+            <circle cx="58" :cy="gy(i)" r="1.7" fill="#9d44ab" />
+          </template>
+          <path v-else-if="g.t === 'mut'" :d="diamond(58, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.4" />
+          <template v-else>
+            <path :d="recGlyph(58, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.5" stroke-linecap="round" />
+            <path v-if="g.t === 'recneg'" :d="slash(58, gy(i))" stroke="#bb4128" stroke-width="1.5" stroke-linecap="round" />
+          </template>
+          <text x="72" :y="gy(i) + 4" class="tf2__genes" translate="no">{{ g.n }}</text>
+        </g>
 
         <!-- Las dos certezas neuroendocrinas -->
         <circle cx="300" cy="96" r="4.5" fill="#ff6b47" />
@@ -55,22 +63,24 @@
         <text x="320" y="106" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
 
         <!-- SSTR2 = receptores sobre la membrana NE (lo característico: siempre
-             los tendrá; sobreexpresados → diana de la PRRT) -->
+             los tendrá; sobreexpresados → diana de la PRRT). Etiqueta pegada
+             al racimo de receptores. -->
         <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
           <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
         </g>
-        <text x="470" y="236" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
-        <text x="470" y="250" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
+        <text x="470" y="196" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
+        <text x="470" y="210" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
 
         <!-- Títulos (derecha en dos líneas → no chocan en móvil) -->
         <text x="34" y="26" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
         <text x="34" y="42" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
         <text x="470" y="24" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
         <text x="470" y="41" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
+        <text x="470" y="57" text-anchor="end" class="tf2__sub">{{ $t('twofaces.ne_sub') }}</text>
 
         <!-- Cierre -->
-        <text x="240" y="266" text-anchor="middle" class="tf2__close">{{ $t('twofaces.close1') }}</text>
-        <text x="240" y="283" text-anchor="middle" class="tf2__close tf2__close--coral">{{ $t('twofaces.close2') }}</text>
+        <text x="240" y="266" text-anchor="middle" class="tf2__close tf2__close--soft">{{ $t('twofaces.close1') }}</text>
+        <text x="240" y="283" text-anchor="middle" class="tf2__close">{{ $t('twofaces.close2') }}</text>
       </svg>
     </figure>
 
@@ -162,31 +172,39 @@ function recPath(px: number, py: number, nx: number, ny: number, len = 8) {
     `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx - perpx * 3.5 - nx).toFixed(1)} ${(ty - perpy * 3.5 - ny).toFixed(1)}`
   )
 }
-// SSTR2 sobreexpresados: varios receptores sobre el arco derecho (NE).
+// SSTR2 sobreexpresados: racimo de receptores en el arco inferior-derecho (NE),
+// junto a su etiqueta (para que se lean cerca).
 const receptors = computed(() => {
   const out: string[] = []
-  for (let i = 0; i < 6; i++) {
-    const a = ((-46 + i * 18) * Math.PI) / 180
+  for (let i = 0; i < 5; i++) {
+    const a = ((8 + i * 12) * Math.PI) / 180
     out.push(recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a)))
   }
   return out
 })
 
-// Textura tenue del lado conocido (sin etiqueta: solo densidad).
-const dots = computed(() => {
-  const rnd = mulberry32(5)
-  const out: { x: number; y: number; r: number }[] = []
-  let guard = 0
-  while (out.length < 6 && guard < 4000) {
-    guard++
-    const x = FX - RX + 10 + rnd() * (BX - (FX - RX) - 20)
-    const y = FY - RY + rnd() * (2 * RY)
-    if (((x - FX) / (RX - 14)) ** 2 + ((y - FY) / (RY - 12)) ** 2 <= 1 && x < BX - 10) {
-      out.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.4 + rnd() * 1).toFixed(1) })
-    }
-  }
-  return out
-})
+// Marcadores conocidos del lado luminal, un glifo por tipo de hallazgo:
+//  amp = amplificación (círculo doble = copias) · mut = mutación (rombo) ·
+//  rec = receptor presente («Y») · recneg = receptor negativo («Y» tachado).
+const genes = [
+  { n: 'FGFR1', t: 'amp' },
+  { n: 'CCND1', t: 'amp' },
+  { n: 'ESR1', t: 'mut' },
+  { n: 'HR+', t: 'rec' },
+  { n: 'HER2−', t: 'recneg' },
+]
+function gy(i: number) {
+  return 98 + i * 19
+}
+function diamond(x: number, y: number) {
+  return `M${x} ${y - 4} l4 4 l-4 4 l-4 -4 z`
+}
+function recGlyph(x: number, y: number) {
+  return `M${x} ${y + 5} L${x} ${y - 1} M${x} ${y - 1} L${x - 3.5} ${y - 5} M${x} ${y - 1} L${x + 3.5} ${y - 5}`
+}
+function slash(x: number, y: number) {
+  return `M${x - 4} ${y + 3} L${x + 4} ${y - 5}`
+}
 // Gránulos Cg/Syn (el 80%), esquivando RB1, SSTR2, el rótulo central y el borde.
 const granules = computed(() => {
   const rnd = mulberry32(424242)
@@ -198,9 +216,9 @@ const granules = computed(() => {
     const y = FY - RY + rnd() * (2 * RY)
     const inF = ((x - FX) / (RX - 16)) ** 2 + ((y - FY) / (RY - 14)) ** 2 <= 1
     const farRB1 = (x - 300) ** 2 + (y - 96) ** 2 > 26 * 26
-    const farSSTR = (x - 320) ** 2 + (y - 182) ** 2 > 24 * 24
-    const farCenter = Math.abs(x - 322) > 50 || y < 132 || y > 176
-    if (inF && farRB1 && farSSTR && farCenter) {
+    const farCenter = Math.abs(x - 324) > 50 || y < 132 || y > 176
+    const farLabel = !(x > 352 && y > 180 && y < 214)
+    if (inF && farRB1 && farCenter && farLabel) {
       out.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.5 + rnd() * 1).toFixed(1) })
     }
   }
@@ -269,12 +287,12 @@ const ariaLabel = computed(() => t('twofaces.sr'))
 }
 .tf2__close {
   font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 18px;
+  font-size: 17px;
   font-weight: 700;
   fill: #2d1b3d;
 }
-.tf2__close--coral {
-  font-size: 16px;
-  fill: #ff6b47;
+.tf2__close--soft {
+  font-weight: 400;
+  fill: #3a3340;
 }
 </style>

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -45,8 +45,9 @@
         </g>
         <text x="8" y="206" class="tf2__rec-lab" translate="no">HR+</text>
         <text x="8" y="220" class="tf2__rec-note">{{ $t('twofaces.hr_note') }}</text>
-        <!-- HER2 negativo = NO lo tiene: receptor ausente (fantasma punteado) -->
-        <path :d="her2Ghost" fill="none" stroke="#9d44ab" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" opacity="0.45" />
+        <!-- HER2 negativo = NO lo tiene: receptor ausente. En GRIS (no es diana,
+             no está) y punteado, frente al lila/coral de los que sí hay. -->
+        <path :d="her2Ghost" fill="none" stroke="#8a857e" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" opacity="0.7" />
         <text x="8" y="110" class="tf2__rec-off" translate="no">HER2−</text>
 
         <!-- Alteraciones genómicas (dentro): amplificación = círculo doble (copias),
@@ -85,9 +86,18 @@
            cada glifo, para que la gente lo entienda. Los mini-iconos mapean al
            dibujo. -->
       <figcaption class="tf2-legend">
+        <!-- Receptores diana: dos colores (lila = HR, coral = SSTR2), los que SÍ hay -->
         <span class="tf2-legend__item">
-          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M9 16 L9 9 M9 9 L5 4 M9 9 L13 4" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" /></svg>
+          <svg class="tf2-legend__g" viewBox="0 0 26 18" aria-hidden="true" style="width: 26px">
+            <path d="M7 16 L7 9 M7 9 L4 5 M7 9 L10 5" fill="none" stroke="#9d44ab" stroke-width="1.5" stroke-linecap="round" />
+            <path d="M18 16 L18 9 M18 9 L15 5 M18 9 L21 5" fill="none" stroke="#ff6b47" stroke-width="1.5" stroke-linecap="round" />
+          </svg>
           {{ $t('twofaces.legend_rec') }}
+        </span>
+        <!-- HER2: gris y punteado = el receptor que NO tiene -->
+        <span class="tf2-legend__item">
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M9 16 L9 9 M9 9 L5 4 M9 9 L13 4" fill="none" stroke="#8a857e" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" /></svg>
+          {{ $t('twofaces.legend_her2') }}
         </span>
         <span class="tf2-legend__item">
           <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="5" fill="none" stroke="#9d44ab" stroke-width="1.4" /><circle cx="9" cy="9" r="2" fill="#9d44ab" /></svg>
@@ -101,9 +111,10 @@
           <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M13.5 5.2 A5 5 0 1 0 13.5 12.8" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" /></svg>
           {{ $t('twofaces.legend_rb1') }}
         </span>
+        <!-- Cg·Syn: los puntitos = gránulos neuroendocrinos, el 80% -->
         <span class="tf2-legend__item">
-          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M9 16 L9 9 M9 9 L5 4 M9 9 L13 4" fill="none" stroke="#8a857e" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" /></svg>
-          {{ $t('twofaces.legend_her2') }}
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true" fill="#2d1b3d"><circle cx="6" cy="7" r="1.9" /><circle cx="12.5" cy="9.5" r="1.7" /><circle cx="8" cy="13" r="1.6" /></svg>
+          {{ $t('twofaces.legend_cgsyn') }}
         </span>
       </figcaption>
     </figure>

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -8,14 +8,13 @@
       <p class="text-sm text-tinta leading-relaxed mb-6 max-w-2xl">{{ $t('twofaces.intro') }}</p>
     </template>
 
-    <!-- ESQUEMA claro (home, gente de a pie). Una célula, dos biologías que
-         conviven: lo CONOCIDO es lo pequeño (mama luminal, con sus marcadores
-         nombrados); lo que MANDA es el 80% neuroendocrino (Cg/Syn), apenas
-         conocido — solo dos certezas: RB1 perdido (dispara el 80%) y SSTR2
-         (receptores → PRRT). Bloquéalo por un lado y escapa por el otro →
-         hay que tratarlo entero. El detalle genómico riguroso vive en /ciencia. -->
+    <!-- ESQUEMA claro (home). Una célula, dos biologías que conviven. Receptores
+         FUERA (membrana): HR+ presentes (lila), HER2 ausente (fantasma), SSTR2
+         sobreexpresados (coral). ADN DENTRO: amplificaciones (FGFR1, CCND1) y
+         mutación (ESR1). El 80% que manda (Cg/Syn) es lo que falta por conocer;
+         RB1 es el freno que se está perdiendo. El detalle riguroso, en /ciencia. -->
     <figure class="tf2">
-      <svg class="tf2__svg" viewBox="0 0 480 288" role="img" :aria-label="ariaLabel">
+      <svg class="tf2__svg" viewBox="0 0 480 246" role="img" :aria-label="ariaLabel">
         <defs>
           <pattern id="tf2-grid" width="22" height="22" patternUnits="userSpaceOnUse">
             <path d="M22 0 H0 V22" fill="none" stroke="rgba(45,27,61,0.06)" stroke-width="1" />
@@ -23,8 +22,8 @@
           <clipPath id="tf2-field"><path :d="fieldPath" /></clipPath>
         </defs>
 
-        <rect x="2" y="2" width="476" height="284" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
-        <rect x="2" y="2" width="476" height="284" rx="14" fill="url(#tf2-grid)" />
+        <rect x="2" y="2" width="476" height="242" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
+        <rect x="2" y="2" width="476" height="242" rx="14" fill="url(#tf2-grid)" />
 
         <g clip-path="url(#tf2-field)">
           <rect :x="FX - RX" :y="FY - RY" :width="BX - (FX - RX)" :height="2 * RY" fill="#9d44ab" opacity="0.08" />
@@ -37,21 +36,21 @@
         <g fill="#2d1b3d" opacity="0.28">
           <circle v-for="(gr, i) in granules" :key="'gr' + i" :cx="gr.x" :cy="gr.y" :r="gr.r" />
         </g>
-        <text x="324" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
-        <text x="324" y="167" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
+        <text x="324" y="170" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
+        <text x="324" y="187" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
 
-        <!-- Receptores hormonales HR+ sobre la membrana luminal (presentes, lila,
-             igual que SSTR2 pero magenta) -->
+        <!-- Receptores hormonales HR+ (presentes, lila) en la membrana luminal -->
         <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none">
           <path v-for="(r, i) in hrReceptors" :key="'hr' + i" :d="r" />
         </g>
-        <text x="10" y="160" class="tf2__rec-lab" translate="no">HR+</text>
+        <text x="8" y="206" class="tf2__rec-lab" translate="no">HR+</text>
+        <text x="8" y="220" class="tf2__rec-note">{{ $t('twofaces.hr_note') }}</text>
         <!-- HER2 negativo = NO lo tiene: receptor ausente (fantasma punteado) -->
         <path :d="her2Ghost" fill="none" stroke="#9d44ab" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" opacity="0.45" />
-        <text x="10" y="92" class="tf2__rec-off" translate="no">HER2−</text>
+        <text x="8" y="110" class="tf2__rec-off" translate="no">HER2−</text>
 
-        <!-- Alteraciones genómicas del lado luminal (dentro): amplificación =
-             círculo doble (copias), mutación = rombo. Nombres legibles. -->
+        <!-- Alteraciones genómicas (dentro): amplificación = círculo doble (copias),
+             mutación = rombo. -->
         <g v-for="(g, i) in genes" :key="'g' + i">
           <template v-if="g.t === 'amp'">
             <circle cx="104" :cy="gy(i)" r="4.5" fill="none" stroke="#9d44ab" stroke-width="1.4" />
@@ -61,32 +60,52 @@
           <text x="116" :y="gy(i) + 4" class="tf2__genes" translate="no">{{ g.n }}</text>
         </g>
 
-        <!-- Las dos certezas neuroendocrinas -->
-        <circle cx="300" cy="96" r="4.5" fill="#ff6b47" />
-        <path :d="rb1Ring" fill="none" stroke="#ff6b47" stroke-width="1.6" />
-        <text x="320" y="92" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
-        <text x="320" y="106" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
+        <!-- RB1 = el freno que se está perdiendo (aro ROTO, no entero) -->
+        <circle cx="300" cy="116" r="4.5" fill="#ff6b47" />
+        <path :d="rb1Broken" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" />
+        <text x="320" y="112" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
+        <text x="320" y="126" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
 
-        <!-- SSTR2 = receptores sobre la membrana NE (lo característico: siempre
-             los tendrá; sobreexpresados → diana de la PRRT). Etiqueta pegada
-             al racimo de receptores. -->
+        <!-- SSTR2 = receptores sobreexpresados (coral) en la membrana NE -->
         <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
           <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
         </g>
-        <text x="470" y="196" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
-        <text x="470" y="210" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
+        <text x="472" y="214" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
+        <text x="472" y="228" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
 
-        <!-- Títulos (derecha en dos líneas → no chocan en móvil) -->
-        <text x="34" y="26" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
-        <text x="34" y="42" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
-        <text x="470" y="24" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
-        <text x="470" y="41" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
-        <text x="470" y="57" text-anchor="end" class="tf2__sub">{{ $t('twofaces.ne_sub') }}</text>
-
-        <!-- Cierre -->
-        <text x="240" y="266" text-anchor="middle" class="tf2__close tf2__close--soft">{{ $t('twofaces.close1') }}</text>
-        <text x="240" y="283" text-anchor="middle" class="tf2__close">{{ $t('twofaces.close2') }}</text>
+        <!-- Títulos (derecha en dos líneas + subtítulo, con aire) -->
+        <text x="34" y="28" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
+        <text x="34" y="44" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
+        <text x="470" y="26" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
+        <text x="470" y="43" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
+        <text x="470" y="59" text-anchor="end" class="tf2__sub">{{ $t('twofaces.ne_sub') }}</text>
       </svg>
+
+      <!-- Leyenda en lenguaje llano (ocupa el hueco del cierre): qué significa
+           cada glifo, para que la gente lo entienda. Los mini-iconos mapean al
+           dibujo. -->
+      <figcaption class="tf2-legend">
+        <span class="tf2-legend__item">
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M9 16 L9 9 M9 9 L5 4 M9 9 L13 4" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" /></svg>
+          {{ $t('twofaces.legend_rec') }}
+        </span>
+        <span class="tf2-legend__item">
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><circle cx="9" cy="9" r="5" fill="none" stroke="#9d44ab" stroke-width="1.4" /><circle cx="9" cy="9" r="2" fill="#9d44ab" /></svg>
+          {{ $t('twofaces.legend_amp') }}
+        </span>
+        <span class="tf2-legend__item">
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M9 3 l5 6 l-5 6 l-5 -6 z" fill="none" stroke="#9d44ab" stroke-width="1.4" /></svg>
+          {{ $t('twofaces.legend_mut') }}
+        </span>
+        <span class="tf2-legend__item">
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M13.5 5.2 A5 5 0 1 0 13.5 12.8" fill="none" stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" /></svg>
+          {{ $t('twofaces.legend_rb1') }}
+        </span>
+        <span class="tf2-legend__item">
+          <svg class="tf2-legend__g" viewBox="0 0 18 18" aria-hidden="true"><path d="M9 16 L9 9 M9 9 L5 4 M9 9 L13 4" fill="none" stroke="#8a857e" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" /></svg>
+          {{ $t('twofaces.legend_her2') }}
+        </span>
+      </figcaption>
     </figure>
 
     <p class="sr-only">{{ $t('twofaces.sr') }}</p>
@@ -95,22 +114,20 @@
 
 <script setup lang="ts">
 /**
- * «Un tumor con dos caras» — ESQUEMA claro para la home (gente de a pie). Una
- * célula, dos biologías que conviven: lo conocido es lo pequeño (mama luminal,
- * marcadores nombrados); lo que manda es el 80% neuroendocrino (gránulos
- * Cg/Syn), apenas conocido — solo dos certezas: RB1 perdido (su pérdida dispara
- * el 80%) y SSTR2 (receptores → PRRT). Mensaje: bloquéalo por un lado y escapa
- * por el otro → tratarlo entero. «Diferenciación neuroendocrina», nunca
- * «neuroendocrino» a secas. El detalle genómico riguroso (amplicón 11q13 con
- * ×N, mutaciones, receptores) vive en /ciencia. viewBox fijo (mobile-first),
- * texto real en sr-only, sin animación (regla de calma).
+ * «Un tumor con dos caras» — ESQUEMA claro para la home. Receptores en la
+ * membrana (HR+ presentes lila, HER2 ausente/fantasma, SSTR2 sobreexpresados
+ * coral); alteraciones genómicas dentro (FGFR1/CCND1 amplificados, ESR1 mutado).
+ * El 80% (Cg/Syn) es lo que manda y lo que falta por conocer; RB1 es el freno
+ * que se está perdiendo (aro roto). Lo conocido es pequeño; lo dominante,
+ * apenas conocido. El detalle riguroso (amplicón 11q13 con ×N, etc.) → /ciencia.
+ * viewBox fijo (mobile-first), texto real en sr-only, sin animación (calma).
  */
 defineProps<{ compact?: boolean }>()
 
 const { t } = useI18n()
 
 const FX = 250
-const FY = 128
+const FY = 148
 const RX = 192
 const RY = 82
 const BX = 178
@@ -152,17 +169,6 @@ const fieldPath = computed(() => {
 })
 const seamPath = `M${BX - 2} ${FY - RY + 14} Q${BX + 8} ${FY} ${BX - 6} ${FY + RY - 14}`
 
-function handRing(x: number, y: number, rx = 14, ry = 11) {
-  const rnd = mulberry32(Math.round(x + y))
-  const pts: { x: number; y: number }[] = []
-  for (let i = 0; i < 12; i++) {
-    const a = (i / 12) * Math.PI * 2 - 0.5
-    pts.push({ x: x + Math.cos(a) * rx + (rnd() * 2 - 1) * 1.1, y: y + Math.sin(a) * ry + (rnd() * 2 - 1) * 1.1 })
-  }
-  return smoothClosed(pts)
-}
-const rb1Ring = handRing(300, 96)
-
 // Receptor «Y» en un punto de la membrana, hacia fuera.
 function recPath(px: number, py: number, nx: number, ny: number, len = 8) {
   const bx = px - nx * 2
@@ -177,47 +183,47 @@ function recPath(px: number, py: number, nx: number, ny: number, len = 8) {
     `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx - perpx * 3.5 - nx).toFixed(1)} ${(ty - perpy * 3.5 - ny).toFixed(1)}`
   )
 }
-// SSTR2 sobreexpresados: racimo de receptores en el arco inferior-derecho (NE),
-// junto a su etiqueta (para que se lean cerca).
-const receptors = computed(() => {
-  const out: string[] = []
-  for (let i = 0; i < 5; i++) {
-    const a = ((8 + i * 12) * Math.PI) / 180
-    out.push(recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a)))
-  }
-  return out
-})
+function arcRec(deg: number) {
+  const a = (deg * Math.PI) / 180
+  return recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a))
+}
+const hrReceptors = computed(() => [156, 174, 192].map(arcRec))
+const her2Ghost = arcRec(208)
+const receptors = computed(() => [8, 20, 32, 44, 56].map(arcRec))
 
-// Marcadores conocidos del lado luminal, un glifo por tipo de hallazgo:
-//  amp = amplificación (círculo doble = copias) · mut = mutación (rombo) ·
-//  rec = receptor presente («Y») · recneg = receptor negativo («Y» tachado).
+// RB1 = el freno: aro ROTO (abierto, con un hueco) = se está perdiendo.
+const rb1Broken = (() => {
+  const x = 300
+  const y = 116
+  const rx = 14
+  const ry = 11
+  const rnd = mulberry32(417)
+  const pts: string[] = []
+  const N = 12
+  const shown = 9 // deja un hueco: el aro no cierra (freno partido)
+  for (let i = 0; i <= shown; i++) {
+    const a = (i / N) * Math.PI * 2 - 0.4
+    pts.push(
+      `${(x + Math.cos(a) * rx + (rnd() * 2 - 1) * 1.1).toFixed(1)} ${(y + Math.sin(a) * ry + (rnd() * 2 - 1) * 1.1).toFixed(1)}`
+    )
+  }
+  return 'M' + pts.join(' L')
+})()
+
 const genes = [
   { n: 'FGFR1', t: 'amp' },
   { n: 'CCND1', t: 'amp' },
   { n: 'ESR1', t: 'mut' },
 ]
 function gy(i: number) {
-  return 100 + i * 22
+  return 120 + i * 22
 }
 function diamond(x: number, y: number) {
   return `M${x} ${y - 4} l4 4 l-4 4 l-4 -4 z`
 }
 
-// Receptores hormonales HR+ sobre la membrana luminal (presentes, arco izq.).
-const hrReceptors = computed(() => {
-  const out: string[] = []
-  for (const deg of [156, 174, 192]) {
-    const a = (deg * Math.PI) / 180
-    out.push(recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a)))
-  }
-  return out
-})
-// HER2 negativo: receptor ausente (un solo «fantasma» en el arco superior izq.).
-const her2Ghost = (() => {
-  const a = (208 * Math.PI) / 180
-  return recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a))
-})()
-// Gránulos Cg/Syn (el 80%), esquivando RB1, SSTR2, el rótulo central y el borde.
+// Gránulos Cg/Syn (el 80%), esquivando RB1, el rótulo central, el borde y la
+// etiqueta de SSTR2.
 const granules = computed(() => {
   const rnd = mulberry32(424242)
   const out: { x: number; y: number; r: number }[] = []
@@ -227,9 +233,9 @@ const granules = computed(() => {
     const x = BX + 18 + rnd() * (FX + RX - (BX + 38))
     const y = FY - RY + rnd() * (2 * RY)
     const inF = ((x - FX) / (RX - 16)) ** 2 + ((y - FY) / (RY - 14)) ** 2 <= 1
-    const farRB1 = (x - 300) ** 2 + (y - 96) ** 2 > 26 * 26
-    const farCenter = Math.abs(x - 324) > 50 || y < 132 || y > 176
-    const farLabel = !(x > 352 && y > 180 && y < 214)
+    const farRB1 = (x - 300) ** 2 + (y - 116) ** 2 > 26 * 26
+    const farCenter = Math.abs(x - 324) > 50 || y < 152 || y > 196
+    const farLabel = !(x > 352 && y > 198 && y < 232)
     if (inF && farRB1 && farCenter && farLabel) {
       out.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.5 + rnd() * 1).toFixed(1) })
     }
@@ -278,6 +284,11 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   font-weight: 700;
   fill: #6a2475;
 }
+.tf2__rec-note {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 11px;
+  fill: #8a857e;
+}
 .tf2__rec-off {
   font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 14px;
@@ -309,14 +320,31 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   fill: #2d1b3d;
   opacity: 0.4;
 }
-.tf2__close {
-  font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 17px;
-  font-weight: 700;
-  fill: #2d1b3d;
+/* Leyenda en lenguaje llano bajo el esquema (sustituye al cierre). */
+.tf2-legend {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px 18px;
+  max-width: 540px;
+  margin: 0.6rem auto 0;
+  padding: 0 4px;
 }
-.tf2__close--soft {
-  font-weight: 400;
-  fill: #3a3340;
+@media (min-width: 560px) {
+  .tf2-legend {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+.tf2-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  line-height: 1.35;
+  color: #3a3340;
+}
+.tf2-legend__g {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
 }
 </style>

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -54,10 +54,13 @@
         <text x="320" y="92" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
         <text x="320" y="106" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
 
-        <circle cx="320" cy="182" r="4.5" fill="#ff6b47" />
-        <path :d="sstr2Ring" fill="none" stroke="#ff6b47" stroke-width="1.6" />
-        <text x="340" y="179" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
-        <text x="340" y="193" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
+        <!-- SSTR2 = receptores sobre la membrana NE (lo característico: siempre
+             los tendrá; sobreexpresados → diana de la PRRT) -->
+        <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
+          <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
+        </g>
+        <text x="470" y="236" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
+        <text x="470" y="250" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
 
         <!-- Títulos (derecha en dos líneas → no chocan en móvil) -->
         <text x="34" y="26" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
@@ -144,7 +147,30 @@ function handRing(x: number, y: number, rx = 14, ry = 11) {
   return smoothClosed(pts)
 }
 const rb1Ring = handRing(300, 96)
-const sstr2Ring = handRing(320, 182)
+
+// Receptor «Y» en un punto de la membrana, hacia fuera.
+function recPath(px: number, py: number, nx: number, ny: number, len = 8) {
+  const bx = px - nx * 2
+  const by = py - ny * 2
+  const tx = px + nx * len
+  const ty = py + ny * len
+  const perpx = -ny
+  const perpy = nx
+  return (
+    `M${bx.toFixed(1)} ${by.toFixed(1)} L${tx.toFixed(1)} ${ty.toFixed(1)} ` +
+    `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx + perpx * 3.5 - nx).toFixed(1)} ${(ty + perpy * 3.5 - ny).toFixed(1)} ` +
+    `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx - perpx * 3.5 - nx).toFixed(1)} ${(ty - perpy * 3.5 - ny).toFixed(1)}`
+  )
+}
+// SSTR2 sobreexpresados: varios receptores sobre el arco derecho (NE).
+const receptors = computed(() => {
+  const out: string[] = []
+  for (let i = 0; i < 6; i++) {
+    const a = ((-46 + i * 18) * Math.PI) / 180
+    out.push(recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a)))
+  }
+  return out
+})
 
 // Textura tenue del lado conocido (sin etiqueta: solo densidad).
 const dots = computed(() => {

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -1,10 +1,14 @@
 <template>
   <section :aria-label="$t('twofaces.title')">
-    <p class="eyebrow mb-2 block">{{ $t('twofaces.eyebrow') }}</p>
-    <h2 class="heading-display text-2xl text-berenjena mb-2" style="letter-spacing: -0.02em">
-      {{ $t('twofaces.title') }}
-    </h2>
-    <p class="text-sm text-tinta leading-relaxed mb-6 max-w-2xl">{{ $t('twofaces.intro') }}</p>
+    <!-- En modo compacto (home) el texto de la sección anfitriona ya hace de
+         intro: solo se pinta la página del cuaderno. -->
+    <template v-if="!compact">
+      <p class="eyebrow mb-2 block">{{ $t('twofaces.eyebrow') }}</p>
+      <h2 class="heading-display text-2xl text-berenjena mb-2" style="letter-spacing: -0.02em">
+        {{ $t('twofaces.title') }}
+      </h2>
+      <p class="text-sm text-tinta leading-relaxed mb-6 max-w-2xl">{{ $t('twofaces.intro') }}</p>
+    </template>
 
     <!-- Página de cuaderno de laboratorio (ADN gráfico del design system):
          tinta berenjena, trazo a pluma imperfecto, UN solo acento (coral) sobre
@@ -146,6 +150,8 @@
  * un bloque sr-only (a11y/SEO). Posiciones deterministas (PRNG), mobile-first
  * (viewBox), animaciones con prefers-reduced-motion.
  */
+defineProps<{ compact?: boolean }>()
+
 const { t, tm, rt } = useI18n()
 
 const R = 132

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -8,16 +8,14 @@
       <p class="text-sm text-tinta leading-relaxed mb-6 max-w-2xl">{{ $t('twofaces.intro') }}</p>
     </template>
 
-    <!-- ESQUEMA (no retrato). Gramática rigurosa de alteraciones:
-         · receptores en la membrana (HR+, HER2 tachado = negativo, SSTR2)
-         · amplificación = copias apiladas + ×N, agrupadas en el clúster 11q13
-         · mutación = rombo (ESR1, en ctDNA)
-         · pérdida = gen roto y tachado (RB1)
-         · gránulos Cg/Syn = lo que define el 80% neuroendocrino.
-         Lo conocido es lo pequeño (mama luminal); lo que manda (80%) apenas se
-         conoce. Bloquéalo por un lado y escapa por el otro → tratarlo entero. -->
+    <!-- ESQUEMA claro (home, gente de a pie). Una célula, dos biologías que
+         conviven: lo CONOCIDO es lo pequeño (mama luminal, con sus marcadores
+         nombrados); lo que MANDA es el 80% neuroendocrino (Cg/Syn), apenas
+         conocido — solo dos certezas: RB1 perdido (dispara el 80%) y SSTR2
+         (receptores → PRRT). Bloquéalo por un lado y escapa por el otro →
+         hay que tratarlo entero. El detalle genómico riguroso vive en /ciencia. -->
     <figure class="tf2">
-      <svg class="tf2__svg" viewBox="0 0 480 300" role="img" :aria-label="ariaLabel">
+      <svg class="tf2__svg" viewBox="0 0 480 288" role="img" :aria-label="ariaLabel">
         <defs>
           <pattern id="tf2-grid" width="22" height="22" patternUnits="userSpaceOnUse">
             <path d="M22 0 H0 V22" fill="none" stroke="rgba(45,27,61,0.06)" stroke-width="1" />
@@ -25,8 +23,8 @@
           <clipPath id="tf2-field"><path :d="fieldPath" /></clipPath>
         </defs>
 
-        <rect x="2" y="2" width="476" height="296" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
-        <rect x="2" y="2" width="476" height="296" rx="14" fill="url(#tf2-grid)" />
+        <rect x="2" y="2" width="476" height="284" rx="14" fill="#faf6f0" stroke="rgba(45,27,61,0.16)" />
+        <rect x="2" y="2" width="476" height="284" rx="14" fill="url(#tf2-grid)" />
 
         <g clip-path="url(#tf2-field)">
           <rect :x="FX - RX" :y="FY - RY" :width="BX - (FX - RX)" :height="2 * RY" fill="#9d44ab" opacity="0.08" />
@@ -35,58 +33,41 @@
         <path :d="fieldPath" fill="none" stroke="rgba(45,27,61,0.45)" stroke-width="2" stroke-linecap="round" />
         <path :d="seamPath" fill="none" stroke="rgba(45,27,61,0.3)" stroke-width="1.3" stroke-dasharray="2 5" />
 
-        <!-- Gránulos Cg/Syn: definen el 80% NE -->
-        <g fill="#2d1b3d" opacity="0.3">
+        <!-- Textura tenue del lado conocido (luminal) -->
+        <g fill="#9d44ab" opacity="0.5">
+          <circle v-for="(d, i) in dots" :key="'d' + i" :cx="d.x" :cy="d.y" :r="d.r" />
+        </g>
+        <!-- Gránulos Cg/Syn = el 80% neuroendocrino -->
+        <g fill="#2d1b3d" opacity="0.28">
           <circle v-for="(gr, i) in granules" :key="'gr' + i" :cx="gr.x" :cy="gr.y" :r="gr.r" />
         </g>
-        <text x="312" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
-        <text x="312" y="168" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
+        <text x="322" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
+        <text x="322" y="167" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
 
-        <!-- LUMINAL · amplicón 11q13 (amplificación = copias apiladas) -->
-        <g>
-          <rect v-for="c in 4" :key="'c' + c" :x="48 + (c - 1) * 3" y="84" width="2" height="9" rx="1" fill="#9d44ab" />
-        </g>
-        <text x="66" y="92" class="tf2__amp-head" translate="no">{{ $t('twofaces.amplicon') }}</text>
-        <text x="48" y="110" class="tf2__amp-g" translate="no">{{ $t('twofaces.amplicon_g1') }}</text>
-        <text x="48" y="126" class="tf2__amp-g" translate="no">{{ $t('twofaces.amplicon_g2') }}</text>
+        <!-- Lo conocido (luminal): marcadores nombrados, en claro -->
+        <text x="50" y="112" class="tf2__genes" translate="no">{{ $t('twofaces.lum_g1') }}</text>
+        <text x="50" y="132" class="tf2__genes" translate="no">{{ $t('twofaces.lum_g2') }}</text>
 
-        <!-- LUMINAL · ESR1 (mutación = rombo) -->
-        <path d="M52 146 l5 5 l-5 5 l-5 -5 z" fill="none" stroke="#9d44ab" stroke-width="1.6" />
-        <text x="62" y="155" class="tf2__amp-g" translate="no">{{ $t('twofaces.esr1') }}</text>
+        <!-- Las dos certezas neuroendocrinas -->
+        <circle cx="300" cy="96" r="4.5" fill="#ff6b47" />
+        <path :d="rb1Ring" fill="none" stroke="#ff6b47" stroke-width="1.6" />
+        <text x="320" y="92" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
+        <text x="320" y="106" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
 
-        <!-- LUMINAL · receptores HR+ (presente) y HER2 (tachado = negativo) -->
-        <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none">
-          <path :d="hrRec" />
-        </g>
-        <text :x="hr.x - 30" :y="hr.y - 6" class="tf2__rec-lab" translate="no">{{ $t('twofaces.hr') }}</text>
-        <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none" opacity="0.55">
-          <path :d="her2Rec" />
-        </g>
-        <path :d="her2Slash" stroke="#bb4128" stroke-width="1.6" stroke-linecap="round" fill="none" />
-        <text :x="her2.x - 44" :y="her2.y + 14" class="tf2__rec-lab tf2__rec-lab--off" translate="no">{{ $t('twofaces.her2') }}</text>
-
-        <!-- NE · RB1 perdido (pérdida = gen roto + tachado) -->
-        <path d="M294 98 h5 M303 98 h5" stroke="#bb4128" stroke-width="2" stroke-linecap="round" />
-        <path d="M292 92 l16 12" stroke="#bb4128" stroke-width="1.6" stroke-linecap="round" />
-        <text x="316" y="95" class="tf2__known-m" translate="no">{{ $t('twofaces.rb1') }}</text>
-        <text x="316" y="109" class="tf2__known-n">{{ $t('twofaces.rb1_note') }}</text>
-
-        <!-- NE · SSTR2 receptores (sobreexpresados → PRRT) -->
-        <g stroke="#ff6b47" stroke-width="1.6" stroke-linecap="round" fill="none">
-          <path v-for="(r, i) in receptors" :key="'r' + i" :d="r" />
-        </g>
-        <text x="470" y="236" text-anchor="end" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
-        <text x="470" y="250" text-anchor="end" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
+        <circle cx="320" cy="182" r="4.5" fill="#ff6b47" />
+        <path :d="sstr2Ring" fill="none" stroke="#ff6b47" stroke-width="1.6" />
+        <text x="340" y="179" class="tf2__known-m" translate="no">{{ $t('twofaces.sstr2') }}</text>
+        <text x="340" y="193" class="tf2__known-n">{{ $t('twofaces.sstr2_note') }}</text>
 
         <!-- Títulos (derecha en dos líneas → no chocan en móvil) -->
         <text x="34" y="26" class="tf2__head">{{ $t('twofaces.lum_head') }}</text>
         <text x="34" y="42" class="tf2__sub">{{ $t('twofaces.lum_sub') }}</text>
         <text x="470" y="24" text-anchor="end" class="tf2__head">{{ neHead[0] }}</text>
-        <text x="470" y="40" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
+        <text x="470" y="41" text-anchor="end" class="tf2__head">{{ neHead[1] }}</text>
 
         <!-- Cierre -->
-        <text x="240" y="278" text-anchor="middle" class="tf2__close">{{ $t('twofaces.close1') }}</text>
-        <text x="240" y="295" text-anchor="middle" class="tf2__close tf2__close--coral">{{ $t('twofaces.close2') }}</text>
+        <text x="240" y="266" text-anchor="middle" class="tf2__close">{{ $t('twofaces.close1') }}</text>
+        <text x="240" y="283" text-anchor="middle" class="tf2__close tf2__close--coral">{{ $t('twofaces.close2') }}</text>
       </svg>
     </figure>
 
@@ -96,24 +77,25 @@
 
 <script setup lang="ts">
 /**
- * «Un tumor con dos caras» — ESQUEMA de cuaderno (no un retrato de la célula),
- * riguroso pero aligerado. Gramática de alteraciones: receptores en la
- * membrana (HR+, HER2 tachado, SSTR2), amplificación = copias apiladas + ×N
- * agrupadas en el clúster 11q13, mutación = rombo (ESR1, ctDNA), pérdida = gen
- * roto (RB1), gránulos Cg/Syn = el 80% neuroendocrino. Lo conocido es pequeño;
- * lo que manda (80%) apenas se conoce → bloquéalo por un lado y escapa por el
- * otro, hay que tratarlo entero. «Diferenciación neuroendocrina», nunca
- * «neuroendocrino» a secas. viewBox fijo (mobile-first), texto real en sr-only.
+ * «Un tumor con dos caras» — ESQUEMA claro para la home (gente de a pie). Una
+ * célula, dos biologías que conviven: lo conocido es lo pequeño (mama luminal,
+ * marcadores nombrados); lo que manda es el 80% neuroendocrino (gránulos
+ * Cg/Syn), apenas conocido — solo dos certezas: RB1 perdido (su pérdida dispara
+ * el 80%) y SSTR2 (receptores → PRRT). Mensaje: bloquéalo por un lado y escapa
+ * por el otro → tratarlo entero. «Diferenciación neuroendocrina», nunca
+ * «neuroendocrino» a secas. El detalle genómico riguroso (amplicón 11q13 con
+ * ×N, mutaciones, receptores) vive en /ciencia. viewBox fijo (mobile-first),
+ * texto real en sr-only, sin animación (regla de calma).
  */
 defineProps<{ compact?: boolean }>()
 
-const { t, tm, rt } = useI18n()
+const { t } = useI18n()
 
 const FX = 250
-const FY = 130
-const RX = 190
-const RY = 80
-const BX = 182 // frontera: luminal pequeño, pero con sitio para su genómica
+const FY = 128
+const RX = 192
+const RY = 82
+const BX = 178
 
 function mulberry32(seed: number) {
   let a = seed
@@ -152,54 +134,47 @@ const fieldPath = computed(() => {
 })
 const seamPath = `M${BX - 2} ${FY - RY + 14} Q${BX + 8} ${FY} ${BX - 6} ${FY + RY - 14}`
 
-// Receptor «Y» en un punto de la membrana, hacia fuera.
-function recPath(px: number, py: number, nx: number, ny: number, len = 8) {
-  const bx = px - nx * 2
-  const by = py - ny * 2
-  const tx = px + nx * len
-  const ty = py + ny * len
-  const perpx = -ny
-  const perpy = nx
-  return (
-    `M${bx.toFixed(1)} ${by.toFixed(1)} L${tx.toFixed(1)} ${ty.toFixed(1)} ` +
-    `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx + perpx * 3.5 - nx).toFixed(1)} ${(ty + perpy * 3.5 - ny).toFixed(1)} ` +
-    `M${tx.toFixed(1)} ${ty.toFixed(1)} L${(tx - perpx * 3.5 - nx).toFixed(1)} ${(ty - perpy * 3.5 - ny).toFixed(1)}`
-  )
+function handRing(x: number, y: number, rx = 14, ry = 11) {
+  const rnd = mulberry32(Math.round(x + y))
+  const pts: { x: number; y: number }[] = []
+  for (let i = 0; i < 12; i++) {
+    const a = (i / 12) * Math.PI * 2 - 0.5
+    pts.push({ x: x + Math.cos(a) * rx + (rnd() * 2 - 1) * 1.1, y: y + Math.sin(a) * ry + (rnd() * 2 - 1) * 1.1 })
+  }
+  return smoothClosed(pts)
 }
-function onArc(deg: number) {
-  const a = (deg * Math.PI) / 180
-  return { x: FX + Math.cos(a) * RX, y: FY + Math.sin(a) * RY, nx: Math.cos(a), ny: Math.sin(a) }
-}
-// HR+ (presente) y HER2 (tachado) sobre la membrana luminal (arco izquierdo)
-const hr = onArc(206)
-const hrRec = recPath(hr.x, hr.y, hr.nx, hr.ny)
-const her2 = onArc(150)
-const her2Rec = recPath(her2.x, her2.y, her2.nx, her2.ny)
-const her2Slash = `M${(her2.x - 6).toFixed(1)} ${(her2.y - 12).toFixed(1)} l12 12`
+const rb1Ring = handRing(300, 96)
+const sstr2Ring = handRing(320, 182)
 
-// SSTR2 receptores sobreexpresados (arco derecho, NE)
-const receptors = computed(() => {
-  const out: string[] = []
-  for (let i = 0; i < 6; i++) {
-    const p = onArc(-46 + i * 18)
-    out.push(recPath(p.x, p.y, p.nx, p.ny))
+// Textura tenue del lado conocido (sin etiqueta: solo densidad).
+const dots = computed(() => {
+  const rnd = mulberry32(5)
+  const out: { x: number; y: number; r: number }[] = []
+  let guard = 0
+  while (out.length < 6 && guard < 4000) {
+    guard++
+    const x = FX - RX + 10 + rnd() * (BX - (FX - RX) - 20)
+    const y = FY - RY + rnd() * (2 * RY)
+    if (((x - FX) / (RX - 14)) ** 2 + ((y - FY) / (RY - 12)) ** 2 <= 1 && x < BX - 10) {
+      out.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.4 + rnd() * 1).toFixed(1) })
+    }
   }
   return out
 })
-
-// Gránulos Cg/Syn (textura del 80% NE), esquivando RB1, el rótulo y el borde.
+// Gránulos Cg/Syn (el 80%), esquivando RB1, SSTR2, el rótulo central y el borde.
 const granules = computed(() => {
   const rnd = mulberry32(424242)
   const out: { x: number; y: number; r: number }[] = []
   let guard = 0
-  while (out.length < 11 && guard < 6000) {
+  while (out.length < 9 && guard < 6000) {
     guard++
-    const x = BX + 16 + rnd() * (FX + RX - (BX + 34))
+    const x = BX + 18 + rnd() * (FX + RX - (BX + 38))
     const y = FY - RY + rnd() * (2 * RY)
     const inF = ((x - FX) / (RX - 16)) ** 2 + ((y - FY) / (RY - 14)) ** 2 <= 1
-    const farRB1 = (x - 300) ** 2 + (y - 100) ** 2 > 28 * 28
-    const farCenter = Math.abs(x - 312) > 48 || y < 130 || y > 178
-    if (inF && farRB1 && farCenter) {
+    const farRB1 = (x - 300) ** 2 + (y - 96) ** 2 > 26 * 26
+    const farSSTR = (x - 320) ** 2 + (y - 182) ** 2 > 24 * 24
+    const farCenter = Math.abs(x - 322) > 50 || y < 132 || y > 176
+    if (inF && farRB1 && farSSTR && farCenter) {
       out.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.5 + rnd() * 1).toFixed(1) })
     }
   }
@@ -208,10 +183,8 @@ const granules = computed(() => {
 
 const neHead = computed(() => {
   const h = t('twofaces.ne_head')
-  // dos líneas para no chocar con el título izquierdo en móvil
   return h.includes(' ') ? [h.split(' ')[0]!, h.split(' ').slice(1).join(' ')] : [h, '']
 })
-
 const ariaLabel = computed(() => t('twofaces.sr'))
 </script>
 
@@ -228,7 +201,7 @@ const ariaLabel = computed(() => t('twofaces.sr'))
 }
 .tf2__head {
   font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 17px;
+  font-size: 18px;
   font-weight: 700;
   fill: #2d1b3d;
 }
@@ -237,30 +210,15 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   font-size: 13px;
   fill: #3a3340;
 }
-.tf2__amp-head {
+.tf2__genes {
   font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 13px;
+  font-size: 15px;
   font-weight: 700;
   fill: #6a2475;
-}
-.tf2__amp-g {
-  font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 13px;
-  font-weight: 700;
-  fill: #6a2475;
-}
-.tf2__rec-lab {
-  font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 13px;
-  font-weight: 700;
-  fill: #6a2475;
-}
-.tf2__rec-lab--off {
-  fill: #3a3340;
 }
 .tf2__known-m {
   font-family: 'Caveat', 'Bradley Hand', cursive;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 700;
   fill: #bb4128;
 }

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -40,20 +40,25 @@
         <text x="324" y="150" text-anchor="middle" class="tf2__pct">{{ $t('twofaces.pct') }}</text>
         <text x="324" y="167" text-anchor="middle" class="tf2__cgsyn" translate="no">{{ $t('twofaces.cgsyn') }}</text>
 
-        <!-- Lo conocido (luminal): un glifo por tipo de hallazgo —
-             amplificación = círculo doble (copias), mutación = rombo,
-             receptor = «Y» (HER2 tachado por negativo). Nombres legibles. -->
+        <!-- Receptores hormonales HR+ sobre la membrana luminal (presentes, lila,
+             igual que SSTR2 pero magenta) -->
+        <g stroke="#9d44ab" stroke-width="1.6" stroke-linecap="round" fill="none">
+          <path v-for="(r, i) in hrReceptors" :key="'hr' + i" :d="r" />
+        </g>
+        <text x="10" y="160" class="tf2__rec-lab" translate="no">HR+</text>
+        <!-- HER2 negativo = NO lo tiene: receptor ausente (fantasma punteado) -->
+        <path :d="her2Ghost" fill="none" stroke="#9d44ab" stroke-width="1.4" stroke-linecap="round" stroke-dasharray="2 2" opacity="0.45" />
+        <text x="10" y="92" class="tf2__rec-off" translate="no">HER2−</text>
+
+        <!-- Alteraciones genómicas del lado luminal (dentro): amplificación =
+             círculo doble (copias), mutación = rombo. Nombres legibles. -->
         <g v-for="(g, i) in genes" :key="'g' + i">
           <template v-if="g.t === 'amp'">
-            <circle cx="58" :cy="gy(i)" r="4.5" fill="none" stroke="#9d44ab" stroke-width="1.4" />
-            <circle cx="58" :cy="gy(i)" r="1.7" fill="#9d44ab" />
+            <circle cx="104" :cy="gy(i)" r="4.5" fill="none" stroke="#9d44ab" stroke-width="1.4" />
+            <circle cx="104" :cy="gy(i)" r="1.7" fill="#9d44ab" />
           </template>
-          <path v-else-if="g.t === 'mut'" :d="diamond(58, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.4" />
-          <template v-else>
-            <path :d="recGlyph(58, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.5" stroke-linecap="round" />
-            <path v-if="g.t === 'recneg'" :d="slash(58, gy(i))" stroke="#bb4128" stroke-width="1.5" stroke-linecap="round" />
-          </template>
-          <text x="72" :y="gy(i) + 4" class="tf2__genes" translate="no">{{ g.n }}</text>
+          <path v-else :d="diamond(104, gy(i))" fill="none" stroke="#9d44ab" stroke-width="1.4" />
+          <text x="116" :y="gy(i) + 4" class="tf2__genes" translate="no">{{ g.n }}</text>
         </g>
 
         <!-- Las dos certezas neuroendocrinas -->
@@ -190,21 +195,28 @@ const genes = [
   { n: 'FGFR1', t: 'amp' },
   { n: 'CCND1', t: 'amp' },
   { n: 'ESR1', t: 'mut' },
-  { n: 'HR+', t: 'rec' },
-  { n: 'HER2−', t: 'recneg' },
 ]
 function gy(i: number) {
-  return 98 + i * 19
+  return 100 + i * 22
 }
 function diamond(x: number, y: number) {
   return `M${x} ${y - 4} l4 4 l-4 4 l-4 -4 z`
 }
-function recGlyph(x: number, y: number) {
-  return `M${x} ${y + 5} L${x} ${y - 1} M${x} ${y - 1} L${x - 3.5} ${y - 5} M${x} ${y - 1} L${x + 3.5} ${y - 5}`
-}
-function slash(x: number, y: number) {
-  return `M${x - 4} ${y + 3} L${x + 4} ${y - 5}`
-}
+
+// Receptores hormonales HR+ sobre la membrana luminal (presentes, arco izq.).
+const hrReceptors = computed(() => {
+  const out: string[] = []
+  for (const deg of [156, 174, 192]) {
+    const a = (deg * Math.PI) / 180
+    out.push(recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a)))
+  }
+  return out
+})
+// HER2 negativo: receptor ausente (un solo «fantasma» en el arco superior izq.).
+const her2Ghost = (() => {
+  const a = (208 * Math.PI) / 180
+  return recPath(FX + Math.cos(a) * RX, FY + Math.sin(a) * RY, Math.cos(a), Math.sin(a))
+})()
 // Gránulos Cg/Syn (el 80%), esquivando RB1, SSTR2, el rótulo central y el borde.
 const granules = computed(() => {
   const rnd = mulberry32(424242)
@@ -259,6 +271,18 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   font-size: 15px;
   font-weight: 700;
   fill: #6a2475;
+}
+.tf2__rec-lab {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 14px;
+  font-weight: 700;
+  fill: #6a2475;
+}
+.tf2__rec-off {
+  font-family: 'Caveat', 'Bradley Hand', cursive;
+  font-size: 14px;
+  font-weight: 700;
+  fill: #8a857e;
 }
 .tf2__known-m {
   font-family: 'Caveat', 'Bradley Hand', cursive;

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -70,7 +70,7 @@
           </g>
 
           <!-- Lado NEUROENDOCRINO: penumbra de puntitos (stippling = lo desconocido) -->
-          <g fill="#2d1b3d" stroke="none" opacity="0.32">
+          <g fill="#2d1b3d" stroke="none" opacity="0.38">
             <circle v-for="(u, i) in unknownNodes" :key="'u' + i" :cx="u.x" :cy="u.y" :r="u.r" />
           </g>
 
@@ -104,7 +104,7 @@
         <!-- Etiquetas -->
         <g class="tf2__hand" fill="#2d1b3d">
           <text :x="ann.mama.x" :y="ann.mama.y" :transform="`rotate(-7 ${ann.mama.x} ${ann.mama.y})`" class="tf2__label tf2__up">{{ $t('twofaces.lum_word') }}</text>
-          <text :x="ann.ne.x" :y="ann.ne.y" :transform="`rotate(5 ${ann.ne.x} ${ann.ne.y})`" class="tf2__label tf2__up">{{ $t('twofaces.ne_word') }}</text>
+          <text :x="ann.ne.x" :y="ann.ne.y" :transform="`rotate(5 ${ann.ne.x} ${ann.ne.y})`" class="tf2__label tf2__label--sm tf2__up">{{ $t('twofaces.ne_word') }}</text>
           <text :x="ann.mapped.x" :y="ann.mapped.y" :transform="`rotate(-4 ${ann.mapped.x} ${ann.mapped.y})`" class="tf2__note tf2__up" opacity="0.75">{{ $t('twofaces.note_mapped') }}</text>
           <text :x="ann.dark.x" :y="ann.dark.y" :transform="`rotate(4 ${ann.dark.x} ${ann.dark.y})`" class="tf2__note tf2__up" opacity="0.6">{{ $t('twofaces.note_dark') }}</text>
           <!-- ? sobre la penumbra -->
@@ -119,8 +119,8 @@
         </g>
         <!-- Cierre: un mismo tumor, se tratan juntas (subrayado coral a mano) -->
         <g class="tf2__hand">
-          <text x="220" y="366" text-anchor="middle" class="tf2__together-txt" fill="#2d1b3d">{{ $t('twofaces.together') }}</text>
-          <path d="M96 373 Q220 379 344 372" fill="none" stroke="#ff6b47" stroke-width="2" stroke-linecap="round" />
+          <text x="220" y="366" text-anchor="middle" class="tf2__together-txt" fill="#2d1b3d">{{ $t('twofaces.together_short') }}</text>
+          <path d="M118 372 Q220 377 322 371" fill="none" stroke="#ff6b47" stroke-width="2" stroke-linecap="round" />
         </g>
       </svg>
     </figure>
@@ -181,19 +181,37 @@ function penLine(x1: number, y1: number, x2: number, y2: number, rnd: () => numb
   return `M${x1} ${y1} Q${(mx + (-dy / len) * off).toFixed(1)} ${(my + (dx / len) * off).toFixed(1)} ${x2} ${y2}`
 }
 
-// Célula dibujada a mano: círculo "imperfecto" con radios ligeramente variables.
+// Cierra una nube de puntos con curvas suaves (Catmull-Rom → Bézier):
+// el wobble queda orgánico, como trazo de boli, no facetado.
+function smoothClosed(pts: { x: number; y: number }[]) {
+  const n = pts.length
+  const P = (i: number) => pts[((i % n) + n) % n]!
+  let d = `M${P(0).x.toFixed(1)} ${P(0).y.toFixed(1)}`
+  for (let i = 0; i < n; i++) {
+    const p0 = P(i - 1)
+    const p1 = P(i)
+    const p2 = P(i + 1)
+    const p3 = P(i + 2)
+    const c1x = p1.x + (p2.x - p0.x) / 6
+    const c1y = p1.y + (p2.y - p0.y) / 6
+    const c2x = p2.x - (p3.x - p1.x) / 6
+    const c2y = p2.y - (p3.y - p1.y) / 6
+    d += ` C${c1x.toFixed(1)} ${c1y.toFixed(1)}, ${c2x.toFixed(1)} ${c2y.toFixed(1)}, ${p2.x.toFixed(1)} ${p2.y.toFixed(1)}`
+  }
+  return d + ' Z'
+}
+
+// Célula dibujada a mano: blob suave con radios ligeramente variables.
 const cellPath = computed(() => {
   const rnd = mulberry32(99)
-  const pts: string[] = []
+  const pts: { x: number; y: number }[] = []
   const N = 16
-  for (let i = 0; i <= N; i++) {
+  for (let i = 0; i < N; i++) {
     const ang = (i / N) * Math.PI * 2
     const rr = R + (rnd() * 2 - 1) * 5
-    const x = (cx + Math.cos(ang) * rr).toFixed(1)
-    const y = (cy + Math.sin(ang) * rr * 0.98).toFixed(1)
-    pts.push((i === 0 ? 'M' : 'L') + x + ' ' + y)
+    pts.push({ x: cx + Math.cos(ang) * rr, y: cy + Math.sin(ang) * rr * 0.98 })
   }
-  return pts.join(' ') + ' Z'
+  return smoothClosed(pts)
 })
 const seamPath = `M${cx} ${cy - R + 10} Q${cx + 6} ${cy} ${cx - 4} ${cy + R - 10}`
 
@@ -207,22 +225,20 @@ const knownNodes = computed(() => {
     arrow: penLine(ax, ay, x + 13, y - 6, mulberry32(Math.round(x * y))),
   })
   return [
-    mk(300, 116, 'RB1', t('twofaces.rb1_note'), 352, 104, 350, 100),
+    mk(294, 122, 'RB1', t('twofaces.rb1_note'), 348, 108, 346, 104),
     mk(286, 244, 'SSTR2', t('twofaces.sstr2_note'), 338, 250, 336, 246),
   ]
 })
 function handRing(x: number, y: number, rx: number, ry: number) {
-  // Elipse abierta dibujada a mano (empieza y acaba con un pequeño solape).
-  const p: string[] = []
-  const N = 14
+  // Aro rodeado a boli: elipse suave con leve temblor (curvas, no facetas).
+  const pts: { x: number; y: number }[] = []
+  const N = 12
   const rnd = mulberry32(Math.round(x + y))
-  for (let i = 0; i <= N + 2; i++) {
+  for (let i = 0; i < N; i++) {
     const ang = (i / N) * Math.PI * 2 - 0.5
-    const jx = (rnd() * 2 - 1) * 1.4
-    const jy = (rnd() * 2 - 1) * 1.4
-    p.push((i === 0 ? 'M' : 'L') + (x + Math.cos(ang) * rx + jx).toFixed(1) + ' ' + (y + Math.sin(ang) * ry + jy).toFixed(1))
+    pts.push({ x: x + Math.cos(ang) * rx + (rnd() * 2 - 1) * 1.2, y: y + Math.sin(ang) * ry + (rnd() * 2 - 1) * 1.2 })
   }
-  return p.join(' ')
+  return smoothClosed(pts)
 }
 
 const geometry = computed(() => {
@@ -260,7 +276,7 @@ const geometry = computed(() => {
     const y = cy - R + rnd() * (2 * R)
     const farFromKnown = kn.every((k) => (k.x - x) ** 2 + (k.y - y) ** 2 > 30 * 30)
     if (x > cx + 10 && inCell(x, y, 14) && farFromKnown) {
-      unknownNodes.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.2 + rnd() * 1.4).toFixed(1) })
+      unknownNodes.push({ x: +x.toFixed(1), y: +y.toFixed(1), r: +(1.6 + rnd() * 1.6).toFixed(1) })
     }
   }
   const bridges = kn.map((k) => {
@@ -289,8 +305,8 @@ const qmarks = [
 // Anotaciones manuscritas con flecha (posiciones fijas).
 const ann = computed(() => ({
   mama: { x: 44, y: 60, arrow: 'M70 66 Q92 78 110 104' },
-  ne: { x: 250, y: 44, arrow: 'M300 52 Q318 66 318 92' },
-  mapped: { x: 34, y: 300, arrow: 'M96 296 Q120 280 138 250' },
+  ne: { x: 244, y: 44, arrow: 'M298 52 Q318 66 318 92' },
+  mapped: { x: 28, y: 318, arrow: 'M92 310 Q118 288 140 256' },
   dark: { x: 250, y: 322, arrow: 'M300 316 Q300 296 296 276' },
 }))
 
@@ -354,6 +370,9 @@ onBeforeUnmount(() => io?.disconnect())
   font-size: 20px;
   font-weight: 700;
 }
+.tf2__label--sm {
+  font-size: 17px;
+}
 .tf2__note {
   font-size: 15px;
 }
@@ -364,7 +383,7 @@ onBeforeUnmount(() => io?.disconnect())
   fill: #2d1b3d;
 }
 .tf2__together-txt {
-  font-size: 19px;
+  font-size: 18px;
   font-weight: 700;
 }
 

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -79,6 +79,11 @@
           </p>
         </section>
 
+        <!-- El esquema de las dos caras: puente visual entre la anomalía y el
+             perfil molecular. Movido desde la home; con la leyenda completa, el
+             detalle vive mejor aquí. -->
+        <TwoFaces class="mb-12" />
+
         <!-- Molecular profile: single canonical source of alterations -->
         <p class="eyebrow mb-2 block">{{ locale === 'es' ? 'Perfil molecular' : 'Molecular profile' }}</p>
         <h2

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -79,10 +79,6 @@
           </p>
         </section>
 
-        <!-- Explicador conceptual: las dos caras del tumor (una célula, dos
-             biologías) antes de entrar en el perfil molecular detallado. -->
-        <TwoFaces class="mb-12" />
-
         <!-- Molecular profile: single canonical source of alterations -->
         <p class="eyebrow mb-2 block">{{ locale === 'es' ? 'Perfil molecular' : 'Molecular profile' }}</p>
         <h2

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -80,11 +80,6 @@
         </i18n-t>
         <Nota icon="tap" class="mt-3">{{ $t('glossary.hint') }}</Nota>
 
-        <!-- La célula de las dos caras (página del cuaderno): el puente visual
-             entre la explicación de arriba y la tabla de lo que existe/falta.
-             Compacta: sin su propio título, el texto de la sección ya lo es. -->
-        <TwoFaces compact class="mt-12" />
-
         <!-- "Lo que existe / lo que falta" · dos paneles (mobile-first: apilan
              en móvil, lado a lado en sm+). Lo cubierto queda sereno; lo que falta
              se eleva con filete violeta (patrón callout del DS). -->

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -80,6 +80,11 @@
         </i18n-t>
         <Nota icon="tap" class="mt-3">{{ $t('glossary.hint') }}</Nota>
 
+        <!-- La célula de las dos caras (página del cuaderno): el puente visual
+             entre la explicación de arriba y la tabla de lo que existe/falta.
+             Compacta: sin su propio título, el texto de la sección ya lo es. -->
+        <TwoFaces compact class="mt-12" />
+
         <!-- "Lo que existe / lo que falta" · dos paneles (mobile-first: apilan
              en móvil, lado a lado en sm+). Lo cubierto queda sereno; lo que falta
              se eleva con filete violeta (patrón callout del DS). -->

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -60,58 +60,36 @@
     "page": "{c} of {t}",
     "empty": "No donations to show yet."
   },
-    "twofaces": {
-      "eyebrow": "The two faces",
+      "twofaces": {
       "title": "One tumor, two faces",
-      "intro": "It is not one tumor: it is two biologies in the same body. Both must be treated at once — hit only one and the other advances.",
-      "lum_label": "Breast face · luminal",
-      "lum_status": "Well understood, with standard treatment.",
+      "intro": "It is not one tumor: it is two biologies in the same body, and both must be treated at once.",
+      "lum_head": "BREAST · luminal",
+      "lum_sub": "fully mapped",
       "lum_markers": [
-        "ER/PR receptors",
-        "CDK4/6",
+        "HER2−",
+        "HR+",
+        "ESR1",
         "FGFR1",
-        "CCND1",
-        "ESR1"
+        "CCND1"
       ],
-      "join": "one single tumor",
-      "ne_label": "Neuroendocrine face",
-      "ne_status": "Barely understood. Two hard-won certainties.",
-      "ne_known": [
-        {
-          "m": "RB1",
-          "d": "the driver of neuroendocrine transformation"
-        },
-        {
-          "m": "SSTR2",
-          "d": "opens the radioligand route (PRRT)"
-        }
-      ],
-      "ne_unknown": "What we still don't know",
-    "lum_word": "breast",
-    "ne_word": "neuroendocrine",
-    "note_mapped": "mapped",
-    "note_dark": "almost dark",
-    "rb1_note": "the driver",
-    "sstr2_note": "PRRT route",
-    "unknown_mark": "what is missing",
-      "together": "One same tumor. Both faces are treated together.",
-    "together_short": "Both faces are treated together."
+      "ne_head": "neuroendocrine differentiation",
+      "ne_sub": "dominant (80%), in the dark",
+      "pct": "80%",
+    "cgsyn": "Cg · Syn",
+    "amplicon": "11q13 amplicon",
+    "amplicon_g1": "FGFR1 ×13 · CCND1 ×20",
+    "amplicon_g2": "FGF3/4/19 ×18",
+    "esr1": "ESR1 mut. (ctDNA)",
+    "hr": "HR+",
+    "her2": "HER2−",
+      "rb1": "RB1 lost",
+      "rb1_note": "the switch",
+      "sstr2": "SSTR2",
+      "sstr2_note": "receptors → PRRT",
+      "close1": "Block one side and it escapes through the other.",
+      "close2": "It must be treated as a whole.",
+      "sr": "Tumor schematic. Luminal breast, the known part: HR+ receptors, HER2 negative, an 11q13 amplicon (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) and an ESR1 mutation in ctDNA. Neuroendocrine differentiation (Cg/Syn in ~80% of cells), barely known: loss of RB1, the switch, and SSTR2 receptors, the PRRT target. Block one side and it escapes through the other; it must be treated as a whole."
     },
-  "error": {
-    "e404_code": "Error 404",
-    "e404_label": "Page not found",
-    "e404_title": "This address isn't in the {firma}.",
-    "e404_firma": "record",
-    "e404_lede": "The link you followed doesn't exist or has moved. It's nothing serious — the case is right where you left it.",
-    "e500_code": "Error 500",
-    "e500_label": "Something went wrong",
-    "e500_title": "Something broke on our {firma}.",
-    "e500_firma": "end",
-    "e500_lede": "It's on us, not you. We're already looking into it. Try reloading in a moment — the case and the campaign will be back shortly.",
-    "home": "Back to home",
-    "retry": "Try again",
-    "case": "See the clinical case"
-  },
   "thanks": {
     "eyebrow": "Donation received · Thank you",
     "title": "You've just brought the next {firma} closer.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -94,7 +94,8 @@
     "rb1_note": "the driver",
     "sstr2_note": "PRRT route",
     "unknown_mark": "what is missing",
-      "together": "One same tumor. Both faces are treated together."
+      "together": "One same tumor. Both faces are treated together.",
+    "together_short": "Both faces are treated together."
     },
   "error": {
     "e404_code": "Error 404",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -64,7 +64,7 @@
       "title": "One tumor, two faces",
       "intro": "It is not one tumor: it is two biologies in the same body, and both must be treated at once.",
       "lum_head": "BREAST · luminal",
-      "lum_sub": "fully mapped",
+      "lum_sub": "we know it",
     "lum_g1": "HR+ · HER2− · ESR1",
     "lum_g2": "FGFR1 · CCND1",
       "lum_markers": [
@@ -75,7 +75,7 @@
         "CCND1"
       ],
       "ne_head": "neuroendocrine differentiation",
-      "ne_sub": "dominant (80%), in the dark",
+      "ne_sub": "the one we need to know",
       "pct": "80%",
     "cgsyn": "Cg · Syn",
     "amplicon": "11q13 amplicon",
@@ -88,8 +88,8 @@
       "rb1_note": "triggers the 80%",
       "sstr2": "SSTR2",
       "sstr2_note": "receptors → PRRT",
-      "close1": "Block one side and it escapes through the other.",
-      "close2": "It must be treated as a whole.",
+      "close1": "Two populations, one tumor.",
+      "close2": "Treating only one selects for the other.",
       "sr": "Tumor schematic. Luminal breast, the known part: HR+ receptors, HER2 negative, an 11q13 amplicon (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) and an ESR1 mutation in ctDNA. Neuroendocrine differentiation (Cg/Syn in ~80% of cells), barely known: loss of RB1, the switch, and SSTR2 receptors, the PRRT target. Block one side and it escapes through the other; it must be treated as a whole."
     },
   "thanks": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -84,13 +84,19 @@
     "esr1": "ESR1 mut. (ctDNA)",
     "hr": "HR+",
     "her2": "HER2−",
-      "rb1": "RB1 lost",
-      "rb1_note": "triggers the 80%",
+      "rb1": "RB1 · the brake",
+      "rb1_note": "being lost",
       "sstr2": "SSTR2",
       "sstr2_note": "receptors → PRRT",
+    "hr_note": "hormone receptors",
       "close1": "Two populations, one tumor.",
       "close2": "Treating only one selects for the other.",
-      "sr": "Tumor schematic. Luminal breast, the known part: HR+ receptors, HER2 negative, an 11q13 amplicon (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) and an ESR1 mutation in ctDNA. Neuroendocrine differentiation (Cg/Syn in ~80% of cells), barely known: loss of RB1, the switch, and SSTR2 receptors, the PRRT target. Block one side and it escapes through the other; it must be treated as a whole."
+      "sr": "Tumor schematic. Luminal breast, the known part: HR+ receptors, HER2 negative, an 11q13 amplicon (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) and an ESR1 mutation in ctDNA. Neuroendocrine differentiation (Cg/Syn in ~80% of cells), barely known: loss of RB1, the switch, and SSTR2 receptors, the PRRT target. Block one side and it escapes through the other; it must be treated as a whole.",
+    "legend_rec": "Receptors: targets to attack.",
+    "legend_amp": "Amplifications: extra copies that push the tumor.",
+    "legend_mut": "Mutations: resistances the tumor builds to keep growing.",
+    "legend_rb1": "RB1: a brake that is being lost.",
+    "legend_her2": "HER2: it does not have it."
     },
   "thanks": {
     "eyebrow": "Donation received · Thank you",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -62,6 +62,7 @@
   },
       "twofaces": {
       "title": "One tumor, two faces",
+      "eyebrow": "The tumor, in schematic form",
       "intro": "It is not one tumor: it is two biologies in the same body, and both must be treated at once.",
       "lum_head": "BREAST · luminal",
       "lum_sub": "we know it",
@@ -91,12 +92,13 @@
     "hr_note": "hormone receptors",
       "close1": "Two populations, one tumor.",
       "close2": "Treating only one selects for the other.",
-      "sr": "Tumor schematic. Luminal breast, the known part: HR+ receptors, HER2 negative, an 11q13 amplicon (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) and an ESR1 mutation in ctDNA. Neuroendocrine differentiation (Cg/Syn in ~80% of cells), barely known: loss of RB1, the switch, and SSTR2 receptors, the PRRT target. Block one side and it escapes through the other; it must be treated as a whole.",
-    "legend_rec": "Receptors: targets to attack.",
+      "sr": "Tumor schematic. Luminal breast, the known part: HR+ receptors, HER2 negative, an 11q13 amplicon (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) and an ESR1 mutation in ctDNA. Neuroendocrine differentiation (Cg/Syn in ~80% of cells), barely known: loss of RB1 (a brake that is being lost) and SSTR2 receptors, the PRRT target. Block one side and it escapes through the other; it must be treated as a whole.",
+    "legend_rec": "Receptors: targets to attack (HR and SSTR2).",
     "legend_amp": "Amplifications: extra copies that push the tumor.",
     "legend_mut": "Mutations: resistances the tumor builds to keep growing.",
     "legend_rb1": "RB1: a brake that is being lost.",
-    "legend_her2": "HER2: it does not have it."
+    "legend_her2": "HER2: a receptor she does not have (no target).",
+    "legend_cgsyn": "Cg · Syn: neuroendocrine granules (80% of the tumor)."
     },
   "thanks": {
     "eyebrow": "Donation received · Thank you",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -65,6 +65,8 @@
       "intro": "It is not one tumor: it is two biologies in the same body, and both must be treated at once.",
       "lum_head": "BREAST · luminal",
       "lum_sub": "fully mapped",
+    "lum_g1": "HR+ · HER2− · ESR1",
+    "lum_g2": "FGFR1 · CCND1",
       "lum_markers": [
         "HER2−",
         "HR+",
@@ -83,7 +85,7 @@
     "hr": "HR+",
     "her2": "HER2−",
       "rb1": "RB1 lost",
-      "rb1_note": "the switch",
+      "rb1_note": "triggers the 80%",
       "sstr2": "SSTR2",
       "sstr2_note": "receptors → PRRT",
       "close1": "Block one side and it escapes through the other.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -64,7 +64,7 @@
       "title": "Un tumor con dos caras",
       "intro": "No es un tumor: son dos biologías en el mismo cuerpo, y hay que tratarlas a la vez.",
       "lum_head": "MAMA · luminal",
-      "lum_sub": "la conocemos entera",
+      "lum_sub": "la conocemos",
     "lum_g1": "HR+ · HER2− · ESR1",
     "lum_g2": "FGFR1 · CCND1",
       "lum_markers": [
@@ -75,7 +75,7 @@
         "CCND1"
       ],
       "ne_head": "diferenciación neuroendocrina",
-      "ne_sub": "manda (80%), casi a oscuras",
+      "ne_sub": "la que necesitamos conocer",
       "pct": "80%",
     "cgsyn": "Cg · Syn",
     "amplicon": "amplicón 11q13",
@@ -88,8 +88,8 @@
       "rb1_note": "dispara el 80%",
       "sstr2": "SSTR2",
       "sstr2_note": "receptores → PRRT",
-      "close1": "Bloquéalo por un lado y escapa por el otro.",
-      "close2": "Hay que atacarlo entero.",
+      "close1": "Dos poblaciones, un mismo tumor.",
+      "close2": "Tratar una sola selecciona a la otra.",
       "sr": "Esquema del tumor. Mama luminal, la parte conocida: receptores HR+ y HER2 negativo, amplicón 11q13 (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) y mutación de ESR1 en ctDNA. Diferenciación neuroendocrina (Cg/Syn en ~80% de las células), apenas conocida: pérdida de RB1, el interruptor, y receptores SSTR2, diana de la PRRT. Si se bloquea un lado, escapa por el otro; hay que tratarlo entero."
     },
   "thanks": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -60,58 +60,36 @@
     "page": "{c} de {t}",
     "empty": "Aún no hay donaciones que mostrar."
   },
-    "twofaces": {
-      "eyebrow": "Las dos caras",
+      "twofaces": {
       "title": "Un tumor con dos caras",
-      "intro": "No es un tumor: son dos biologías en el mismo cuerpo. Hay que tratar las dos a la vez — si solo atacas una, la otra avanza.",
-      "lum_label": "Cara de mama · luminal",
-      "lum_status": "La conocemos bien y tiene tratamiento estándar.",
+      "intro": "No es un tumor: son dos biologías en el mismo cuerpo, y hay que tratarlas a la vez.",
+      "lum_head": "MAMA · luminal",
+      "lum_sub": "la conocemos entera",
       "lum_markers": [
-        "Receptores ER/PR",
-        "CDK4/6",
+        "HER2−",
+        "HR+",
+        "ESR1",
         "FGFR1",
-        "CCND1",
-        "ESR1"
+        "CCND1"
       ],
-      "join": "un solo tumor",
-      "ne_label": "Cara neuroendocrina",
-      "ne_status": "Apenas conocida. Dos certezas, ganadas a pulso.",
-      "ne_known": [
-        {
-          "m": "RB1",
-          "d": "el motor de la transformación neuroendocrina"
-        },
-        {
-          "m": "SSTR2",
-          "d": "abre la vía de radioligandos (PRRT)"
-        }
-      ],
-      "ne_unknown": "Lo que aún no sabemos",
-    "lum_word": "mama",
-    "ne_word": "neuroendocrino",
-    "note_mapped": "cartografiada",
-    "note_dark": "casi a oscuras",
-    "rb1_note": "el motor",
-    "sstr2_note": "vía PRRT",
-    "unknown_mark": "lo que falta",
-      "together": "Un mismo tumor. Las dos caras se tratan juntas.",
-    "together_short": "Las dos caras se tratan juntas."
+      "ne_head": "diferenciación neuroendocrina",
+      "ne_sub": "manda (80%), casi a oscuras",
+      "pct": "80%",
+    "cgsyn": "Cg · Syn",
+    "amplicon": "amplicón 11q13",
+    "amplicon_g1": "FGFR1 ×13 · CCND1 ×20",
+    "amplicon_g2": "FGF3/4/19 ×18",
+    "esr1": "ESR1 mut. (ctDNA)",
+    "hr": "HR+",
+    "her2": "HER2−",
+      "rb1": "RB1 perdido",
+      "rb1_note": "el interruptor",
+      "sstr2": "SSTR2",
+      "sstr2_note": "receptores → PRRT",
+      "close1": "Bloquéalo por un lado y escapa por el otro.",
+      "close2": "Hay que atacarlo entero.",
+      "sr": "Esquema del tumor. Mama luminal, la parte conocida: receptores HR+ y HER2 negativo, amplicón 11q13 (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) y mutación de ESR1 en ctDNA. Diferenciación neuroendocrina (Cg/Syn en ~80% de las células), apenas conocida: pérdida de RB1, el interruptor, y receptores SSTR2, diana de la PRRT. Si se bloquea un lado, escapa por el otro; hay que tratarlo entero."
     },
-  "error": {
-    "e404_code": "Error 404",
-    "e404_label": "Página no encontrada",
-    "e404_title": "Esta dirección no figura en el {firma}.",
-    "e404_firma": "historial",
-    "e404_lede": "El enlace que has seguido no existe o ha cambiado de sitio. No es nada grave — el caso sigue donde lo dejaste.",
-    "e500_code": "Error 500",
-    "e500_label": "Algo ha fallado",
-    "e500_title": "Se nos ha caído algo por {firma}.",
-    "e500_firma": "aquí",
-    "e500_lede": "Es un fallo nuestro, no tuyo. Ya lo estamos revisando. Prueba a recargar en un momento — el estado del caso y la campaña vuelven enseguida.",
-    "home": "Volver al inicio",
-    "retry": "Reintentar",
-    "case": "Ver el caso clínico"
-  },
   "thanks": {
     "eyebrow": "Donación recibida · Gracias",
     "title": "Acabas de acercar el siguiente {firma}.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -94,7 +94,8 @@
     "rb1_note": "el motor",
     "sstr2_note": "vía PRRT",
     "unknown_mark": "lo que falta",
-      "together": "Un mismo tumor. Las dos caras se tratan juntas."
+      "together": "Un mismo tumor. Las dos caras se tratan juntas.",
+    "together_short": "Las dos caras se tratan juntas."
     },
   "error": {
     "e404_code": "Error 404",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -65,6 +65,8 @@
       "intro": "No es un tumor: son dos biologías en el mismo cuerpo, y hay que tratarlas a la vez.",
       "lum_head": "MAMA · luminal",
       "lum_sub": "la conocemos entera",
+    "lum_g1": "HR+ · HER2− · ESR1",
+    "lum_g2": "FGFR1 · CCND1",
       "lum_markers": [
         "HER2−",
         "HR+",
@@ -83,7 +85,7 @@
     "hr": "HR+",
     "her2": "HER2−",
       "rb1": "RB1 perdido",
-      "rb1_note": "el interruptor",
+      "rb1_note": "dispara el 80%",
       "sstr2": "SSTR2",
       "sstr2_note": "receptores → PRRT",
       "close1": "Bloquéalo por un lado y escapa por el otro.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -84,13 +84,19 @@
     "esr1": "ESR1 mut. (ctDNA)",
     "hr": "HR+",
     "her2": "HER2−",
-      "rb1": "RB1 perdido",
-      "rb1_note": "dispara el 80%",
+      "rb1": "RB1 · el freno",
+      "rb1_note": "se está perdiendo",
       "sstr2": "SSTR2",
       "sstr2_note": "receptores → PRRT",
+    "hr_note": "receptores hormonales",
       "close1": "Dos poblaciones, un mismo tumor.",
       "close2": "Tratar una sola selecciona a la otra.",
-      "sr": "Esquema del tumor. Mama luminal, la parte conocida: receptores HR+ y HER2 negativo, amplicón 11q13 (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) y mutación de ESR1 en ctDNA. Diferenciación neuroendocrina (Cg/Syn en ~80% de las células), apenas conocida: pérdida de RB1, el interruptor, y receptores SSTR2, diana de la PRRT. Si se bloquea un lado, escapa por el otro; hay que tratarlo entero."
+      "sr": "Esquema del tumor. Mama luminal, la parte conocida: receptores HR+ y HER2 negativo, amplicón 11q13 (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) y mutación de ESR1 en ctDNA. Diferenciación neuroendocrina (Cg/Syn en ~80% de las células), apenas conocida: pérdida de RB1, el interruptor, y receptores SSTR2, diana de la PRRT. Si se bloquea un lado, escapa por el otro; hay que tratarlo entero.",
+    "legend_rec": "Receptores: dianas para atacar.",
+    "legend_amp": "Amplificaciones: copias de más que empujan el tumor.",
+    "legend_mut": "Mutaciones: resistencias que el tumor crea para crecer.",
+    "legend_rb1": "RB1: un freno que se va perdiendo.",
+    "legend_her2": "HER2: no lo tiene."
     },
   "thanks": {
     "eyebrow": "Donación recibida · Gracias",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -62,6 +62,7 @@
   },
       "twofaces": {
       "title": "Un tumor con dos caras",
+      "eyebrow": "El tumor, en esquema",
       "intro": "No es un tumor: son dos biologías en el mismo cuerpo, y hay que tratarlas a la vez.",
       "lum_head": "MAMA · luminal",
       "lum_sub": "la conocemos",
@@ -91,12 +92,13 @@
     "hr_note": "receptores hormonales",
       "close1": "Dos poblaciones, un mismo tumor.",
       "close2": "Tratar una sola selecciona a la otra.",
-      "sr": "Esquema del tumor. Mama luminal, la parte conocida: receptores HR+ y HER2 negativo, amplicón 11q13 (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) y mutación de ESR1 en ctDNA. Diferenciación neuroendocrina (Cg/Syn en ~80% de las células), apenas conocida: pérdida de RB1, el interruptor, y receptores SSTR2, diana de la PRRT. Si se bloquea un lado, escapa por el otro; hay que tratarlo entero.",
-    "legend_rec": "Receptores: dianas para atacar.",
+      "sr": "Esquema del tumor. Mama luminal, la parte conocida: receptores HR+ y HER2 negativo, amplicón 11q13 (FGFR1 ×13, CCND1 ×20, FGF3/4/19 ×18) y mutación de ESR1 en ctDNA. Diferenciación neuroendocrina (Cg/Syn en ~80% de las células), apenas conocida: pérdida de RB1 (un freno que se está perdiendo) y receptores SSTR2, diana de la PRRT. Si se bloquea un lado, escapa por el otro; hay que tratarlo entero.",
+    "legend_rec": "Receptores: dianas para atacar (HR y SSTR2).",
     "legend_amp": "Amplificaciones: copias de más que empujan el tumor.",
     "legend_mut": "Mutaciones: resistencias que el tumor crea para crecer.",
     "legend_rb1": "RB1: un freno que se va perdiendo.",
-    "legend_her2": "HER2: no lo tiene."
+    "legend_her2": "HER2: un receptor que no tiene (sin diana).",
+    "legend_cgsyn": "Cg · Syn: gránulos neuroendocrinos (el 80% del tumor)."
     },
   "thanks": {
     "eyebrow": "Donación recibida · Gracias",


### PR DESCRIPTION
Redraws the two-faces tumor cell as a rigorous-but-light schematic, moved to the home, with per-marker glyphs, corrected RB1 / HR+ / HER2 / SSTR2 biology, plain-language legend, and a once-on-entry narrative reveal (reduced-motion safe). Schema detail lives on /ciencia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)