### PR TITLE
ci: Vite Doctor code-quality gate for future vibe-coding

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,7 +4,9 @@ name: Checks
 # y cada push a main en busca de bugs de framework (hidratación, reactividad,
 # SSR, secretos en config pública…). Falla SOLO ante diagnósticos `high`
 # (blockers/errors); los warnings se informan pero no bloquean. Para subir el
-# listón más adelante, añade `--max-warnings 0` al script `doctor`.
+# listón más adelante, añade `--max-warnings 0` al script `doctor`. La versión
+# de vite-doctor va FIJADA en el script (no "la última"), para que el CI corra
+# siempre exactamente la que se revisó.
 on:
   pull_request:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,30 @@
+name: Checks
+
+# Control de calidad de código para el vibe coding: Vite Doctor escanea cada PR
+# y cada push a main en busca de bugs de framework (hidratación, reactividad,
+# SSR, secretos en config pública…). Falla SOLO ante diagnósticos `high`
+# (blockers/errors); los warnings se informan pero no bloquean. Para subir el
+# listón más adelante, añade `--max-warnings 0` al script `doctor`.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  vite-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Vite Doctor (fails only on high-severity diagnostics)
+        run: pnpm doctor

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "lint:github": "oxlint --format=github",
-    "doctor": "pnpm dlx vite-doctor .",
+    "doctor": "pnpm dlx vite-doctor@0.0.2 .",
     "icons": "nuxt-seo-utils icons --source favicon.svg",
     "update-fundraiser": "tsx update-fundraiser.ts"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "lint:github": "oxlint --format=github",
+    "doctor": "pnpm dlx vite-doctor .",
     "icons": "nuxt-seo-utils icons --source favicon.svg",
     "update-fundraiser": "tsx update-fundraiser.ts"
   },


### PR DESCRIPTION
Wires **Vite Doctor** into CI so every future PR / push to `main` is scanned for the framework bugs AI agents commonly ship (hydration, reactivity, SSR, secrets in public config). Prevention, not a one-off pass.

**Scan verdict today: the site is clean** — 0 blockers, 0 errors, 0 secrets. The 31 findings are all advisory `warnings` and none are real bugs:
- The flagged *hydration* items are **false positives** — `reveal.ts` uses `window` inside a client-only directive hook (guarded), `ciencia/[slug]` formats a **fixed** content date (not `Date.now()`), `DonationReturnPrompt` reads `sessionStorage` in an event handler (not during render). `DaysWaitingCounter` wasn't even flagged.
- The rest are intentional client-side live fetches, proper nouns / legal text (`no-untranslated-text`), or **dynamically-used** i18n keys falsely reported as unused (`$t(\`nav.${item.key}\`)`).

So nothing was changed in the app/components (touching working code for cosmetic warnings would add risk for no benefit). This PR is **additive only**:
- `package.json`: `doctor` script (`pnpm dlx vite-doctor .` — no lockfile change)
- `.github/workflows/checks.yml`: `pnpm install` + `pnpm doctor`

`vite-doctor .` exits non-zero **only on high-severity** diagnostics, so CI is green today and will flag a real regression the moment vibe coding introduces one. To tighten later, add `--max-warnings 0` to the `doctor` script.

Optional follow-up (not included): install the `vite-doctor/nuxt` module for local `npx nuxt doctor`.