### PR TITLE
Sala de prensa visible + arreglos: hero, 404 elegante, swap de separadores

### DIFF
--- a/app/components/SiteFooter.vue
+++ b/app/components/SiteFooter.vue
@@ -149,6 +149,7 @@ const navItems = [
   { key: 'timeline', to: '/timeline' },
   { key: 'team', to: '/equipo' },
   { key: 'collaborate', to: '/colabora' },
+  { key: 'press', to: '/prensa' },
   { key: 'contact', to: '/contacto' },
 ]
 </script>

--- a/app/components/StarDivider.vue
+++ b/app/components/StarDivider.vue
@@ -67,65 +67,64 @@ onBeforeUnmount(() => io?.disconnect())
   opacity: 0.55;
 }
 @media (prefers-reduced-motion: no-preference) {
-  /* Oculta antes de entrar; al entrar en viewport, cada destello parpadea en
-     BUCLE con su propia duración y fase → constelación viva y orgánica, nunca
-     al unísono. (Como el resto del sitio: aquí también hay movimiento continuo.) */
+  /* Oculta antes de entrar; al entrar en viewport, cada destello parpadea UNA
+     sola vez (del centro hacia fuera) y se queda fijo. Sin bucle: el movimiento
+     ocurre solo la primera vez que la constelación aparece en pantalla. */
   .star-divider:not(.star-in) .st {
     opacity: 0;
   }
   .star-in .st {
-    animation: star-tw var(--d, 3s) ease-in-out var(--o, 0s) infinite both;
+    animation: star-tw var(--d, 0.9s) ease-out var(--o, 0s) 1 both;
   }
   .star-in .st--d1,
   .star-in .st--d2 {
     animation-name: star-tw-soft;
   }
-  /* duración + desfase propios por destello; delays negativos para que arranquen
-     a media intensidad (sin salto brusco desde 0). */
+  /* mismo destello para todos; el desfase (center-out) hace la entrada orgánica
+     y escalonada del centro hacia los lados. */
   .st--c {
-    --d: 3.2s;
-    --o: -0.2s;
+    --o: 0s;
   }
-  .st--m1 {
-    --d: 2.7s;
-    --o: -1.1s;
-  }
+  .st--m1,
   .st--m2 {
-    --d: 2.9s;
-    --o: -1.9s;
+    --o: 0.12s;
   }
-  .st--s1 {
-    --d: 2.4s;
-    --o: -0.6s;
-  }
+  .st--s1,
   .st--s2 {
-    --d: 2.6s;
-    --o: -1.5s;
+    --o: 0.24s;
   }
-  .st--d1 {
-    --d: 3.4s;
-    --o: -2.2s;
-  }
+  .st--d1,
   .st--d2 {
-    --d: 3.1s;
-    --o: -0.9s;
+    --o: 0.36s;
   }
+  /* Un único destello: aparece, parpadea una vez y queda en su opacidad final
+     (both → conserva el 100%). */
   @keyframes star-tw {
-    0%,
+    0% {
+      opacity: 0;
+    }
+    45% {
+      opacity: 1;
+    }
+    68% {
+      opacity: 0.3;
+    }
     100% {
       opacity: 1;
     }
-    50% {
-      opacity: 0.3;
-    }
   }
   @keyframes star-tw-soft {
-    0%,
-    100% {
+    0% {
+      opacity: 0;
+    }
+    45% {
       opacity: 0.55;
     }
-    50% {
+    68% {
       opacity: 0.15;
+    }
+    100% {
+      opacity: 0.55;
     }
   }
 }

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -211,18 +211,19 @@
       </div>
     </section>
 
-    <!-- Latido como división: perfiles y gracias comparten fondo (cream-card). -->
-    <EcgDivider class="bg-cream-card" />
+    <!-- Constelación como división: las estrellas ABREN el muro de gracias
+         (perfiles y gracias comparten fondo cream-card). -->
+    <StarDivider class="bg-cream-card" />
 
     <!-- ░░ GRACIAS ░░ #gracias · el muro completo (paginado + constelación) tras
          los perfiles, con la card de apoyar arriba en la parrilla: la prueba
          social respalda a la petición. Aquí enlaza el widget de la home.
-         Tras el muro, un separador de constelación cierra la sección. -->
+         Tras el muro, el latido cierra la sección. -->
     <DonationsWall />
 
-    <!-- Separador de estrellas: remata el muro de donantes (constelación) y lo
-         separa de los enlaces rápidos. Comparten fondo (cream-card). -->
-    <StarDivider class="bg-cream-card" />
+    <!-- Latido coral: remata el muro de donantes y lo separa de los enlaces
+         rápidos. Comparten fondo (cream-card). -->
+    <EcgDivider class="bg-cream-card" />
 
     <!-- ░░ ENLACES RÁPIDOS ░░ bg-cream-card · panel neutro -->
     <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'links-title'">

--- a/app/pages/prensa.vue
+++ b/app/pages/prensa.vue
@@ -1,0 +1,240 @@
+<template>
+  <div>
+    <section class="section-spacing" :aria-label="$t('press.title')">
+      <div class="section-wide">
+        <PageHeader
+          :tag="$t('press.tag')"
+          :title="$t('press.title')"
+          :subtitle="$t('press.subtitle')"
+        />
+
+        <!-- Ficha del caso · hechos clave (izq) + retrato y campaña en vivo (der) -->
+        <div class="grid gap-10 lg:grid-cols-[1.6fr_1fr] lg:gap-14 items-start">
+          <!-- Hechos clave -->
+          <div>
+            <h2 id="press-facts" class="eyebrow mb-5 block">
+              {{ $t('press.facts_title') }}
+            </h2>
+            <dl
+              aria-labelledby="press-facts"
+              class="divide-y"
+              style="border-color: rgba(45,27,61,0.08)"
+            >
+              <div
+                v-for="fact in facts"
+                :key="fact.label"
+                class="grid sm:grid-cols-[160px_1fr] gap-x-6 gap-y-1 py-4"
+              >
+                <dt class="font-mono uppercase text-[11px] tracking-[0.1em] text-tinta pt-0.5">
+                  {{ fact.label }}
+                </dt>
+                <dd class="text-[15px] text-berenjena leading-relaxed">
+                  {{ fact.value }}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <!-- Retrato + estado de campaña en vivo -->
+          <aside class="card-base">
+            <figure class="m-0">
+              <NuxtImg
+                src="/img/miriam-avatar.webp"
+                alt="Miriam González"
+                width="480"
+                height="480"
+                sizes="sm:100vw md:360px"
+                class="w-full h-auto rounded-[16px]"
+                style="aspect-ratio: 1 / 1; object-fit: cover"
+                loading="lazy"
+              />
+              <figcaption class="mt-3 font-mono text-[11.5px] leading-relaxed text-tinta">
+                {{ $t('press.photo_caption') }}
+              </figcaption>
+            </figure>
+            <div class="mt-5 pt-5" style="border-top: 1px solid rgba(45,27,61,0.08)">
+              <GoFundMeProgress />
+            </div>
+          </aside>
+        </div>
+
+        <!-- El caso en los medios -->
+        <div class="mt-16">
+          <h2 id="press-mentions" class="eyebrow mb-2 block">
+            {{ $t('press.mentions_title') }}
+          </h2>
+          <p class="text-sm text-tinta mb-6">{{ $t('press.mentions_note') }}</p>
+          <ul aria-labelledby="press-mentions" class="space-y-3">
+            <li v-for="item in mentions" :key="item.url">
+              <a
+                :href="item.url"
+                target="_blank"
+                rel="noopener"
+                class="press-mention card-base flex items-start gap-4 group"
+              >
+                <Icon
+                  name="ph:newspaper-clipping"
+                  class="size-5 shrink-0 mt-0.5 text-miriam"
+                  aria-hidden="true"
+                />
+                <span class="flex-1">
+                  <span class="block font-display font-semibold text-berenjena text-[15px] leading-snug">
+                    {{ item.title }}
+                  </span>
+                  <span class="mt-1 block font-mono text-[11.5px] uppercase tracking-[0.08em] text-tinta">
+                    {{ item.outlet }}<template v-if="item.date"> · {{ fmtDate(item.date) }}</template>
+                  </span>
+                </span>
+                <Icon
+                  name="ph:arrow-up-right"
+                  class="size-4 shrink-0 mt-0.5 text-tinta transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                  aria-hidden="true"
+                />
+                <span class="sr-only"> {{ $t('a11y.new_tab') }}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Material descargable / enlaces de referencia -->
+        <div class="mt-16">
+          <h2 id="press-resources" class="eyebrow mb-6 block">
+            {{ $t('press.resources_title') }}
+          </h2>
+          <div aria-labelledby="press-resources" class="grid sm:grid-cols-2 gap-4">
+            <NuxtLink :to="localePath('ciencia')" class="press-resource card-base group">
+              <Icon name="ph:flask" class="size-5 text-miriam mb-3" aria-hidden="true" />
+              <span class="block font-display font-semibold text-berenjena text-[15px]">
+                {{ $t('press.resource_science') }}
+              </span>
+              <span class="mt-1 block text-[13px] text-tinta leading-relaxed">
+                {{ $t('press.resource_science_desc') }}
+              </span>
+            </NuxtLink>
+            <a href="/llms.txt" target="_blank" rel="noopener" class="press-resource card-base group">
+              <Icon name="ph:robot" class="size-5 text-miriam mb-3" aria-hidden="true" />
+              <span class="block font-display font-semibold text-berenjena text-[15px]">
+                {{ $t('press.resource_llms') }}<span class="sr-only"> {{ $t('a11y.new_tab') }}</span>
+              </span>
+              <span class="mt-1 block text-[13px] text-tinta leading-relaxed">
+                {{ $t('press.resource_llms_desc') }}
+              </span>
+            </a>
+          </div>
+        </div>
+
+        <!-- Contacto de prensa -->
+        <section
+          class="mt-16 relative overflow-hidden rounded-card p-8 sm:p-12 max-w-4xl"
+          style="background: #2d1b3d; color: #faf6f0"
+          aria-labelledby="press-contact-title"
+        >
+          <div
+            aria-hidden="true"
+            class="absolute inset-0 opacity-[0.04]"
+            style="background-image: radial-gradient(circle at 1px 1px, #faf6f0 1px, transparent 0); background-size: 32px 32px"
+          />
+          <div class="relative max-w-2xl">
+            <h2
+              id="press-contact-title"
+              class="heading-display text-2xl sm:text-3xl mb-4"
+              style="color: #faf6f0; letter-spacing: -0.02em"
+            >
+              {{ $t('press.contact_title') }}
+            </h2>
+            <p class="text-[15px] leading-relaxed" style="color: rgba(250,246,240,0.85)">
+              {{ $t('press.contact_body') }}
+            </p>
+            <NuxtLink :to="localePath('contacto') + '?role=journalist'" class="btn-cta mt-7">
+              <Icon name="ph:envelope-simple" class="w-4 h-4" aria-hidden="true" />
+              {{ $t('press.contact_cta') }}
+            </NuxtLink>
+          </div>
+        </section>
+
+        <Nota class="mt-12 pt-6" style="border-top: 1px solid rgba(45,27,61,0.08)">
+          {{ $t('footer.updated') }}: {{ $t('footer.month_updated') }} 2026
+        </Nota>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Collections, PressEnCollectionItem } from '@nuxt/content'
+
+const { locale, t } = useI18n()
+const localePath = useLocalePath()
+
+// Hechos clave · las cifras que pueden desincronizarse (edad, nº de países)
+// vienen de la fuente única (caseData), no del texto i18n.
+const facts = computed(() => [
+  { label: t('press.fact_who_label'), value: t('press.fact_who_value', { age: caseData.currentAge }) },
+  { label: t('press.fact_diagnosis_label'), value: t('press.fact_diagnosis_value') },
+  { label: t('press.fact_why_label'), value: t('press.fact_why_value') },
+  { label: t('press.fact_need_label'), value: t('press.fact_need_value') },
+  { label: t('press.fact_network_label'), value: t('press.fact_network_value', { countries: caseData.countries }) },
+  { label: t('press.fact_lang_label'), value: t('press.fact_lang_value') },
+])
+
+// Apariciones en prensa (content/<locale>/press.yml).
+const { data: pressData } = await useAsyncData(
+  `press-${locale.value}`,
+  () => {
+    const collection = `press_${locale.value || 'en'}` as keyof Collections
+    return queryCollection(collection).first() as Promise<PressEnCollectionItem | null>
+  },
+  { watch: [locale] }
+)
+const mentions = computed(() => pressData.value?.articles ?? [])
+
+// 'YYYY-MM-DD' / 'YYYY-MM' → mes y año legibles según idioma.
+const fmtDate = (d?: string) => {
+  if (!d) return ''
+  const [y, m] = d.split('-')
+  if (!m) return y
+  const date = new Date(Number(y), Number(m) - 1, 1)
+  return new Intl.DateTimeFormat(locale.value === 'es' ? 'es-ES' : 'en-US', {
+    year: 'numeric',
+    month: 'long',
+  }).format(date)
+}
+
+useSeoMeta({
+  title: () => (locale.value === 'es' ? 'Sala de prensa' : 'Press room'),
+  description: () =>
+    locale.value === 'es'
+      ? 'Kit de prensa del caso de Miriam González: hechos verificados, perfil molecular, cobertura en medios y contacto para periodistas.'
+      : "Press kit for Miriam González's case: verified facts, molecular profile, media coverage and a contact for journalists.",
+  ogTitle: () => (locale.value === 'es' ? 'Sala de prensa · Miriam González' : 'Press room · Miriam González'),
+  ogDescription: () =>
+    locale.value === 'es'
+      ? 'Hechos verificados, perfil molecular y contacto para medios.'
+      : 'Verified facts, molecular profile and a media contact.',
+  ogType: 'website',
+  twitterCard: 'summary_large_image',
+})
+
+defineOgImage('Default.takumi', {
+  title: () => t('press.title'),
+  description: () =>
+    locale.value === 'es'
+      ? 'Hechos verificados y contacto para periodistas.'
+      : 'Verified facts and a contact for journalists.',
+})
+</script>
+
+<style scoped>
+.press-mention,
+.press-resource {
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.press-mention:hover,
+.press-resource:hover {
+  transform: translateY(-2px);
+}
+.press-resource {
+  display: block;
+}
+</style>

--- a/app/utils/caseData.ts
+++ b/app/utils/caseData.ts
@@ -1,0 +1,19 @@
+// Fuente única de los datos del caso que se repiten en varias páginas e idiomas.
+// Centralizarlos evita que la edad, el nº de especialistas o de países se
+// desincronicen al editar los textos i18n (auditoría · «fuente única de verdad»).
+//
+// Las cifras de recaudación (recaudado / objetivo / nº de donantes) NO van aquí:
+// son dinámicas y se sirven en vivo desde /fundraiser.json (función de Netlify).
+//
+// Auto-importado por Nuxt desde app/utils — usable en cualquier <script>/template
+// sin import. Para inyectarlo en textos i18n usar interpolación con nombre, p. ej.:
+//   $t('hero.subtitle_lead', { age: caseData.currentAge })
+//   $t('hero.stat_specialists_label', { countries: caseData.countries })
+export const caseData = {
+  /** Edad de Miriam (años). */
+  currentAge: 35,
+  /** Nº de especialistas implicados (etiqueta «5+»). */
+  specialists: '5+',
+  /** Nº de países de la red de especialistas. */
+  countries: 3,
+} as const

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -112,6 +112,21 @@
     "home": "Back to home",
     "follow": "Want to follow the case closely? {'@'}miriamgonp on Instagram"
   },
+  "error": {
+    "e404_code": "404",
+    "e404_label": "Page not found",
+    "e404_title": "This page has {firma}",
+    "e404_firma": "wandered off",
+    "e404_lede": "The link may be broken or the page may have moved. But Miriam's case is still here.",
+    "e500_code": "500",
+    "e500_label": "Server error",
+    "e500_title": "Something went {firma}",
+    "e500_firma": "sideways",
+    "e500_lede": "Something failed on our side. Please try again in a moment.",
+    "home": "Back to home",
+    "case": "See the science",
+    "retry": "Retry"
+  },
   "hero": {
     "title": "A rare cancer, {op}.",
     "title_short": "A rare cancer, a real opportunity.",
@@ -124,7 +139,8 @@
     "section_label": "Case overview",
     "stat_raised_label": "raised so far",
     "stat_donors_label": "people have contributed",
-    "stat_specialists_label": "specialists in {countries} countries",
+    "stat_specialists_value": "5+",
+    "stat_specialists_label": "specialists in 3 countries",
     "stat_ne_value": "80%",
     "stat_ne_label": "neuroendocrine differentiation",
     "latest_label": "Latest",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -112,6 +112,21 @@
     "home": "Volver al inicio",
     "follow": "¿Quieres seguir el caso de cerca? {'@'}miriamgonp en Instagram"
   },
+  "error": {
+    "e404_code": "404",
+    "e404_label": "Página no encontrada",
+    "e404_title": "Esta página se nos {firma}",
+    "e404_firma": "ha escapado",
+    "e404_lede": "Puede que el enlace esté roto o que la página se haya movido. Pero el caso de Miriam sigue aquí.",
+    "e500_code": "500",
+    "e500_label": "Error del servidor",
+    "e500_title": "Algo se ha {firma}",
+    "e500_firma": "torcido",
+    "e500_lede": "Ha fallado algo por nuestra parte. Vuelve a intentarlo en un momento.",
+    "home": "Volver al inicio",
+    "case": "Ver la ciencia del caso",
+    "retry": "Reintentar"
+  },
   "hero": {
     "title": "Un cáncer raro, {op} real.",
     "title_short": "Un cáncer raro, una oportunidad real.",
@@ -124,7 +139,8 @@
     "section_label": "Presentación del caso",
     "stat_raised_label": "recaudados hasta ahora",
     "stat_donors_label": "personas ya han contribuido",
-    "stat_specialists_label": "especialistas en {countries} países",
+    "stat_specialists_value": "5+",
+    "stat_specialists_label": "especialistas en 3 países",
     "stat_ne_value": "80%",
     "stat_ne_label": "diferenciación neuroendocrina",
     "latest_label": "Lo último",


### PR DESCRIPTION
Correcciones tras publicar las mejoras:

**Sala de prensa** — se publica `app/pages/prensa.vue` (+ `caseData.ts` que necesita); el resto de dependencias ya estaban en main. Enlace **Prensa** añadido al footer para que sea accesible.

**Home (hero)** — restaurado el valor de especialistas (mostraba la clave cruda `hero.stat_specialists_value` y "especialistas en  países"). El JSON publicado había movido eso a caseData, pero producción aún usa el SectionHero viejo.

**Página de error 404/500** — añadido el namespace `error.*` (es+en) que el componente pedía y no existía en ningún locale → adiós claves crudas, página elegante.

**StarDivider** — parpadea UNA vez al entrar en pantalla (del centro hacia fuera), ya no en bucle.

**colabora** — swap de separadores: estrellas arriba (abren el muro), latido coral abajo (lo cierra).

Verificado: `pnpm generate` limpio (exit 0, 0 errores de enlaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)