### PR TITLE
Consistencia clínica: 73 días, fechas ECOG, errata

### DIFF
--- a/app/components/Term.vue
+++ b/app/components/Term.vue
@@ -133,11 +133,11 @@ const GLOSSARY: Record<string, Entry> = {
   ecog: {
     es: {
       label: 'ECOG 1',
-      def: 'Escala ECOG: 0 desde el diagnóstico (enero 2024) hasta el 01/04/2026; 1 desde el 30/04/2026 (aumento del dolor óseo en cadera, capacidad funcional conservada).',
+      def: 'Escala ECOG: 0 desde el diagnóstico (enero 2024) hasta abril de 2026; 1 desde entonces (aumento del dolor óseo en cadera, capacidad funcional conservada).',
     },
     en: {
       label: 'ECOG 1',
-      def: 'ECOG scale: 0 from diagnosis (January 2024) until 01 Apr 2026; 1 since 30 Apr 2026 (increased hip bone pain, preserved functional capacity).',
+      def: 'ECOG scale: 0 from diagnosis (January 2024) until April 2026; 1 since then (increased hip bone pain, preserved functional capacity).',
     },
   },
   ki67: {

--- a/content/en/timeline.yml
+++ b/content/en/timeline.yml
@@ -213,7 +213,7 @@ entries:
     tag: Progression
     title: A lesion threatening the spinal cord, and urgent radiotherapy
     description: >
-      A follow-up MRI, after 60 days without treatment, shows clear bone progression and, above
+      A follow-up MRI, after 73 days without treatment, shows clear bone progression and, above
       all, a lesion in the T11 vertebra starting to threaten the spinal canal: the risk of cord
       compression is real. Urgent SBRT radiotherapy is scheduled to shrink the lesion and protect
       the spinal cord.

--- a/content/es/timeline.yml
+++ b/content/es/timeline.yml
@@ -47,7 +47,7 @@ entries:
       La estancia total supera los 50 días. Fue el momento más grave desde el diagnóstico.
     highlight: true
     image: /img/hospital.webp
-    imageAlt: "Miriam en la UCI durante su ingreso hospitalario. Entubada pero divina, haciendose el skincare"
+    imageAlt: "Miriam en la UCI durante su ingreso hospitalario. Entubada pero divina, haciéndose el skincare"
 
   - date: 'jul 2024'
     tag: Molecular
@@ -215,7 +215,7 @@ entries:
     tag: Progresión
     title: Una lesión que amenaza la médula y radioterapia de urgencia
     description: >
-      Una resonancia de control, tras 60 días sin tratamiento, muestra progresión ósea clara y,
+      Una resonancia de control, tras 73 días sin tratamiento, muestra progresión ósea clara y,
       sobre todo, una lesión en la vértebra D11 que empieza a amenazar el canal medular: el riesgo
       de compresión medular es real. Se programa radioterapia SBRT de urgencia para reducir la
       lesión y proteger la médula.


### PR DESCRIPTION
De la auditoría clínica:
- Cronología 11 jun: «60 días sin tratamiento» → «73» (30/03 abemaciclib → 11 jun = 73 días; cuadra con el contador).
- Tooltip ECOG: tenía un hueco imposible (0 hasta 01/04; 1 desde 30/04). Lo dejo en «hasta abril de 2026; 1 desde entonces» — sin inventar la fecha exacta de transición.
- Errata «haciendose» → «haciéndose».

🤖 Generated with [Claude Code](https://claude.com/claude-code)