### PR TITLE
fix: safelist de los tonos pill-data (estaban purgados → tags sin color)

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,17 @@ export default {
     './content/**/*.md',
     './app.vue',
   ],
+  // Tonos de pill-data construidos dinámicamente (`pill-data--${tone}`) en las
+  // tablas clínicas (snapshot, perfil molecular, biopsia líquida, evidencia).
+  // Sin safelist, Tailwind los purga —no los ve literales— y los tags salen sin
+  // fondo (transparentes). Mantener en sync con app/assets/css/main.css.
+  safelist: [
+    'pill-data--info',
+    'pill-data--warn',
+    'pill-data--positive',
+    'pill-data--neutral',
+    'pill-data--violet',
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Las tablas clínicas (snapshot «de un vistazo», perfil molecular, biopsia líquida, evidencia) construyen la clase del tono dinámicamente (`pill-data--${tone}`). Tailwind no la ve literal y **purgaba** esas reglas → los tags salían **sin fondo (transparentes)**; solo el violeta sobrevivía (se usa literal en otra tabla). De ahí «ya no se ven tantos tags de colorins». Safelist de los 5 tonos. Verificado en el build de prod: `pill-data--warn{background:#fde4cc…}` presente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)