### PR TITLE
Umami: disparar VerCiencia (faltaba en producción)

### DIFF
--- a/app/composables/useSupport.ts
+++ b/app/composables/useSupport.ts
@@ -43,6 +43,9 @@ export function useSupport() {
   // embudo más allá del clic del héroe. No toca el goal «Apoyar».
   function trackScience(location: string) {
     fire('VerCiencia', location)
+    // Umami (convivencia con Plausible): mismo evento «VerCiencia», con el botón
+    // como propiedad. Mismo patrón que «Donar» en trackSupport.
+    trackUmami('VerCiencia', { location })
   }
 
   return { GOFUNDME_URL, trackSupport, trackScience }


### PR DESCRIPTION
`trackScience` ya disparaba el goal `VerCiencia` de Plausible pero no el de Umami. Añade `trackUmami("VerCiencia", { location })` al lado (mismo patrón que `Donar`). Único disparo, sin duplicar. Plausible intacto.

Cierra el único evento Umami que faltaba en producción (Donar y Clic-prensa ya estaban desde #50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)