### PR TITLE
fix(ciencia): índice alineado con el contenido + hero sin profesión

### DIFF
--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -1,12 +1,12 @@
 <template>
   <!-- Índice de secciones del dossier clínico (modo pro de /ciencia). Comité:
-       rail pegajoso a la izquierda en lg+, desplegable «Saltar a…» en móvil;
-       etiquetas clínicas en sans bajo un único rótulo mono; activo en
-       berenjena + punto violeta (NUNCA coral, reservado al CTA); foco
+       rail pegajoso a la izquierda en lg+ (variant="rail"), desplegable
+       «Saltar a…» en móvil (variant="mobile"); etiquetas clínicas en sans bajo
+       un rótulo mono; activo en berenjena + punto violeta (NUNCA coral); foco
        gestionado al saltar y respeto por prefers-reduced-motion. -->
   <nav :aria-label="locale === 'es' ? 'Índice de secciones' : 'Section index'">
     <!-- Móvil: desplegable en el flujo (no pegajoso) -->
-    <details class="cn-m lg:hidden">
+    <details v-if="variant === 'mobile'" class="cn-m">
       <summary class="cn-m__summary">
         <Icon name="ph:list-bold" class="w-4 h-4 shrink-0" aria-hidden="true" />
         {{ locale === 'es' ? 'Saltar a una sección' : 'Jump to a section' }}
@@ -19,8 +19,8 @@
       </ul>
     </details>
 
-    <!-- Desktop: lista; el aside padre aporta el sticky -->
-    <div class="cn-d hidden lg:block">
+    <!-- Desktop: lista; el contenedor padre aporta el sticky -->
+    <div v-else class="cn-d">
       <p class="eyebrow cn-d__title">{{ locale === 'es' ? 'Índice' : 'Contents' }}</p>
       <ul>
         <li v-for="c in chapters" :key="c.id">
@@ -41,6 +41,9 @@
 </template>
 
 <script setup lang="ts">
+const props = withDefaults(defineProps<{ variant?: 'rail' | 'mobile' }>(), {
+  variant: 'rail',
+})
 const { locale } = useI18n()
 
 // 6 capítulos clínicos mapeados a ids de título ya existentes en la página
@@ -69,12 +72,12 @@ const activeId = ref('')
 let observer: IntersectionObserver | null = null
 
 onMounted(() => {
+  // El scroll-spy solo lo necesita el rail de escritorio (resalta el activo).
+  if (props.variant !== 'rail') return
   const els = chapters.value
     .map((c) => document.getElementById(c.id))
     .filter((el): el is HTMLElement => !!el)
   if (!els.length) return
-  // Scroll-spy: el capítulo se activa cuando su título entra en la banda
-  // superior del viewport. aria-current cambia como mucho una vez por sección.
   observer = new IntersectionObserver(
     (entries) => {
       for (const e of entries) {
@@ -92,8 +95,7 @@ function jumpTo(e: Event, id: string) {
   const el = document.getElementById(id)
   if (!el) return
   e.preventDefault()
-  // A11y: el foco va al título destino (no se queda perdido); respeta
-  // prefers-reduced-motion (sin scroll animado).
+  // A11y: el foco va al título destino; respeta prefers-reduced-motion.
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
   el.setAttribute('tabindex', '-1')
   el.focus({ preventScroll: true })

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -2,6 +2,18 @@
   <div>
     <section class="section-spacing" :aria-label="$t('science.title')">
       <div :class="level === 'pro' ? 'section-wide' : 'section-container'">
+        <!-- Layout pro: índice pegajoso (izq, lg+) + contenido en grid; la
+             cabecera va DENTRO de la columna de contenido para que el título
+             alinee con el cuerpo, no con el índice. En simple, sin grid. -->
+        <div
+          :class="level === 'pro' ? 'lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-12 xl:gap-16 lg:items-start' : ''"
+        >
+          <CienciaSectionNav
+            v-if="level === 'pro'"
+            variant="rail"
+            class="hidden lg:block lg:sticky lg:top-24 lg:self-start"
+          />
+          <div class="min-w-0">
         <PageHeader
           :title="$t('science.title')"
           :subtitle="headerSubtitle"
@@ -49,17 +61,9 @@
 
         <EcgDivider class="mb-12" />
 
-        <!-- Índice de secciones (solo pro): rail pegajoso a la izquierda en lg+,
-             desplegable «Saltar a…» en móvil. El grid solo se activa en pro;
-             en simple el contenido fluye a ancho completo (sin índice). -->
-        <div
-          :class="level === 'pro' ? 'lg:grid lg:grid-cols-[220px_minmax(0,1fr)] lg:gap-12 xl:gap-16 lg:items-start' : ''"
-        >
-          <CienciaSectionNav
-            v-if="level === 'pro'"
-            class="mb-8 lg:mb-0 lg:sticky lg:top-24 lg:self-start"
-          />
-          <div class="min-w-0">
+        <!-- Índice móvil: desplegable «Saltar a…» en el flujo, tras la cabecera
+             (solo pro, <lg). El rail de escritorio va arriba, junto al título. -->
+        <CienciaSectionNav v-if="level === 'pro'" variant="mobile" class="lg:hidden mb-8" />
 
         <!-- Case snapshot (médicos + tabla completa; técnico, fuera del resumen simple) -->
         <section v-show="showData" aria-labelledby="snapshot-title" class="mb-12">

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -131,7 +131,7 @@
     "title": "A rare cancer, {op}.",
     "title_short": "A rare cancer, a real opportunity.",
     "title_emphasis": "a real opportunity",
-    "subtitle": "{lead} a software engineer and science communicator, has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
+    "subtitle": "{lead} has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
     "twofaces": "two sides",
     "subtitle_lead": "Miriam, {age},",
     "cta_donate": "Support Miriam",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -131,7 +131,7 @@
     "title": "Un cáncer raro, {op} real.",
     "title_short": "Un cáncer raro, una oportunidad real.",
     "title_emphasis": "una oportunidad",
-    "subtitle": "{lead} ingeniera y divulgadora, tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
+    "subtitle": "{lead} tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
     "twofaces": "dos caras",
     "subtitle_lead": "Miriam, {age} años,",
     "cta_donate": "Apoyar a Miriam",


### PR DESCRIPTION
**Índice del modo pro:** el título y el divisor iban a ancho completo mientras el cuerpo quedaba indentado (el título parecía etiquetar el índice). Ahora la cabecera va dentro de la columna de contenido y el índice es un rail pegajoso a su izquierda desde arriba — título, toggle y cuerpo alineados (verificado: x=372 los tres, índice x=88). Móvil: el desplegable «Saltar a…» queda tras la cabecera (orden correcto).

**Hero:** se quita «ingeniera y divulgadora» del párrafo (es+en) → «Miriam, 35 años, tiene un tumor con dos caras…».

Build-verified: pnpm generate 0 errores, 0 enlaces rotos, 237 rutas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)