### PR TITLE
feat(home): data-optimization brief — P1/P2/P6 (review, do not merge yet)

### DIFF
--- a/UTM-convention.md
+++ b/UTM-convention.md
@@ -1,0 +1,54 @@
+# Convención UTM · helpmiriam.com
+
+> **Por qué:** el 71% del tráfico es social pero todos los `utm_*` llegan vacíos, así
+> que la atribución depende solo del *referrer* — y Twitter llega como `t.co/…` opaco.
+> Etiquetando NUESTROS propios enlaces sabremos qué canal y qué pieza traen donantes.
+> (Brief P6 · `OPTIMIZACION-datos-helpmiriam.md`.)
+
+## Regla
+
+Añade parámetros UTM **solo a los enlaces que controlamos nosotros** (bio de Instagram,
+tuits, firma de prensa, newsletters…). **Nunca** los pongas en enlaces internos del sitio
+ni en los que comparten terceros — solo en los que publicamos.
+
+```
+https://helpmiriam.com/?utm_source=<dónde>&utm_medium=<tipo>&utm_campaign=<acción>
+```
+
+| Parámetro | Qué es | Valores que usamos |
+|---|---|---|
+| `utm_source` | la plataforma | `instagram` · `twitter` · `prensa` · `whatsapp` · `linkedin` · `newsletter` |
+| `utm_medium` | el tipo de enlace | `bio` · `post` · `story` · `firma` · `perfil` · `dm` |
+| `utm_campaign` | la acción/ola | `lanzamiento` · (futuras: `actualizacion-jun`, `hito-50k`…) |
+
+Todo en **minúsculas, sin acentos ni espacios** (usa guiones). Sé consistente: Plausible
+agrupa por coincidencia exacta, así que `Instagram` ≠ `instagram`.
+
+## Plantillas listas para copiar
+
+```
+# Bio de Instagram
+https://helpmiriam.com/?utm_source=instagram&utm_medium=bio&utm_campaign=lanzamiento
+
+# Story de Instagram (con enlace)
+https://helpmiriam.com/?utm_source=instagram&utm_medium=story&utm_campaign=lanzamiento
+
+# Tuit de lanzamiento
+https://helpmiriam.com/?utm_source=twitter&utm_medium=post&utm_campaign=lanzamiento
+
+# Firma / pie en notas de prensa
+https://helpmiriam.com/?utm_source=prensa&utm_medium=firma&utm_campaign=lanzamiento
+
+# WhatsApp / difusión directa
+https://helpmiriam.com/?utm_source=whatsapp&utm_medium=dm&utm_campaign=lanzamiento
+```
+
+> Para enlazar a una página concreta, pon los UTM detrás de la ruta:
+> `https://helpmiriam.com/ciencia?utm_source=twitter&utm_medium=post&utm_campaign=lanzamiento`
+
+## Cómo leerlo en Plausible
+
+Filtros → **Sources / UTM Source · UTM Medium · UTM Campaign**. Cruza con el goal
+`Apoyar` (intención de donar) para ver **qué canal convierte mejor**, no solo cuál trae
+más visitas. (El importe donado no es medible desde la web — la donación ocurre en
+GoFundMe; ver `plausible-donar-tracking.md`.)

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -122,6 +122,7 @@
               <NuxtLink
                 :to="localePath({ name: 'ciencia' })"
                 class="btn-secondary w-full sm:w-auto whitespace-nowrap"
+                @click="trackScience('home_hero')"
               >
                 <Icon name="ph:flask-fill" class="w-4 h-4" aria-hidden="true" />
                 {{ $t('hero.cta_science') }}
@@ -131,6 +132,19 @@
               </p>
             </div>
           </div>
