### PR TITLE
Fix: la edad desaparecía en el hero (Miriam, años)

### DIFF
--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -85,7 +85,7 @@
             style="animation-delay: 0.2s"
           >
             <template #lead>
-              <strong class="font-semibold text-berenjena">{{ $t('hero.subtitle_lead') }}</strong>
+              <strong class="font-semibold text-berenjena">{{ $t('hero.subtitle_lead', { age: caseData.currentAge }) }}</strong>
             </template>
             <template #twofaces>
               <!-- «dos caras»: un trazo a mano (como las anotaciones de la


### PR DESCRIPTION
`SectionHero` llamaba `$t("hero.subtitle_lead")` sin pasar `{age}`, así que el hero decía "Miriam,  años," sin la edad. Ahora pasa `caseData.currentAge` (la fuente única). Bug pre-existente.

Verificado: `pnpm generate` exit 0, el home renderiza "Miriam, 35 años".

🤖 Generated with [Claude Code](https://claude.com/claude-code)