### PR TITLE
Quitar URLs duplicadas: servir sin barra final (de-dup de páginas en analítica)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -114,6 +114,12 @@ export default defineNuxtConfig({
       // crawlLinks lo descubre desde /colabora, intenta prerenderizarlo, da 404
       // y aborta el build. Lo ignoramos: el archivo estático se copia igual.
       ignore: ['/design-system'],
+      // URLs SIN barra final, coherentes con los links y el canonical del sitio
+      // (que ya usan «/colabora», no «/colabora/»). Genera «colabora.html» en
+      // vez de «colabora/index.html», así Netlify sirve «/colabora» directo sin
+      // redirigir a «/colabora/». Evita que la analítica (Umami) cuente cada
+      // página dos veces (/x y /x/) y arregla el desajuste canonical↔URL servida.
+      autoSubfolderIndex: false,
     },
   },
 })


### PR DESCRIPTION
Umami contaba cada página dos veces: `/colabora` (navegación interna + canonical) y `/colabora/` (carga directa, por la redirección 301 de Netlify).

`nitro.prerender.autoSubfolderIndex: false` hace que Nuxt genere `colabora.html` en vez de `colabora/index.html`, así Netlify sirve `/colabora` directo (sin barra), coherente con los links, el canonical, el og:url y el sitemap (que ya iban sin barra). Las tools estáticas de `public/` (informe, design-system, analisis-de-lesiones) siguen siendo carpetas.

Verificado en build: HTML flat, sin index.html que compita, sitemap+canonical sin barra, `pnpm generate` limpio (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)