+
+          <!-- P2 · prueba social junto al CTA: nº de donantes EN VIVO + prensa,
+               para que también lo vea quien no baja al panel de cifras. -->
+          <p
+            v-if="gofundme?.donationCount"
+            class="mt-4 flex items-center gap-2 text-sm text-tinta animate-fade-up"
+            style="animation-delay: 0.34s"
+          >
+            <Icon name="ph:heart-fill" class="w-3.5 h-3.5 shrink-0 text-coral" aria-hidden="true" />
+            <i18n-t keypath="home.hero_social_proof" tag="span">
+              <template #n><strong class="text-berenjena nums">{{ donorsFormatted }}</strong></template>
+            </i18n-t>
+          </p>
 
           <!-- Lo último de la cronología (dinámico, lo que pasa ahora mismo).
                Título subrayado + flecha → señala que es un enlace a la cronología. -->
@@ -189,13 +203,31 @@
 <script setup lang="ts">
 const localePath = useLocalePath()
 const { locale, t } = useI18n()
-const { trackSupport } = useSupport()
+const { trackSupport, trackScience } = useSupport()
 
-// Datos de campaña EN VIVO: /fundraiser.json lo sirve una función Netlify
-// (GoFundMe + caché de CDN). Carga en cliente, así refleja el dato actual.
-const gofundme = ref<import('../../utils/fundraiser').GoFundMeFundraiser | null>(null)
-onMounted(async () => {
-  gofundme.value = await $fetch('/fundraiser.json')
+// Datos de campaña. En PRERENDER leemos la semilla del disco
+// (public/fundraiser.json, generada por update-fundraiser antes del build) para
+// hornear la cifra real en el HTML y que NUNCA salga "—". En cliente refrescamos
+// al dato EN VIVO que sirve la función Netlify (mismo endpoint /fundraiser.json,
+// vía redirect de netlify.toml). $fetch del JSON en SSR no es fiable (lo resuelve
+// el router), por eso en servidor vamos a disco. Si algo falla, queda null.
+type GoFundMeFundraiser = import('../../utils/fundraiser').GoFundMeFundraiser
+const { data: gofundme, refresh: refreshFundraiser } = await useAsyncData<GoFundMeFundraiser | null>(
+  'hero-fundraiser',
+  async () => {
+    if (import.meta.server) {
+      try {
+        const { readFile } = await import('node:fs/promises')
+        return JSON.parse(await readFile('public/fundraiser.json', 'utf-8'))
+      } catch {
+        return null
+      }
+    }
+    return $fetch<GoFundMeFundraiser>('/fundraiser.json')
+  }
+)
+onMounted(() => {
+  refreshFundraiser()
 })
 
 // Lo más reciente de la cronología: las entradas están ordenadas de más

--- a/app/components/StarMap.vue
+++ b/app/components/StarMap.vue
@@ -67,12 +67,29 @@
             <path fill="#9d44ab" :d="STAR_D" />
           </svg>
 
-          <!-- Donantes: una estrella por aportación; importe → brillo y cercanía al corazón -->
+          <!-- Puntas de difracción + halo de las estrellas PRINCIPALES (detrás
+               de los núcleos): la firma de las mayores aportaciones. -->
+          <svg
+            v-for="s in principals"
+            :key="'spike-' + s.id"
+            class="starmap__spike"
+            :style="{ left: s.x + '%', top: s.y + '%', width: s.size * 2.7 + 'px', height: s.size * 2.7 + 'px' }"
+            viewBox="0 0 40 40"
+            aria-hidden="true"
+          >
+            <path d="M20 3 V37 M3 20 H37" stroke="#9d44ab" stroke-width="0.8" stroke-linecap="round" opacity="0.42" />
+          </svg>
+
+          <!-- Donantes: una estrella por aportación; importe → magnitud (brillo +
+               tamaño) y cercanía al corazón. Principales/brillantes con halo. -->
           <svg
             v-for="(s, i) in stars"
             :key="s.id"
             class="starmap__star"
-            :class="{ 'starmap__star--new': s.newest, 'starmap__star--lit': i === activeIdx }"
+            :class="[
+              s.tier === 'principal' ? 'starmap__star--principal' : s.tier === 'bright' ? 'starmap__star--bright' : '',
+              { 'starmap__star--new': s.newest, 'starmap__star--lit': i === activeIdx },
+            ]"
             :style="{
               left: s.x + '%',
               top: s.y + '%',
@@ -84,6 +101,7 @@
             viewBox="0 0 20 20"
           >
             <path :fill="s.newest ? '#ff6b47' : '#9d44ab'" :d="STAR_D" />
+            <circle v-if="s.tier === 'principal' && !s.newest" cx="10" cy="10" r="2" fill="#fdf7fb" opacity="0.9" />
           </svg>
 
           <!-- Anotaciones a mano (cuaderno) -->
@@ -114,6 +132,8 @@
 
     <!-- Cómo se juega: nota de gesto (dedito), pequeña, bajo el mapa. -->
     <Nota icon="tap" class="mt-3">{{ $t('thanksWall.sky_hint') }}</Nota>
+    <!-- Cómo leerlo: el brillo crece en escala log (✱ nota al margen). -->
+    <Nota class="mt-2">{{ $t('thanksWall.magnitude_note') }}</Nota>
 
     <!-- El juego: tu estrella se enciende donando (solo el botón; el resto
          del texto se quitó — el pie manuscrito ya cuenta la historia). -->
@@ -229,6 +249,7 @@ interface Star {
   o: number
   rot: number
   newest: boolean
+  tier: 'faint' | 'bright' | 'principal'
   name: string
   amount: number
   currencyCode?: string
@@ -241,6 +262,13 @@ const stars = computed<Star[]>(() => {
   const amts = ds.map((d) => d.amount).filter((a) => a > 0)
   const sorted = [...amts].sort((a, b) => a - b)
   const median = sorted.length ? sorted[Math.floor(sorted.length / 2)]! : 0
+  // Magnitud (brillo + tamaño) por importe en escala LOGARÍTMICA —como en los
+  // catálogos estelares: ninguna estrella eclipsa a las demás—, normalizada
+  // entre el p5 y el p98 para que un extremo no aplaste a todo el resto.
+  const at = (f: number) =>
+    sorted.length ? sorted[Math.min(sorted.length - 1, Math.max(0, Math.floor(sorted.length * f)))]! : 1
+  const lLo = Math.log(Math.max(1, at(0.05)))
+  const lHi = Math.log(Math.max(Math.max(1, at(0.05)) + 1, at(0.98)))
   // Percentil del importe (0 = menor, 1 = mayor) → cercanía al corazón.
   const pct = (a: number) => {
     if (sorted.length < 2) return 0.5
@@ -281,20 +309,24 @@ const stars = computed<Star[]>(() => {
     let y = BEEHIVE.y + Math.sin(ang) * radius
     x = +reflect(x, 2, 98).toFixed(2)
     y = +reflect(y, 6, 94).toFixed(2)
-    const o = +(0.4 + rnd() * 0.35).toFixed(2)
-    let size = +(4.5 + rnd() * 2.5).toFixed(1)
-    if (median > 0 && d.amount > 0) {
-      size = +Math.min(10, Math.max(4, 7 + 2.2 * Math.log10(d.amount / median))).toFixed(1)
-    }
+    // Brillo (opacidad) y tamaño según la magnitud: las mayores casi opacas y
+    // grandes; las menores, tenues y pequeñas. Suave (log) para no eclipsar.
+    const b = d.amount > 0 ? Math.min(1, Math.max(0, (Math.log(d.amount) - lLo) / (lHi - lLo || 1))) : 0.12
+    const o = +(0.34 + b * 0.62).toFixed(2)
+    const size = +(3.5 + b * 12.5).toFixed(1)
+    // Jerarquía por percentil: principales (≈top 1.5%) con halo + puntas de
+    // difracción; brillantes (top 20%) con halo suave; el resto, tenues.
+    const tier: Star['tier'] = d.amount <= 0 ? 'faint' : p >= 0.985 ? 'principal' : p >= 0.8 ? 'bright' : 'faint'
     const newest = i === newestIdx
     return {
       id: String(d.id ?? i),
       x,
       y,
-      size: newest ? 18 : size,
+      size: newest ? 17 : size,
       o: newest ? 1 : o,
       rot: +(rnd() * 44 - 22).toFixed(1),
       newest,
+      tier,
       name: d.name,
       amount: d.amount,
       currencyCode: d.currencyCode,
@@ -302,6 +334,10 @@ const stars = computed<Star[]>(() => {
     }
   })
 })
+
+// Las principales (mayores aportaciones, salvo la recién encendida) llevan halo
+// y puntas de difracción, dibujadas en una capa propia detrás de los núcleos.
+const principals = computed(() => stars.value.filter((s) => s.tier === 'principal' && !s.newest))
 
 /* ── Zoom + pan ───────────────────────────────────────────────────────── */
 const viewport = ref<HTMLElement | null>(null)
@@ -563,6 +599,20 @@ const tipStyle = computed(() => {
   transform: translate(-50%, -50%) rotate(var(--rot, 0deg));
   opacity: var(--o, 0.5);
   transition: opacity 0.25s ease, filter 0.25s ease;
+}
+/* Magnitud: las brillantes y principales ganan un halo (las mayores aportaciones). */
+.starmap__star--bright {
+  filter: drop-shadow(0 0 3px rgba(157, 68, 171, 0.4));
+}
+.starmap__star--principal {
+  filter: drop-shadow(0 0 6px rgba(157, 68, 171, 0.55));
+}
+/* Puntas de difracción de las principales (capa propia, detrás de los núcleos). */
+.starmap__spike {
+  position: absolute;
+  display: block;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
 }
 .starmap__star--lit {
   opacity: 1;

--- a/app/composables/useSupport.ts
+++ b/app/composables/useSupport.ts
@@ -13,18 +13,22 @@ export const GOFUNDME_URL = 'https://gofund.me/3e25cae99'
 export function useSupport() {
   const nuxtApp = useNuxtApp()
 
-  function trackSupport(location: string) {
+  // Doble evento: «<Nombre>» = total (un solo número) y «<Nombre>: <botón>» =
+  // desglose por ubicación sin custom properties (de pago en Plausible). Cada
+  // nombre tiene su goal en el panel; el props se mantiene por si algún día se
+  // activa el plan con propiedades.
+  function fire(name: string, location: string) {
     if (!import.meta.client) return
     // $plausible lo inyecta @nuxtjs/plausible (solo en cliente).
     const plausible = nuxtApp.$plausible as
       | { trackEvent?: (name: string, opts?: { props?: Record<string, string> }) => void }
       | undefined
-    // Doble evento: «Apoyar» = total de conversiones (un solo número), y
-    // «Apoyar: <botón>» = desglose por ubicación sin custom properties (de
-    // pago en Plausible). Cada nombre tiene su goal en el panel. El props se
-    // mantiene por si algún día se activa el plan con propiedades.
-    plausible?.trackEvent?.('Apoyar', { props: { location } })
-    plausible?.trackEvent?.(`Apoyar: ${location}`)
+    plausible?.trackEvent?.(name, { props: { location } })
+    plausible?.trackEvent?.(`${name}: ${location}`)
+  }
+
+  function trackSupport(location: string) {
+    fire('Apoyar', location)
     // Marca para el aviso suave al volver de GoFundMe (DonationReturnPrompt).
     try {
       sessionStorage.setItem('hm_support_ts', String(Date.now()))
@@ -33,5 +37,11 @@ export function useSupport() {
     }
   }
 
-  return { GOFUNDME_URL, trackSupport }
+  // P6 · mide quién elige LEER la ciencia (vs donar) para ver el reparto del
+  // embudo más allá del clic del héroe. No toca el goal «Apoyar».
+  function trackScience(location: string) {
+    fire('VerCiencia', location)
+  }
+
+  return { GOFUNDME_URL, trackSupport, trackScience }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -356,6 +356,7 @@
     "s10_l3_caption": "Secure payment. Receipt available. 100% to Miriam's case.",
     "hero_cta_donate_caption": "Every euro funds clinical research applied to her case.",
     "hero_cta_science_caption": "Open the full molecular profile in The science.",
+    "hero_social_proof": "Already supported by {n} people · featured in El País",
     "hero_eyebrow": "Metastatic breast cancer · Ultra-rare molecular profile",
     "story_eyebrow": "The story",
     "story_heading": "A diagnosis that fit no protocol.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -379,6 +379,7 @@
     "s10_l3_caption": "Pago seguro. Recibo disponible. 100% al caso de Miriam.",
     "hero_cta_donate_caption": "Cada euro va a investigación clínica aplicada a su caso.",
     "hero_cta_science_caption": "Accede al perfil molecular completo en La ciencia.",
+    "hero_social_proof": "Ya nos apoyan {n} personas · visto en El País",
     "hero_eyebrow": "Cáncer de mama metastásico · Perfil molecular ultra-raro",
     "story_eyebrow": "La historia",
     "story_heading": "Un diagnóstico que no cabía en ningún protocolo.",


### PR DESCRIPTION
Applies the conversion/UX brief (`OPTIMIZACION-datos-helpmiriam.md`). **Review branch — don't merge until you check the deploy-preview.** Most of P1–P8 was already shipped on `main`; this only adds the real gaps.

## Changed (the genuine gaps)
- **P1 · no more `—` flash.** Hero counters were filled client-side (`onMounted $fetch`), so the prerendered HTML showed `—` until JS ran. Now the seed (`public/fundraiser.json`) is read from disk during SSR/prerender → the **real total + donor count are baked into the HTML** (verified: 37.651 € / 948); the client still refreshes to the live Netlify-function value. (`$fetch` of a public JSON is unreliable in SSR — the Vue router intercepts it — hence the fs read on the server branch.)
- **P2 · hero social-proof.** Added a live line by the CTA: *"Ya nos apoyan N personas · visto en El País"* / *"Already supported by N people · featured in El País"*, using the live `donationCount`. (Sticky mobile bar + CTA hierarchy were already shipped.)
- **P6 · `VerCiencia` event + UTM doc.** The secondary "Ver la ciencia" CTA now fires a `VerCiencia` Plausible event (read-vs-donate split); **`Apoyar` untouched** (refactored to a shared `fire()` helper). Added `UTM-convention.md`.

## Already shipped on main (verified, NOT rebuilt)
- **P3** tooltips open on tap (`canHover`), tables stack (`data-table--cards`), CTA opens GoFundMe via `href`, events fire. → still needs a **real-device check** in the Twitter/IG Android webview (can't run that here).
- **P4** /ciencia already opens with "De un vistazo" (chips + plain-language) and uses `<details>` collapsibles.
- **P5** "3 formas de contribuir" + `/gastos` transparency link already within the first ~50% of scroll.
- **P7** ES/EN switcher on every page; es.json/en.json at 100% key parity; EN slugs all defined.

## Deliberately NOT done
- **P8 · trailing-slash.** Internal links + canonical are **already slash-free**. Production Netlify already 301s `/ciencia → /ciencia/` (adds the slash); a strip-slash rule would form an **infinite redirect loop**. The Plausible split is already resolved by that 301. **Your call** whether to flip Netlify to slash-free (bigger change) or leave it.

ES + EN, lint clean, verified in dev (both locales render the figures + social-proof server-side).