### PR TITLE
fix(diseño): pulido visual — nodo del timeline centrado y "Lo que NO somos" sin muro de ✗

### DIFF
--- a/app/components/TimelineEntry.vue
+++ b/app/components/TimelineEntry.vue
@@ -4,7 +4,7 @@
          destacado late en coral. `echo` = doble pulso de saludo al aterrizar
          desde "Lo último" del hero. -->
     <div
-      class="tl-dot absolute left-0 top-1.5 w-[23px] h-[23px] rounded-full flex items-center justify-center transition-transform duration-200 group-hover:scale-110"
+      class="tl-dot absolute left-0 top-1.5 w-[22px] h-[22px] rounded-full flex items-center justify-center transition-transform duration-200 group-hover:scale-110"
       :class="{ 'tl-dot-live': live, 'tl-dot-echo': echo }"
       :style="dotStyle"
     >

--- a/app/pages/equipo.vue
+++ b/app/pages/equipo.vue
@@ -74,19 +74,19 @@
 
             <ul class="space-y-4">
               <li
-                v-for="(item, i) in notUsList"
+                v-for="(item, i) in notUsItems"
                 :key="i"
-                class="flex items-start gap-4 text-[15px] leading-relaxed"
-                style="color: rgba(250,246,240,0.9)"
+                class="flex items-start gap-3.5 text-[15px] leading-relaxed"
               >
                 <span
-                  class="shrink-0 mt-0.5 inline-flex items-center justify-center w-[22px] h-[22px] rounded-md"
-                  style="background: rgba(255,107,71,0.18)"
+                  class="shrink-0 mt-[11px] h-[2px] w-3.5 rounded-full"
+                  style="background: rgba(255,107,71,0.7)"
                   aria-hidden="true"
+                />
+                <span style="color: rgba(250,246,240,0.72)"
+                  ><strong class="font-semibold" style="color: #faf6f0">{{ item.lead }}</strong
+                  >{{ item.rest ? ' ' + item.rest : '' }}</span
                 >
-                  <Icon name="ph:x-bold" class="w-3.5 h-3.5 text-coral" />
-                </span>
-                <span>{{ item }}</span>
               </li>
             </ul>
 
@@ -134,6 +134,17 @@ function arr(key: string): string[] {
   return list.map((item) => rt(item as never))
 }
 const notUsList = computed(() => arr('team.notus_list'))
+
+// "Lo que NO somos": separa la frase-tesis de su explicación para destacarla en
+// negrita y sustituir el muro de iconos ✗ repetidos por jerarquía tipográfica.
+const notUsItems = computed(() =>
+  notUsList.value.map((s) => {
+    const idx = s.indexOf('. ')
+    return idx === -1
+      ? { lead: s, rest: '' }
+      : { lead: s.slice(0, idx + 1), rest: s.slice(idx + 2) }
+  })
+)
 
 const { data: teamData } = await useAsyncData(
   `team-data-${locale.value}`,

--- a/app/pages/gastos.vue
+++ b/app/pages/gastos.vue
@@ -89,7 +89,7 @@
             >
               <Icon
                 name="ph:check-circle-fill"
-                class="mt-0.5 w-4 h-4 text-miriam shrink-0"
+                class="mt-[3px] w-4 h-4 text-miriam shrink-0"
                 aria-hidden="true"
               />
               <span class="text-sm text-tinta leading-relaxed">{{ $rt(item) }}</span>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -210,9 +210,9 @@
             <li
               v-for="(item, i) in $tm('home.s8_advantages')"
               :key="i"
-              class="flex items-start gap-2.5"
+              class="flex items-start gap-3"
             >
-              <Icon name="ph:check-circle-fill" class="mt-0.5 w-4 h-4 text-miriam shrink-0" aria-hidden="true" />
+              <Icon name="ph:check-circle-fill" class="mt-[3px] w-4 h-4 text-miriam shrink-0" aria-hidden="true" />
               <span class="text-sm text-tinta leading-relaxed">{{ $rt(item) }}</span>
             </li>
           </ul>
@@ -277,7 +277,7 @@
             >
               <Icon
                 name="ph:check-circle-fill"
-                class="mt-0.5 w-4 h-4 text-miriam shrink-0"
+                class="mt-[3px] w-4 h-4 text-miriam shrink-0"
                 aria-hidden="true"
               />
               <span class="text-sm text-tinta leading-relaxed">{{ $rt(item) }}</span>

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -68,7 +68,7 @@
         <div class="relative max-w-2xl">
           <span
             aria-hidden="true"
-            class="absolute left-[11px] top-2 bottom-3 w-[2px] rounded-full"
+            class="absolute left-[10px] top-2 bottom-3 w-[2px] rounded-full"
             style="background: linear-gradient(180deg, #a44db2 0%, rgba(164,77,178,0.15) 100%)"
           />
           <!-- key=selected → al filtrar, el bloque se remonta y reproduce un fundido


### PR DESCRIPTION
Pasada de control de calidad visual a partir de dos defectos que el equipo detectó (cosas que "dan toc" de ver). Mi experto en diseño barrió todo el código buscando **este mismo tipo de defecto** (alineación/consistencia, no estilo). El código está muy limpio: solo había un bug real + un muro de iconos + un par de nimiedades de ritmo.

### Arreglos

| # | Dónde | Defecto | Sev |
|---|---|---|---|
| 1 | Timeline (nodo/raíl) | el punto iba **0,5px descentrado** respecto a la línea → "el raíl salía torcido de cada nodo". Punto 23→22px y raíl `left-11`→`left-10`: ambos a centro x=11px, entero, sin medio píxel borroso | **alto** |
| 2 | Equipo · "Lo que NO somos" | **muro de 5 ✗ coral** idénticos = parecía lista de errores. Ahora jerarquía tipográfica: tesis en negrita + guion coral discreto que refuerza el "no" sin alarmar | **medio** |
| 3 | Home · ventajas | `gap` de 10px donde el resto usa 12px → unificado | bajo |
| 4 | Home/Gastos · checks | el icono subía ~1,4px sobre la 1ª línea → centrado óptico (`mt-0.5`→`mt-[3px]`) | bajo |

Verificado a 2x con capturas locales (nodo del timeline centrado; tarjeta del equipo limpia y con espaciado correcto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)