### PR TITLE
feat(analytics): re-enable Umami recorder.js (replays + heatmaps)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,10 +53,9 @@ export default defineNuxtConfig({
       // visitas. Mantener una sola fuente: el repo.
       // data-domains: solo envía desde el dominio real (no localhost/previews).
       // data-performance: recoge Core Web Vitals reales de los visitantes.
-      // NOTA RGPD: NO se carga el recorder.js (session replays + heatmaps). En un
-      // sitio de salud, grabar sesiones individuales requeriría consentimiento;
-      // por eso solo usamos analítica cookieless y agregada, sin banner. Si algún
-      // día se quieren replays, hay que añadir un flujo de consentimiento primero.
+      // recorder.js · Replays + Heatmaps (plan Business). Mask level «moderate» en
+      // Umami → Settings (enmascara inputs). Sample rate 100% mientras el volumen
+      // es bajo. Convive con script.js; no duplicar vía Snippet injection.
       script: [
         {
           src: 'https://cloud.umami.is/script.js',
@@ -64,6 +63,11 @@ export default defineNuxtConfig({
           'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
           'data-domains': 'helpmiriam.com',
           'data-performance': 'true',
+        },
+        {
+          src: 'https://cloud.umami.is/recorder.js',
+          defer: true,
+          'data-website-id': '30a40c53-5573-45c0-8ac9-8f0f94621ecf',
         },
       ],
     },


### PR DESCRIPTION
## Qué hace
Reactiva `recorder.js` de Umami Cloud para **Session Replays** y **Heatmaps** (plan Business).

## Contexto
- Los eventos `Donar` / `VerCiencia` ya están en producción vía `script.js` + `useSupport.ts`.
- PR #59 desactivó el recorder por privacidad; desde entonces se habilitó en el panel Umami con **mask level moderate** (enmascara inputs).
- Build verificado: `pnpm generate` OK, 0 errores de link checker.

## QA tras merge
1. Abrir https://helpmiriam.com/colabora (sin ad-blocker)
2. Consola: `typeof window.umami` → `object`
3. View source / Network: deben cargar `script.js` **y** `recorder.js`
4. Umami → Realtime → Events: clic en «Financiar» dispara `Donar` una vez
5. Umami → Sessions/Replays: grabaciones tras unos minutos de tráfico
