### PR TITLE
fix(seo): serve a valid /sitemap.xml (broken by the trailing-slash redirect)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,3 +27,13 @@
   to = "/.netlify/functions/donations"
   status = 200
   force = true
+
+# SEO · /sitemap.xml no es un fichero estático (es un índice que apunta a los
+# sitemaps por idioma), así que Netlify le añadía la barra (/sitemap.xml/) y
+# servía HTML, no XML → Google no lo parseaba (declarado en robots.txt). Esta
+# regla sirve el índice válido directamente en /sitemap.xml (force gana al slash).
+[[redirects]]
+  from = "/sitemap.xml"
+  to = "/sitemap_index.xml"
+  status = 200
+  force = true


### PR DESCRIPTION
Found during an SEO health check. `robots.txt` declares `/sitemap.xml`, but that URL **301s to `/sitemap.xml/`** (Netlify's auto-slash, since it's not a static file) and serves an **HTML meta-refresh page, not XML** → Google can't parse it (it'd show as *couldn't fetch* in Search Console). It's also the `[sitemap] Failed to parse` warning seen at build.

`/sitemap_index.xml` (the real index → es-ES + en-US sitemaps) already works and is **also** listed in robots.txt, so pages are still discovered — but this fixes the broken entry.

**Fix:** a forced 200 rewrite in `netlify.toml` so `/sitemap.xml` serves the valid index directly (`force` wins over the auto-slash). One redirect block, nothing else touched.

**Verify on the deploy-preview** (this is Netlify-only behavior, not visible in a local build):
```
curl -sI <preview-url>/sitemap.xml   # expect: HTTP 200, content-type application/xml (no 301)
```

Rest of the SEO foundation audited and healthy: title/description, canonical, **hreflang es/en/x-default**, schema.org (Person/WebSite), OG, `index,follow,max-image-preview:large`, /design-system blocked.