### PR TITLE
Privacidad: desactivar session replays de Umami + declarar analítica (RGPD)

### DIFF
--- a/app/pages/cookies.vue
+++ b/app/pages/cookies.vue
@@ -5,7 +5,7 @@
       Política de cookies
     </h1>
     <p class="font-mono text-xs text-tinta mb-8">
-      Última actualización · 6 de junio de 2026
+      Última actualización · 14 de junio de 2026
     </p>
 
     <article class="prose prose-ink max-w-none">
@@ -15,7 +15,7 @@
       <h2>2 · Cookies que usamos</h2>
       <ul>
         <li><strong>Técnicas / necesarias:</strong> recordar tu <strong>idioma</strong> (cookie <code>i18n_redirected</code>). Imprescindibles para el funcionamiento; no requieren consentimiento.</li>
-        <li><strong>Analítica sin cookies:</strong> usamos Plausible Analytics, que mide visitas de forma agregada y <strong>no instala cookies ni rastrea</strong> a personas individuales.</li>
+        <li><strong>Analítica sin cookies:</strong> usamos Plausible Analytics y Umami, que miden visitas de forma agregada y <strong>no instalan cookies ni rastrean</strong> a personas individuales.</li>
         <li><strong>De terceros:</strong> al pulsar enlaces externos (GoFundMe, redes sociales) esos sitios pueden instalar sus propias cookies, regidas por sus políticas.</li>
       </ul>
 

--- a/app/pages/privacidad.vue
+++ b/app/pages/privacidad.vue
@@ -5,7 +5,7 @@
       Política de privacidad
     </h1>
     <p class="font-mono text-xs text-tinta mb-8">
-      Última actualización · 6 de junio de 2026
+      Última actualización · 14 de junio de 2026
     </p>
 
     <div class="alert-callout mb-10">
@@ -38,7 +38,7 @@
       <p>No vendemos ni cedemos tus datos, salvo obligación legal. Empleamos proveedores que actúan como encargados del tratamiento (art. 28 RGPD):</p>
       <ul>
         <li><strong>Netlify, Inc.</strong> (EE. UU., con cláusulas contractuales tipo) — alojamiento del sitio y gestión del formulario de contacto (Netlify Forms).</li>
-        <li><strong>Plausible Analytics</strong> (UE) — analítica de visitas agregada, <strong>sin cookies</strong> y sin rastreo individual.</li>
+        <li><strong>Plausible Analytics</strong> (UE) y <strong>Umami Cloud</strong> (UE) — analítica de visitas agregada, <strong>sin cookies</strong> y sin rastreo individual.</li>
         <li><strong>GoFundMe</strong> — plataforma de donación; los datos de pago se rigen por su propia política.</li>
       </ul>
       <p>Las tipografías se sirven <strong>desde nuestro propio dominio</strong> (auto-alojadas): no se cargan desde servidores de terceros ni se transfiere tu dirección IP a Google.</p>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,12 +47,16 @@ export default defineNuxtConfig({
       meta: [
         { name: 'theme-color', content: '#faf6f0' },
       ],
-      // Analítica Umami (privada, sin cookies). Convive con Plausible. Ambos
-      // scripts viven AQUÍ (no por «Snippet injection» de Netlify): si se añade
-      // el snippet además de esto, script.js se cargaría dos veces y se
-      // duplicarían las visitas. Mantener una sola fuente: el repo.
+      // Analítica Umami (privada, SIN cookies, agregada). Convive con Plausible.
+      // Vive AQUÍ (no por «Snippet injection» de Netlify): si se añade el snippet
+      // además de esto, script.js se cargaría dos veces y se duplicarían las
+      // visitas. Mantener una sola fuente: el repo.
       // data-domains: solo envía desde el dominio real (no localhost/previews).
       // data-performance: recoge Core Web Vitals reales de los visitantes.
+      // NOTA RGPD: NO se carga el recorder.js (session replays + heatmaps). En un
+      // sitio de salud, grabar sesiones individuales requeriría consentimiento;
+      // por eso solo usamos analítica cookieless y agregada, sin banner. Si algún
+      // día se quieren replays, hay que añadir un flujo de consentimiento primero.
       script: [
         {
           src: 'https://cloud.umami.is/script.js',
@@ -60,13 +64,6 @@ export default defineNuxtConfig({
           'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
           'data-domains': 'helpmiriam.com',
           'data-performance': 'true',
-        },
-        // recorder.js · Replays + Heatmaps (plan Business). Se activan/desactivan
-        // desde Umami → Settings; aquí solo se carga el grabador.
-        {
-          src: 'https://cloud.umami.is/recorder.js',
-          defer: true,
-          'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
         },
       ],
     },


### PR DESCRIPTION
La política decía «Plausible, sin cookies, sin rastreo individual», pero el `recorder.js` de Umami (replays + heatmaps) estaba vivo y graba sesiones individuales — en un sitio de salud sin flujo de consentimiento, es la parte sensible del RGPD.

Postura limpia, sin banner (coherente con la web): quito `recorder.js` (replays/heatmaps fuera), mantengo la analítica cookieless (Umami script.js + Plausible: visitas, eventos, Web Vitals), y declaro Umami en ambas políticas → «sin rastreo individual» vuelve a ser verdad. Reversible si algún día se quieren replays con consentimiento.

Verificado: generate exit 0, recorder.js fuera del HTML, script.js intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)