### PR TITLE
fix(ciencia): índice con los nombres de cada sección + fechas a 14 jun

### DIFF
--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -51,19 +51,19 @@ const { locale } = useI18n()
 const chapters = computed(() =>
   locale.value === 'es'
     ? [
-        { id: 'snapshot-title', label: 'Diagnóstico' },
+        { id: 'snapshot-title', label: 'Resumen clínico' },
         { id: 'tejido-3veces', label: 'Anatomía patológica' },
         { id: 'molecular-profile-title', label: 'Perfil molecular' },
-        { id: 'imaging-tissue-title', label: 'Imagen (PET Ga-68)' },
-        { id: 'panel-title', label: 'Rebiopsia' },
+        { id: 'imaging-tissue-title', label: 'Imagen funcional' },
+        { id: 'panel-title', label: 'El siguiente paso' },
         { id: 'treatment-title', label: 'Historia clínica' },
       ]
     : [
-        { id: 'snapshot-title', label: 'Diagnosis' },
+        { id: 'snapshot-title', label: 'Clinical summary' },
         { id: 'tejido-3veces', label: 'Pathology' },
         { id: 'molecular-profile-title', label: 'Molecular profile' },
-        { id: 'imaging-tissue-title', label: 'Imaging (Ga-68 PET)' },
-        { id: 'panel-title', label: 'Rebiopsy' },
+        { id: 'imaging-tissue-title', label: 'Functional imaging' },
+        { id: 'panel-title', label: 'The next step' },
         { id: 'treatment-title', label: 'Clinical history' },
       ]
 )

--- a/app/pages/aviso-legal.vue
+++ b/app/pages/aviso-legal.vue
@@ -5,7 +5,7 @@
       Aviso legal
     </h1>
     <p class="font-mono text-xs text-tinta mb-8">
-      Última actualización · 6 de junio de 2026
+      Última actualización · 14 de junio de 2026
     </p>
 
     <div class="alert-callout mb-10">

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -658,7 +658,7 @@
         <CaseFollowSignup class="mt-4" />
 
         <Nota class="mt-12 pt-6" style="border-top: 1px solid rgba(45,27,61,0.08)">
-          {{ locale === 'es' ? 'Última actualización: 6 de junio de 2026' : 'Last updated: 6 June 2026' }}
+          {{ locale === 'es' ? 'Última actualización: 14 de junio de 2026' : 'Last updated: 14 June 2026' }}
         </Nota>
           </div>
           <!-- /columna de contenido del dossier -->


### PR DESCRIPTION
- El índice del modo pro ahora usa exactamente el rótulo de cada sección (Resumen clínico · Anatomía patológica · Perfil molecular · Imagen funcional · El siguiente paso · Historia clínica), para que el menú se llame igual que el destino.
- Fecha de «última actualización» a 14 jun 2026 en aviso-legal y /ciencia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)