### PR TITLE
Eventos de campaña en Umami (Donar, Compartir, Clic-prensa, Contacto-enviado)

### DIFF
--- a/app/composables/useSupport.ts
+++ b/app/composables/useSupport.ts
@@ -29,6 +29,8 @@ export function useSupport() {
 
   function trackSupport(location: string) {
     fire('Apoyar', location)
+    // Umami (convivencia con Plausible): «Donar» con el botón como propiedad.
+    trackUmami('Donar', { location })
     // Marca para el aviso suave al volver de GoFundMe (DonationReturnPrompt).
     try {
       sessionStorage.setItem('hm_support_ts', String(Date.now()))

--- a/app/pages/contacto.vue
+++ b/app/pages/contacto.vue
@@ -280,6 +280,7 @@ async function onSubmit(e: Event) {
       body,
     })
     sent.value = true
+    trackUmami('Contacto-enviado', { rol: role.value || 'otro' })
   } catch {
     failed.value = true
   } finally {

--- a/app/pages/gracias.vue
+++ b/app/pages/gracias.vue
@@ -67,6 +67,7 @@ async function share() {
   if (navigator.share) {
     try {
       await navigator.share(data)
+      trackUmami('Compartir', { metodo: 'nativo', desde: 'gracias' })
     } catch {
       /* usuario canceló — sin acción */
     }
@@ -74,6 +75,7 @@ async function share() {
     try {
       await navigator.clipboard.writeText(url)
       copied.value = true
+      trackUmami('Compartir', { metodo: 'copiar', desde: 'gracias' })
       setTimeout(() => (copied.value = false), 2500)
     } catch {
       /* sin clipboard — sin acción */

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -388,18 +388,24 @@
             :href="elPaisUrl"
             target="_blank"
             rel="noopener"
+            data-umami-event="Clic-prensa"
+            data-umami-event-medio="El País"
             class="link-logo text-2xl sm:text-3xl"
           >El País<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
           <a
             :href="murciaUrl"
             target="_blank"
             rel="noopener"
+            data-umami-event="Clic-prensa"
+            data-umami-event-medio="La Opinión de Murcia"
             class="link-logo text-2xl sm:text-3xl"
           >La Opinión de Murcia<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
           <a
             :href="la7Url"
             target="_blank"
             rel="noopener"
+            data-umami-event="Clic-prensa"
+            data-umami-event-medio="La 7"
             class="link-logo text-2xl sm:text-3xl"
           >La 7<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
           <NuxtLink
@@ -449,6 +455,7 @@ const shareCase = async () => {
   if (typeof navigator !== 'undefined' && navigator.share) {
     try {
       await navigator.share({ title, url })
+      trackUmami('Compartir', { metodo: 'nativo' })
       return
     } catch {
       /* user cancelled */
@@ -456,6 +463,7 @@ const shareCase = async () => {
   }
   if (typeof navigator !== 'undefined' && navigator.clipboard) {
     await navigator.clipboard.writeText(url)
+    trackUmami('Compartir', { metodo: 'copiar' })
   }
 }
 

--- a/app/pages/prensa.vue
+++ b/app/pages/prensa.vue
@@ -70,6 +70,8 @@
                 :href="item.url"
                 target="_blank"
                 rel="noopener"
+                data-umami-event="Clic-prensa"
+                :data-umami-event-medio="item.outlet"
                 class="press-mention card-base flex items-start gap-4 group"
               >
                 <Icon

--- a/app/utils/umami.ts
+++ b/app/utils/umami.ts
@@ -1,0 +1,10 @@
+// Tracking de eventos de Umami (analytics). Seguro en SSR y si el script aún
+// no ha cargado (defer): si `window.umami` no existe, no hace nada. Convive con
+// Plausible (ver useSupport.ts) — cada acción puede disparar ambos.
+export function trackUmami(event: string, data?: Record<string, string | number | boolean>) {
+  if (!import.meta.client) return
+  const w = window as unknown as {
+    umami?: { track: (event: string, data?: Record<string, unknown>) => void }
+  }
+  w.umami?.track(event, data)
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -48,11 +48,15 @@ export default defineNuxtConfig({
         { name: 'theme-color', content: '#faf6f0' },
       ],
       // Analítica Umami (privada, sin cookies). Convive con Plausible.
+      // data-domains: solo envía desde el dominio real (no localhost/previews).
+      // data-performance: recoge Core Web Vitals reales de los visitantes.
       script: [
         {
           src: 'https://cloud.umami.is/script.js',
           defer: true,
           'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
+          'data-domains': 'helpmiriam.com',
+          'data-performance': 'true',
         },
       ],
     },


### PR DESCRIPTION
Aplica la guía de Umami; **Plausible se mantiene** (convivencia).

- `nuxt.config`: `data-domains=helpmiriam.com` (fuera tráfico de localhost/previews) + `data-performance=true` (Core Web Vitals).
- `app/utils/umami.ts`: helper `trackUmami()` (seguro en SSR).
- **Donar**: en `useSupport.trackSupport` junto al `Apoyar` de Plausible → cubre los 3+ botones de GoFundMe.
- **Compartir**: en el share nativo de la home y de /gracias.
- **Contacto-enviado**: al enviar el formulario con éxito (con el rol).
- **Clic-prensa**: tira de medios de la home + menciones de /prensa.

No añadidos por no existir en el sitio: Colaborar-marca (la CTA de empresas no se renderiza) y Descarga-documento (no hay PDFs).

Verificado: oxlint limpio, `pnpm generate` limpio (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)