### PR TITLE
Umami recorder.js (Replays + Heatmaps)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,7 +47,10 @@ export default defineNuxtConfig({
       meta: [
         { name: 'theme-color', content: '#faf6f0' },
       ],
-      // Analítica Umami (privada, sin cookies). Convive con Plausible.
+      // Analítica Umami (privada, sin cookies). Convive con Plausible. Ambos
+      // scripts viven AQUÍ (no por «Snippet injection» de Netlify): si se añade
+      // el snippet además de esto, script.js se cargaría dos veces y se
+      // duplicarían las visitas. Mantener una sola fuente: el repo.
       // data-domains: solo envía desde el dominio real (no localhost/previews).
       // data-performance: recoge Core Web Vitals reales de los visitantes.
       script: [
@@ -57,6 +60,13 @@ export default defineNuxtConfig({
           'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
           'data-domains': 'helpmiriam.com',
           'data-performance': 'true',
+        },
+        // recorder.js · Replays + Heatmaps (plan Business). Se activan/desactivan
+        // desde Umami → Settings; aquí solo se carga el grabador.
+        {
+          src: 'https://cloud.umami.is/recorder.js',
+          defer: true,
+          'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
         },
       ],
     },


### PR DESCRIPTION
Añade `recorder.js` de Umami junto al `script.js` existente, ambos en `nuxt.config` (una sola fuente — NO por Snippet injection de Netlify, para no cargar `script.js` dos veces). Activa Replays + Heatmaps (plan Business).

`Donar` ya se dispara una vez en producción (#50) y `script.js` carga una vez — no hace falta reconciliar nada aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)