### PR TITLE
Contador: «días sin tratamiento»

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -36,8 +36,8 @@
     "dismiss": "Close"
   },
   "counter": {
-    "label": "days waiting for a new line of treatment",
-    "short": "days without a new line"
+    "label": "days without treatment",
+    "short": "days without treatment"
   },
   "thanksWall": {
     "eyebrow": "Thank you",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -36,8 +36,8 @@
     "dismiss": "Cerrar"
   },
   "counter": {
-    "label": "días esperando una nueva línea de tratamiento",
-    "short": "días sin nueva línea"
+    "label": "días sin tratamiento",
+    "short": "días sin tratamiento"
   },
   "thanksWall": {
     "eyebrow": "Gracias",


### PR DESCRIPTION
Etiqueta del contador → «días sin tratamiento» (antes «sin nueva línea»). El número no cambia: cuenta desde 2026-03-30 (retirada de abemaciclib) = 76 hoy. ES+EN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)