### PR TITLE
feat(desktop): pixel-perfect pass for the event (D1–D8, design-only)

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -73,7 +73,19 @@
   }
 
   .section-wide {
-    @apply max-w-6xl mx-auto px-6 sm:px-8 lg:px-12;
+    @apply mx-auto px-6 sm:px-8 lg:px-12;
+    /* Ancho canónico ÚNICO para header, footer y cuerpo de todas las páginas
+       (D1). 1200px (antes max-w-6xl = 1152) respira mejor a 1920 y sigue cómodo
+       a 1440. En < 1200px el max-width no aplica → móvil intacto. */
+    max-width: 75rem;
+  }
+
+  /* Medida de lectura para párrafos largos DENTRO del shell ancho: limita el
+     ancho pero alineado a la IZQUIERDA del shell (no centrado), para que cuadre
+     con el logo y el H1. Solo es un tope: en móvil ocupa el 100%. */
+  .measure {
+    max-width: 72ch;
+    margin-inline-start: 0;
   }
 
   .section-spacing {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -132,6 +132,28 @@
     border: 1px solid rgba(45, 27, 61, 0.08);
   }
 
+  /* D8 · pulido desktop: lift sutil al pasar el cursor SOLO en tarjetas
+     interactivas (las que son enlace o botón). Gated a punteros finos
+     (@media hover) → el táctil/móvil no se ve afectado; sin movimiento con
+     reduced-motion. Las tarjetas estáticas (div.card-base) no se mueven. */
+  @media (hover: hover) {
+    a.card-base,
+    button.card-base {
+      transition: transform 0.18s ease, box-shadow 0.18s ease;
+    }
+    a.card-base:hover,
+    button.card-base:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 34px rgba(45, 27, 61, 0.1);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    a.card-base:hover,
+    button.card-base:hover {
+      transform: none;
+    }
+  }
+
   /* DS botones */
   .btn-cta {
     @apply inline-flex items-center justify-center gap-2 px-6 py-3.5 rounded-btn font-semibold text-berenjena bg-coral hover:bg-coral-hover transition-all;

--- a/app/components/SiteFooter.vue
+++ b/app/components/SiteFooter.vue
@@ -7,7 +7,7 @@
         <p class="text-cream/70 text-xs font-mono font-medium uppercase tracking-[0.12em] mb-8">
           {{ $t('index.supported_by') }}
         </p>
-        <ul class="grid grid-cols-2 sm:grid-cols-4 items-center justify-items-center gap-x-8 gap-y-9 max-w-2xl mx-auto">
+        <ul class="grid grid-cols-2 sm:grid-cols-4 items-center justify-items-center gap-x-8 sm:gap-x-14 gap-y-9 max-w-2xl mx-auto">
           <li v-for="s in supporters" :key="s.name" class="flex items-center justify-center">
             <a
               v-if="s.url"
@@ -42,7 +42,9 @@
       </div>
     </section>
     <div class="section-wide py-12 sm:py-16">
-      <div class="grid sm:grid-cols-3 gap-8">
+      <!-- D6: marca (2fr) + Navegación/Social (1fr c/u) repartidas a lo ancho del
+           shell. En < md se apila (1 col); en móvil 375-390 es idéntico a hoy. -->
+      <div class="grid gap-10 md:grid-cols-[2fr_1fr_1fr] lg:gap-16 items-start">
         <!-- Brand -->
         <div>
           <div class="flex items-center gap-2.5 mb-3">

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -20,7 +20,9 @@
 
     <!-- ░░ HERO ░░ bg-cream -->
     <section v-reveal class="section-spacing bg-cream" :aria-label="$t('collaborate.title')">
-      <div class="section-container">
+      <!-- D1/D3: shell ancho para alinear el hero con las tarjetas de abajo
+           (mismo borde izquierdo); intro/cita/contexto se topan con .measure. -->
+      <div class="section-wide">
         <p class="eyebrow mb-4 block">{{ $t('collaborate.eyebrow') }}</p>
         <h1
           class="heading-display text-3xl sm:text-4xl lg:text-5xl text-berenjena mb-4 max-w-3xl"
@@ -215,7 +217,7 @@
 
     <!-- ░░ ENLACES RÁPIDOS ░░ bg-cream-card · panel neutro -->
     <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'links-title'">
-      <div class="section-container">
+      <div class="section-wide">
         <p class="eyebrow mb-3 block">{{ $t('collaborate.links_eyebrow') }}</p>
         <h2
           id="links-title"

--- a/app/pages/contacto.vue
+++ b/app/pages/contacto.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <section class="section-spacing" :aria-label="$t('contact.title')">
-      <div class="section-container">
+      <div class="section-wide">
         <PageHeader
           :title="$t('contact.title')"
           :subtitle="$t('contact.subtitle')"

--- a/app/pages/equipo.vue
+++ b/app/pages/equipo.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <section class="section-spacing" :aria-label="$t('team.title')">
-      <div class="section-container">
+      <div class="section-wide">
         <PageHeader :title="$t('team.title')" :subtitle="$t('team.subtitle')" />
 
         <!-- El equipo de Miriam · retratos del círculo cercano (Miriam, primera) -->
@@ -26,7 +26,7 @@
         </h2>
         <ul
           aria-labelledby="team-medical"
-          class="grid sm:grid-cols-2 gap-4 mb-14 stagger-children"
+          class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-14 stagger-children"
         >
           <li v-for="member in medicalNetwork" :key="member.role">
             <TeamCard :member="member" />
@@ -39,7 +39,7 @@
         </h2>
         <ul
           aria-labelledby="team-integrative"
-          class="grid sm:grid-cols-2 gap-4 stagger-children"
+          class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 stagger-children"
         >
           <li v-for="member in integrativeSupport" :key="member.role">
             <TeamCard :member="member" />
@@ -47,9 +47,11 @@
         </ul>
 
         <!-- Cierre · "Lo que NO somos" (honestidad operativa) + Beyond the
-             Protocol (próximamente) + cómo ayudar. Panel oscuro sobrio. -->
+             Protocol (próximamente) + cómo ayudar. Panel oscuro sobrio.
+             D5: contenido a max-w-4xl (alineado a la izquierda del shell) para
+             que el panel no quede con un hueco grande a la derecha a 1200px. -->
         <section
-          class="mt-16 relative overflow-hidden rounded-card p-8 sm:p-12"
+          class="mt-16 relative overflow-hidden rounded-card p-8 sm:p-12 max-w-4xl"
           style="background: #2d1b3d; color: #faf6f0"
           :aria-labelledby="'notus-title'"
         >

--- a/app/pages/gastos.vue
+++ b/app/pages/gastos.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
     <section class="section-spacing bg-cream" :aria-label="$t('expenses.title')">
-      <div class="section-container max-w-3xl">
+      <div class="section-wide">
         <PageHeader :title="$t('expenses.title')" :subtitle="$t('expenses.subtitle')" />
 
-        <p class="text-base text-tinta leading-relaxed mb-8 max-w-2xl">
+        <p class="text-base text-tinta leading-relaxed mb-8 measure">
           {{ $t('expenses.intro') }}
         </p>
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -344,13 +344,16 @@
 
     <section v-reveal class="section-spacing bg-cream" :aria-label="$t('home.pro_eyebrow')">
       <div class="section-container max-w-3xl">
-        <div class="card-base flex flex-col gap-5 sm:flex-row sm:items-center sm:justify-between">
+        <!-- D7: en desktop apila (título a todo el ancho arriba, botones debajo)
+             en vez de texto|botones lado a lado, que estrujaba el título a 4
+             líneas y dejaba hueco abajo. En móvil ya era flex-col → idéntico. -->
+        <div class="card-base flex flex-col gap-5">
           <div>
             <p class="eyebrow mb-2 block">{{ $t('home.pro_eyebrow') }}</p>
-            <p class="font-display font-semibold text-berenjena text-lg">{{ $t('home.pro_text') }}</p>
+            <p class="font-display font-semibold text-berenjena text-lg sm:text-xl max-w-2xl">{{ $t('home.pro_text') }}</p>
             <p class="text-sm text-tinta mt-1">{{ $t('home.pro_sub') }}</p>
           </div>
-          <div class="flex flex-col sm:flex-row gap-3 shrink-0">
+          <div class="flex flex-col sm:flex-row gap-3">
             <NuxtLink :to="localePath('colabora') + '#revision-clinica'" class="btn-secondary">
               <Icon name="ph:stethoscope" class="w-4 h-4" aria-hidden="true" />
               {{ $t('home.pro_clinical') }}

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
     <section class="section-spacing" :aria-label="$t('timeline.title')">
-      <div class="section-container">
+      <!-- D4: a partir de lg, 2 columnas dentro del shell — raíl izquierdo
+           pegajoso (cabecera + meta + filtros) y los hitos a la derecha. En
+           < lg la rejilla no aplica → se apila idéntico al móvil de hoy. -->
+      <div class="section-wide lg:grid lg:grid-cols-[320px_minmax(0,1fr)] lg:gap-16 xl:gap-24">
+        <!-- Columna izquierda · cabecera + filtros (sticky en desktop) -->
+        <aside class="lg:sticky lg:top-24 lg:self-start">
         <PageHeader
           :title="$t('timeline.title')"
           :subtitle="$t('timeline.subtitle')"
@@ -55,7 +60,10 @@
             <span class="tl-chip__count">{{ opt.count }}</span>
           </button>
         </div>
+        </aside>
 
+        <!-- Columna derecha · los hitos (raíl) + el cierre -->
+        <div class="lg:max-w-[760px]">
         <!-- Cronología con raíl continuo + estaciones por año -->
         <div class="relative max-w-2xl">
           <span
@@ -119,6 +127,7 @@
               </NuxtLink>
             </div>
           </div>
+        </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Desktop pixel-perfect pass for the event (1440/1920), per `HANDOFF-desktop-pixel-perfect.md`. **Design/layout only — zero content, clinical, figure or link changes. Review branch, don't deploy until you check it on a 1440 and a 1920 screen.**

Built on a clean branch off `main` (isolated worktree, away from the concurrent starmap work). One small commit per block:

- **D1 · canonical width** — `.section-wide` → 1200px (header, footer, bodies share one left edge), new `.measure` for reading intros; `/contacto` promoted.
- **D2 · /gastos** — dropped `max-w-3xl` (672) → shell; cards/breakdown fill the width, H1 aligns to header.
- **D3 · /colabora** — hero (+ quick-links) → `section-wide` so it lines up with its own cards (kills the 176px step).
- **D4 · /timeline** — 2-column at `lg` (sticky rail: title/meta/filters · milestones right), fills the dead right gutter. Stacked exactly as today below `lg`.
- **D5 · /equipo** — grid → shell, role cards `lg:grid-cols-3`; dark closing panel capped so it doesn't leave a big gutter.
- **D6 · footer** — `md:grid-cols-[2fr_1fr_1fr]` so the 3 columns span the shell; logo band more evenly spaced at desktop.
- **D7 · home impact card** — stacks (title full width, buttons below) instead of text|buttons side-by-side that squeezed the title.
- **D8 · polish** — most was already in the DS (visible focus, AA CTA contrast berenjena-on-coral, fluid hero clamp, nav/button hovers); added a subtle hover lift on **interactive** cards only.

**Safety**
- Mobile (375–390): every change is gated to `lg:`/`md:`/`sm:` or `max-width`/`@media (hover:hover)` → mobile renders identically.
- ES = EN: shared components/i18n, so both locales change together. All 12 routes (6 ES + 6 EN) compile and return 200; lint clean; timeline milestones + filters intact.

**Needs your eyes** (can't verify visually from here): the pixel-perfect look at **1440 and 1920**, and the in-app Twitter/IG webview check. Optional S4 'see full breakdown' link tweak left out.