### PR TITLE
feat(b2): sparkline de dinámica del ctDNA + tabla de biopsias seriadas

### DIFF
--- a/app/components/LiquidBiopsyPivot.vue
+++ b/app/components/LiquidBiopsyPivot.vue
@@ -70,6 +70,18 @@
       </table>
     </div>
 
+    <!-- B2 · dinámica del ctDNA: la señal de RB1 a lo largo de las extracciones.
+         Los valores siguen en la tabla (accesibles); el sparkline es complemento
+         visual decorativo. -->
+    <div v-if="rbTrend" class="mt-5 flex items-center gap-4 flex-wrap">
+      <Sparkline :points="rbTrend.points" />
+      <p class="text-sm text-tinta leading-relaxed">
+        <strong class="text-berenjena" translate="no">RB1 {{ rbTrend.sub }}</strong>
+        {{ locale === 'es' ? 'en sangre' : 'in blood' }}:
+        <span class="font-mono nums text-berenjena">{{ rbTrend.from }} → {{ rbTrend.to }}</span>
+      </p>
+    </div>
+
     <p v-if="data.sources" class="mt-4 text-xs text-tinta leading-relaxed font-mono">
       {{ data.sources }}
     </p>
@@ -92,4 +104,24 @@ const { locale } = useI18n()
 function cell(row: Row, sampleId: string): CellValue | undefined {
   return row.values?.[sampleId]
 }
+
+// B2 · serie numérica de RB1 (VAF %) a lo largo de las muestras, para el
+// sparkline. Solo si hay ≥2 puntos numéricos; si no, no se muestra.
+const rbTrend = computed(() => {
+  const row = props.data?.rows?.find((r) => r.alteration === 'RB1')
+  if (!row || !props.data) return null
+  const seq: { value: string; n: number }[] = []
+  for (const s of props.data.samples) {
+    const v = row.values?.[s.id]?.value
+    const m = typeof v === 'string' ? v.match(/(\d+(?:[.,]\d+)?)\s*%/) : null
+    if (m) seq.push({ value: m[0], n: parseFloat((m[1] ?? '').replace(',', '.')) })
+  }
+  if (seq.length < 2) return null
+  return {
+    points: seq.map((x) => x.n),
+    from: seq[0]?.value ?? '',
+    to: seq[seq.length - 1]?.value ?? '',
+    sub: row.subscript ?? '',
+  }
+})
 </script>

--- a/app/components/Sparkline.vue
+++ b/app/components/Sparkline.vue
@@ -1,0 +1,108 @@
+<template>
+  <div ref="root" class="sparkline" :class="{ 'spark-in': inView }" aria-hidden="true">
+    <svg :viewBox="`0 0 ${W} ${H}`" :width="W" :height="H" fill="none" class="sparkline__svg">
+      <polyline
+        class="sparkline__line"
+        :points="linePoints"
+        stroke="#ff6b47"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <circle
+        v-for="(p, i) in coords"
+        :key="i"
+        :cx="p.x"
+        :cy="p.y"
+        :r="i === coords.length - 1 ? 3.6 : 2.6"
+        fill="#ff6b47"
+        :class="i === coords.length - 1 ? 'heart-beat sparkline__last' : ''"
+      />
+    </svg>
+  </div>
+</template>
+
+<script setup lang="ts">
+/**
+ * Sparkline (detalles con alma · B2). Dibuja una serie numérica como polyline
+ * coral que se traza al entrar en viewport; el último punto late (heart-beat).
+ * Decorativo (aria-hidden): los valores reales siguen como texto/tabla al lado.
+ * Estático con reduced-motion (línea completa, sin latido).
+ */
+const props = defineProps<{ points: number[] }>()
+
+const W = 88
+const H = 30
+const PAD = 5
+
+const coords = computed(() => {
+  const pts = props.points
+  if (pts.length < 2) return []
+  const min = Math.min(...pts)
+  const max = Math.max(...pts)
+  const span = max - min || 1
+  const stepX = (W - PAD * 2) / (pts.length - 1)
+  return pts.map((v, i) => ({
+    x: PAD + i * stepX,
+    // valor alto → arriba (y pequeña); invertimos.
+    y: H - PAD - ((v - min) / span) * (H - PAD * 2),
+  }))
+})
+
+const linePoints = computed(() => coords.value.map((p) => `${p.x},${p.y}`).join(' '))
+
+const root = ref<HTMLElement | null>(null)
+const inView = ref(false)
+let io: IntersectionObserver | null = null
+onMounted(() => {
+  if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+    inView.value = true
+    return
+  }
+  io = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          inView.value = true
+          io?.disconnect()
+          break
+        }
+      }
+    },
+    { threshold: 0.6 }
+  )
+  if (root.value) io.observe(root.value)
+})
+onBeforeUnmount(() => io?.disconnect())
+</script>
+
+<style scoped>
+.sparkline {
+  display: inline-block;
+  line-height: 0;
+}
+.sparkline__svg {
+  display: block;
+}
+.sparkline__line {
+  --len: 120;
+  stroke-dasharray: 120;
+  stroke-dashoffset: 0; /* estático / reduced-motion: línea completa */
+}
+.heart-beat {
+  transform-origin: center;
+  transform-box: fill-box;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .sparkline:not(.spark-in) .sparkline__line {
+    stroke-dashoffset: var(--len);
+  }
+  .spark-in .sparkline__line {
+    animation: draw-in 1s ease forwards;
+  }
+  /* el punto final late solo cuando ya se trazó la línea */
+  .spark-in .sparkline__last {
+    animation: heart-beat-soft 2.4s ease-in-out 1s infinite;
+  }
+}
+</style>

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -100,6 +100,9 @@
         </p>
         <MolecularProfileDetailed class="mb-12" />
 
+        <!-- ctDNA seriado (3 extracciones) + sparkline B2 de la dinámica. -->
+        <LiquidBiopsyPivot v-if="liquidBiopsyPivot" :data="liquidBiopsyPivot" class="mb-12" />
+
         <section v-if="imaging" class="mb-14" aria-labelledby="imaging-tissue-title">
           <p class="eyebrow mb-2 block">{{ locale === 'es' ? 'Imagen funcional' : 'Functional imaging' }}</p>
           <h2
@@ -541,6 +544,9 @@ const { data: scienceData } = await useAsyncData(
 const treatments = computed(() => scienceData.value?.treatments ?? [])
 const panelRows = computed(() => scienceData.value?.panelRows ?? [])
 const imaging = computed(() => scienceData.value?.imaging ?? null)
+const liquidBiopsyPivot = computed(
+  () => (scienceData.value as Record<string, unknown> | null)?.liquidBiopsyPivot ?? null
+)
 
 const snapshotRows = computed(() =>
   [


### PR DESCRIPTION
Rescatado limpio de PR #26 (cerrado) sobre `main` actual.

- `Sparkline.vue`: serie numérica como polyline coral que se traza al entrar (draw-in), último punto latiendo; decorativo (`aria-hidden`), estático con reduced-motion.
- `LiquidBiopsyPivot.vue`: extrae la serie VAF de **RB1 (p.V622Yfs*33)** y muestra el sparkline + valores como texto bajo la tabla. Verificado: 2 puntos → **1,58% → 0,19%** (descenso = respuesta).
- `ciencia/index.vue`: renderiza la tabla de ctDNA seriado (3 extracciones) que estaba en `science.yml` pero no se invocaba en ningún sitio (código muerto).

Lint limpio (0 errores). No toca P7 (trailing-slash): comprobado que Netlify ya canoniza y una regla strip-slash haría bucle.