### PR TITLE
feat(ux): auditoría integral — caminos por persona, a11y y neurodivergencia

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -923,6 +923,244 @@
   }
 }
 
+/* ── Visitor pathways · orientación por persona ─────────────────────────── */
+.pathway-comfort {
+    display: flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    line-height: 1.55;
+    color: rgba(58, 51, 64, 0.82);
+    margin-top: 0.25rem;
+  }
+  .pathway-comfort__icon {
+    width: 14px;
+    height: 14px;
+    color: #9d44ab;
+    flex-shrink: 0;
+    align-self: center;
+  }
+
+  .pathway-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .pathway-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    padding: 1.25rem 1.35rem;
+    border-radius: 16px;
+    background: #faf6f0;
+    border: 1px solid rgba(45, 27, 61, 0.08);
+    transition: box-shadow 0.18s ease;
+  }
+  @media (hover: hover) {
+    .pathway-card:hover {
+      box-shadow: 0 10px 28px rgba(45, 27, 61, 0.08);
+    }
+  }
+  .pathway-card__head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  .pathway-card__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 10px;
+    background: rgba(164, 77, 178, 0.12);
+    color: #2d1b3d;
+  }
+  .pathway-card__time {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: rgba(58, 51, 64, 0.72);
+    white-space: nowrap;
+  }
+  .pathway-card__title {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: 1.05rem;
+    line-height: 1.25;
+    color: #2d1b3d;
+    text-wrap: balance;
+  }
+  .pathway-card__desc {
+    font-size: 0.875rem;
+    line-height: 1.55;
+    color: #3a3340;
+    flex: 1;
+  }
+  .pathway-card__steps {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    color: rgba(58, 51, 64, 0.88);
+  }
+  .pathway-card__steps li {
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+  .pathway-card__steps li::before {
+    content: '→';
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: #9d44ab;
+    flex-shrink: 0;
+  }
+  .pathway-card__cta {
+    margin-top: auto;
+    padding-top: 0.35rem;
+  }
+  .pathway-card__caption {
+    margin-top: 0.45rem;
+    font-size: 0.72rem;
+    line-height: 1.45;
+    color: rgba(58, 51, 64, 0.78);
+    min-height: 2rem;
+  }
+
+  .pathway-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .pathway-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.55rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(45, 27, 61, 0.12);
+    background: #faf6f0;
+    color: #2d1b3d;
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .pathway-chip:hover {
+    background: rgba(164, 77, 178, 0.1);
+    border-color: rgba(157, 68, 171, 0.28);
+  }
+  .pathway-chip__label {
+    white-space: nowrap;
+  }
+  .pathway-chip__time {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: rgba(58, 51, 64, 0.65);
+    margin-left: 0.1rem;
+  }
+
+  .pathway-brief__summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    cursor: pointer;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #2d1b3d;
+    list-style: none;
+    padding: 0.65rem 0;
+  }
+  .pathway-brief__summary::-webkit-details-marker {
+    display: none;
+  }
+  .pathway-brief__summary::before {
+    content: '▸';
+    color: #9d44ab;
+    transition: transform 0.15s ease;
+  }
+  .pathway-brief[open] .pathway-brief__summary::before {
+    transform: rotate(90deg);
+  }
+  .pathway-brief__badge {
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(164, 77, 178, 0.12);
+    color: #2d1b3d;
+  }
+  .pathway-brief__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .pathway-brief__list li {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: #3a3340;
+  }
+  .pathway-brief__num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 6px;
+    background: rgba(164, 77, 178, 0.14);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 700;
+    color: #2d1b3d;
+    flex-shrink: 0;
+  }
+
+  /* Alto contraste: refuerzo suave sin romper la marca */
+  @media (prefers-contrast: more) {
+    .pathway-card,
+    .pathway-chip,
+    .card-base {
+      border-color: rgba(45, 27, 61, 0.22);
+    }
+    .pathway-card__desc,
+    .pathway-comfort,
+    .nota {
+      color: #2d1b3d;
+    }
+    .btn-secondary {
+      border-width: 2.5px;
+    }
+  }
+
+@media (prefers-reduced-motion: reduce) {
+  .pathway-brief__summary::before {
+    transition: none;
+  }
+  .pathway-card {
+    transition: none;
+  }
+}
+
 /* ── Impresión ──────────────────────────────────────────────────────────────
    Pensado sobre todo para /ciencia: un oncólogo imprime el caso y se lo lleva
    al comité. Fuera el cromo de navegación; texto en negro sobre blanco; las

--- a/app/components/DonationReturnPrompt.vue
+++ b/app/components/DonationReturnPrompt.vue
@@ -98,7 +98,7 @@ onBeforeUnmount(() => document.removeEventListener('visibilitychange', maybeShow
 /* En móvil, sobre la barra de apoyo persistente. */
 @media (max-width: 639px) {
   .drp {
-    bottom: calc(72px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(88px + env(safe-area-inset-bottom, 0px));
   }
 }
 .drp__cta {

--- a/app/components/MobileSupportBar.vue
+++ b/app/components/MobileSupportBar.vue
@@ -19,6 +19,13 @@
         <Icon name="ph:heart-fill" class="heart-beat w-4 h-4" aria-hidden="true" />
         {{ $t('nav.donate') }}<span class="sr-only"> {{ $t('a11y.new_tab') }}</span>
       </a>
+      <NuxtLink
+        :to="localePath('colabora')"
+        class="mobile-support-bar__more"
+      >
+        {{ $t('a11y.more_ways') }}
+        <Icon name="ph:arrow-right" class="w-3 h-3" aria-hidden="true" />
+      </NuxtLink>
     </div>
   </Transition>
 </template>
@@ -35,6 +42,7 @@
  */
 const { y } = useWindowScroll()
 const route = useRoute()
+const localePath = useLocalePath()
 const { GOFUNDME_URL, trackSupport } = useSupport()
 
 const visible = ref(false)
@@ -82,8 +90,28 @@ onBeforeUnmount(() => {
   bottom: 0;
   z-index: 40;
   background: #2d1b3d; /* berenjena */
-  padding: 10px 16px;
-  padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+  padding: 10px 16px 8px;
+  padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
   border-top: 1px solid rgba(250, 246, 240, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+.mobile-support-bar__more {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(250, 246, 240, 0.72);
+  text-decoration: none;
+  padding-bottom: 2px;
+}
+.mobile-support-bar__more:hover {
+  color: #faf6f0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 </style>

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -2,7 +2,9 @@
   <section
     class="relative overflow-hidden bg-cream"
     :aria-label="$t('hero.section_label')"
+    :aria-describedby="'hero-sr-summary'"
   >
+    <p id="hero-sr-summary" class="sr-only">{{ $t('pathways.hero_sr_summary') }}</p>
     <div class="relative section-wide pt-7 pb-12 sm:pt-16 sm:pb-20 lg:pt-20">
       <!-- Editorial hero. Mobile-first: el orden del DOM crea el ritmo narrativo
            en móvil (título → cara → brecha → acción → en vivo). En desktop, las

--- a/app/components/VisitorPathways.vue
+++ b/app/components/VisitorPathways.vue
@@ -1,0 +1,269 @@
+<template>
+  <section
+    v-reveal
+    class="pathways"
+    :class="variant === 'home' ? 'bg-cream-card section-spacing' : ''"
+    :aria-labelledby="titleId"
+    :style="variant === 'colabora' ? '' : 'border-bottom: 1px solid rgba(45,27,61,0.08)'"
+  >
+    <div :class="variant === 'home' ? 'section-wide' : ''">
+      <p class="eyebrow mb-3 block">{{ $t('pathways.eyebrow') }}</p>
+      <h2
+        :id="titleId"
+        class="heading-display text-2xl sm:text-3xl text-berenjena mb-2"
+        style="letter-spacing: -0.02em"
+      >
+        {{ variant === 'home' ? $t('pathways.home_title') : $t('pathways.colabora_title') }}
+      </h2>
+      <p class="text-sm sm:text-base text-tinta leading-relaxed max-w-2xl mb-3">
+        {{ variant === 'home' ? $t('pathways.home_sub') : $t('pathways.colabora_sub') }}
+      </p>
+      <p class="pathway-comfort max-w-2xl" role="note">
+        <Icon name="ph:leaf" class="pathway-comfort__icon" aria-hidden="true" />
+        {{ $t('pathways.comfort') }}
+      </p>
+
+      <!-- Home: tarjetas por persona -->
+      <div
+        v-if="variant === 'home'"
+        class="pathway-grid mt-8"
+        role="list"
+        :aria-label="$t('pathways.grid_aria')"
+      >
+        <article
+          v-for="path in homePaths"
+          :key="path.id"
+          class="pathway-card"
+          role="listitem"
+        >
+          <div class="pathway-card__head">
+            <span class="pathway-card__icon" aria-hidden="true">
+              <Icon :name="path.icon" class="w-5 h-5" />
+            </span>
+            <span class="pathway-card__time">{{ path.time }}</span>
+          </div>
+          <h3 class="pathway-card__title">{{ path.title }}</h3>
+          <p class="pathway-card__desc">{{ path.desc }}</p>
+          <ol class="pathway-card__steps" :aria-label="path.stepsAria">
+            <li v-for="(step, i) in path.steps" :key="i">{{ step }}</li>
+          </ol>
+          <div class="pathway-card__cta">
+            <component
+              :is="path.as ?? (path.external ? 'a' : 'NuxtLink')"
+              v-bind="path.linkProps"
+              :class="path.primary ? 'btn-cta w-full justify-center' : 'btn-secondary w-full justify-center'"
+              :style="path.external ? 'text-decoration: none' : undefined"
+              @click="path.onClick?.()"
+            >
+              <Icon v-if="path.ctaIcon" :name="path.ctaIcon" class="w-4 h-4" aria-hidden="true" />
+              {{ path.cta }}
+              <span v-if="path.external" class="sr-only"> {{ $t('a11y.new_tab') }}</span>
+            </component>
+            <p v-if="path.caption" class="pathway-card__caption">{{ path.caption }}</p>
+          </div>
+        </article>
+      </div>
+
+      <!-- Colabora: chips de salto a cada perfil -->
+      <nav
+        v-else
+        class="pathway-chips mt-6"
+        :aria-label="$t('pathways.chips_aria')"
+      >
+        <a
+          v-for="chip in colaboraChips"
+          :key="chip.id"
+          :href="chip.hash"
+          class="pathway-chip"
+          @click="scrollTo(chip.hash)"
+        >
+          <Icon :name="chip.icon" class="w-4 h-4 shrink-0" aria-hidden="true" />
+          <span class="pathway-chip__label">{{ chip.label }}</span>
+          <span class="pathway-chip__time">{{ chip.time }}</span>
+        </a>
+      </nav>
+
+      <!-- Resumen de 2 minutos (home): progressive disclosure, sin presión -->
+      <details v-if="variant === 'home'" id="pathway-brief" class="pathway-brief mt-10 max-w-3xl">
+        <summary class="pathway-brief__summary">
+          <Icon name="ph:book-open-text" class="w-4 h-4 shrink-0 text-miriam" aria-hidden="true" />
+          {{ $t('pathways.brief_toggle') }}
+          <span class="pathway-brief__badge">{{ $t('pathways.brief_time') }}</span>
+        </summary>
+        <div class="pathway-brief__body card-base bg-cream mt-3">
+          <p class="font-display font-semibold text-berenjena text-lg mb-4">
+            {{ $t('pathways.brief_heading') }}
+          </p>
+          <ol class="pathway-brief__list">
+            <li v-for="(item, i) in briefPoints" :key="i">
+              <span class="pathway-brief__num" aria-hidden="true">{{ i + 1 }}</span>
+              <span>{{ item }}</span>
+            </li>
+          </ol>
+          <p class="text-sm text-tinta mt-5 leading-relaxed">{{ $t('pathways.brief_outro') }}</p>
+          <div class="flex flex-col sm:flex-row gap-3 mt-6">
+            <NuxtLink :to="localePath({ name: 'ciencia' })" class="btn-secondary w-full sm:w-auto justify-center">
+              <Icon name="ph:flask-fill" class="w-4 h-4" aria-hidden="true" />
+              {{ $t('pathways.brief_cta_science') }}
+            </NuxtLink>
+            <NuxtLink :to="localePath('colabora')" class="btn-ghost w-full sm:w-auto justify-center">
+              {{ $t('pathways.brief_cta_help') }}
+              <Icon name="ph:arrow-right" class="w-4 h-4" aria-hidden="true" />
+            </NuxtLink>
+          </div>
+        </div>
+      </details>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{ variant?: 'home' | 'colabora' }>(),
+  { variant: 'home' }
+)
+
+const { t, tm, rt } = useI18n()
+const localePath = useLocalePath()
+const { GOFUNDME_URL, trackSupport } = useSupport()
+
+const titleId = computed(() => `pathways-title-${props.variant}`)
+
+function arr(key: string): string[] {
+  const raw = tm(key) as unknown
+  const list = Array.isArray(raw) ? raw : Object.values((raw ?? {}) as Record<string, unknown>)
+  return list.map((item) => rt(item as never))
+}
+
+const briefPoints = computed(() => arr('pathways.brief_points'))
+
+interface HomePath {
+  id: string
+  icon: string
+  time: string
+  title: string
+  desc: string
+  steps: string[]
+  stepsAria: string
+  cta: string
+  ctaIcon?: string
+  caption?: string
+  primary?: boolean
+  external?: boolean
+  linkProps: Record<string, string>
+  as?: 'a' | 'NuxtLink'
+  onClick?: () => void
+}
+
+const homePaths = computed<HomePath[]>(() => [
+  {
+    id: 'supporter',
+    icon: 'ph:heart-fill',
+    time: t('pathways.time_1'),
+    title: t('pathways.supporter_title'),
+    desc: t('pathways.supporter_desc'),
+    steps: arr('pathways.supporter_steps'),
+    stepsAria: t('pathways.supporter_steps_aria'),
+    cta: t('pathways.supporter_cta'),
+    ctaIcon: 'ph:heart-fill',
+    caption: t('pathways.supporter_caption'),
+    primary: true,
+    external: true,
+    linkProps: { href: GOFUNDME_URL, target: '_blank', rel: 'noopener noreferrer', 'data-support-cta': '' },
+    onClick: () => trackSupport('pathway_supporter'),
+  },
+  {
+    id: 'curious',
+    icon: 'ph:compass',
+    time: t('pathways.time_3'),
+    title: t('pathways.curious_title'),
+    desc: t('pathways.curious_desc'),
+    steps: arr('pathways.curious_steps'),
+    stepsAria: t('pathways.curious_steps_aria'),
+    cta: t('pathways.curious_cta'),
+    ctaIcon: 'ph:book-open-text',
+    caption: t('pathways.curious_caption'),
+    as: 'a',
+    linkProps: { href: '#pathway-brief' },
+    onClick: () => {
+      const el = document.getElementById('pathway-brief')
+      if (el && el.tagName === 'DETAILS') (el as HTMLDetailsElement).open = true
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    },
+  },
+  {
+    id: 'clinician',
+    icon: 'ph:stethoscope',
+    time: t('pathways.time_6'),
+    title: t('pathways.clinician_title'),
+    desc: t('pathways.clinician_desc'),
+    steps: arr('pathways.clinician_steps'),
+    stepsAria: t('pathways.clinician_steps_aria'),
+    cta: t('pathways.clinician_cta'),
+    ctaIcon: 'ph:flask-fill',
+    caption: t('pathways.clinician_caption'),
+    linkProps: { to: localePath({ name: 'ciencia' }) + '?nivel=pro' },
+  },
+  {
+    id: 'press',
+    icon: 'ph:megaphone-simple-fill',
+    time: t('pathways.time_4'),
+    title: t('pathways.press_title'),
+    desc: t('pathways.press_desc'),
+    steps: arr('pathways.press_steps'),
+    stepsAria: t('pathways.press_steps_aria'),
+    cta: t('pathways.press_cta'),
+    ctaIcon: 'ph:megaphone-simple-fill',
+    caption: t('pathways.press_caption'),
+    linkProps: { to: localePath('prensa') },
+  },
+  {
+    id: 'tech',
+    icon: 'ph:code',
+    time: t('pathways.time_5'),
+    title: t('pathways.tech_title'),
+    desc: t('pathways.tech_desc'),
+    steps: arr('pathways.tech_steps'),
+    stepsAria: t('pathways.tech_steps_aria'),
+    cta: t('pathways.tech_cta'),
+    ctaIcon: 'ph:envelope-simple-fill',
+    caption: t('pathways.tech_caption'),
+    linkProps: { to: localePath('contacto') + '?role=tech' },
+  },
+  {
+    id: 'peer',
+    icon: 'ph:hands-praying-fill',
+    time: t('pathways.time_2'),
+    title: t('pathways.peer_title'),
+    desc: t('pathways.peer_desc'),
+    steps: arr('pathways.peer_steps'),
+    stepsAria: t('pathways.peer_steps_aria'),
+    cta: t('pathways.peer_cta'),
+    ctaIcon: 'ph:envelope-simple-fill',
+    caption: t('pathways.peer_caption'),
+    linkProps: { to: localePath('contacto') + '?role=patient' },
+  },
+])
+
+interface ColaboraChip {
+  id: string
+  hash: string
+  icon: string
+  label: string
+  time: string
+}
+
+const colaboraChips = computed<ColaboraChip[]>(() => [
+  { id: 'clinical', hash: '#revision-clinica', icon: 'ph:stethoscope', label: t('pathways.chip_clinical'), time: t('pathways.time_5') },
+  { id: 'press', hash: '#alcance', icon: 'ph:megaphone-simple-fill', label: t('pathways.chip_press'), time: t('pathways.time_3') },
+  { id: 'tech', hash: '#tech-ia', icon: 'ph:code', label: t('pathways.chip_tech'), time: t('pathways.time_4') },
+  { id: 'peer', hash: '#apoyo-mutuo', icon: 'ph:hands-praying-fill', label: t('pathways.chip_peer'), time: t('pathways.time_2') },
+  { id: 'donate', hash: '#financiar', icon: 'ph:hand-heart-fill', label: t('pathways.chip_donate'), time: t('pathways.time_1') },
+])
+
+function scrollTo(hash: string) {
+  const id = hash.replace('#', '')
+  const el = document.getElementById(id)
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+</script>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen flex flex-col">
-    <a href="#main-content" class="skip-link">{{
+    <a href="#main-content" class="skip-link" @click="focusMain">{{
       $t('nav.skip_to_content')
     }}</a>
     <SiteNav />
@@ -20,6 +20,13 @@
 
 <script setup lang="ts">
 const { locale } = useI18n()
+
+function focusMain() {
+  nextTick(() => {
+    const main = document.getElementById('main-content')
+    main?.focus()
+  })
+}
 
 const head = useLocaleHead({ dir: true, lang: true, seo: true })
 useHead(head)

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -25,6 +25,11 @@
              todo (la página completa). Las capas usan v-show (display) sobre
              contenedores `display:contents`, así el HTML estático no cambia y el
              SEO/hidratación siguen intactos. -->
+        <p class="pathway-comfort mb-6 max-w-2xl" role="note">
+          <Icon name="ph:leaf" class="pathway-comfort__icon" aria-hidden="true" />
+          {{ $t('pathways.comfort') }}
+        </p>
+
         <div class="reading-level mb-10" role="group" :aria-label="$t('ciencia.level_aria')">
           <span class="reading-level__hint">{{ $t('ciencia.level_hint') }}</span>
           <div class="reading-level__seg">

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -70,9 +70,11 @@
         >
           {{ $t('collaborate.profiles_title') }}
         </h2>
-        <p class="text-tinta leading-relaxed mb-10 max-w-2xl">
+        <p class="text-tinta leading-relaxed mb-6 max-w-2xl">
           {{ $t('collaborate.profiles_sub') }}
         </p>
+
+        <VisitorPathways variant="colabora" class="mb-10" />
 
         <div class="grid md:grid-cols-2 gap-4">
           <!-- ─ Card 1 — revisión clínica ─ -->
@@ -120,7 +122,7 @@
           </article>
 
           <!-- ─ Card 4 — tech & IA ─ -->
-          <article class="card-base bg-cream flex flex-col">
+          <article id="tech-ia" class="card-base bg-cream flex flex-col scroll-mt-24">
             <div class="flex items-center gap-4 mb-4">
               <span class="w-10 h-10 rounded-xl bg-berenjena flex items-center justify-center shrink-0" aria-hidden="true">
                 <Icon name="ph:flask-fill" class="w-5 h-5 text-cream" />
@@ -153,7 +155,7 @@
           </article>
 
           <!-- ─ Card 5 — apoyo mutuo ─ -->
-          <article class="card-base bg-cream flex flex-col">
+          <article id="apoyo-mutuo" class="card-base bg-cream flex flex-col scroll-mt-24">
             <div class="flex items-center gap-4 mb-4">
               <span class="w-10 h-10 rounded-xl bg-berenjena flex items-center justify-center shrink-0" aria-hidden="true">
                 <Icon name="ph:hands-praying-fill" class="w-5 h-5 text-cream" />

--- a/app/pages/contacto.vue
+++ b/app/pages/contacto.vue
@@ -7,6 +7,16 @@
           :subtitle="$t('contact.subtitle')"
         />
 
+        <p
+          v-if="roleLabel"
+          class="pathway-comfort mb-8 max-w-2xl"
+          role="status"
+          aria-live="polite"
+        >
+          <Icon name="ph:identification-badge" class="pathway-comfort__icon" aria-hidden="true" />
+          {{ $t('a11y.role_detected', { role: roleLabel }) }}
+        </p>
+
         <div class="grid md:grid-cols-2 gap-8 lg:gap-12">
           <div>
             <p class="text-tinta leading-relaxed mb-8">
@@ -261,6 +271,19 @@ const roleFromQuery = () => {
 }
 const role = ref(roleFromQuery())
 watch(() => route.query.role, () => { role.value = roleFromQuery() })
+
+const { t } = useI18n()
+const roleLabel = computed(() => {
+  const map: Record<string, string> = {
+    oncologist: t('contact.role_oncologist'),
+    researcher: t('contact.role_researcher'),
+    journalist: t('contact.role_journalist'),
+    patient: t('contact.role_patient'),
+    tech: t('contact.role_tech'),
+    other: t('contact.role_other'),
+  }
+  return role.value ? map[role.value] ?? '' : ''
+})
 
 // Envío AJAX a Netlify Forms: mismo endpoint (POST a "/" con urlencode), pero
 // mostramos el agradecimiento en la propia página en vez de redirigir.

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,8 @@
   <div>
     <SectionHero />
 
+    <VisitorPathways variant="home" />
+
     <!-- La historia + en sus propias palabras (beat humano: persona antes que problema) -->
     <section v-reveal class="py-24 sm:py-32 relative overflow-hidden" :aria-label="$t('home.story_eyebrow')" style="background: #2d1b3d; color: #faf6f0">
       <div class="absolute inset-0 opacity-[0.04]" style="background-image: radial-gradient(circle at 1px 1px, #faf6f0 1px, transparent 0); background-size: 32px 32px;" />

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -25,7 +25,105 @@
     "language": "Language"
   },
   "a11y": {
-    "new_tab": "(opens in a new tab)"
+    "new_tab": "(opens in a new tab)",
+    "external_link": "External link",
+    "role_detected": "Profile detected: {role}. You can change it in the form.",
+    "skip_focused": "Main content",
+    "more_ways": "More ways to help"
+  },
+  "pathways": {
+    "eyebrow": "Where do I start?",
+    "home_title": "Pick your path",
+    "home_sub": "You don't have to read everything. Tell us who you are and we'll take you to the next step.",
+    "colabora_title": "Jump to your profile",
+    "colabora_sub": "Five routes, one per person. Tap yours and go straight to what matters for you.",
+    "comfort": "Take all the time you need. You can come back anytime; nothing is lost.",
+    "grid_aria": "Paths based on who is visiting",
+    "chips_aria": "Jump to each way of helping",
+    "time_1": "~1 min",
+    "time_2": "~2 min",
+    "time_3": "~3 min",
+    "time_4": "~4 min",
+    "time_5": "~5 min",
+    "time_6": "~6 min",
+    "supporter_title": "I want to help now",
+    "supporter_desc": "You know Miriam or trust the cause. Your gift funds the next test.",
+    "supporter_steps": [
+      "Open GoFundMe (secure payment)",
+      "Choose an amount that fits you",
+      "Your name appears on the thank-you constellation"
+    ],
+    "supporter_steps_aria": "Steps to support financially",
+    "supporter_cta": "Support Miriam",
+    "supporter_caption": "Secure payment. Receipt available. 100% to the case.",
+    "curious_title": "I just arrived",
+    "curious_desc": "You want to understand what this is about before deciding anything.",
+    "curious_steps": [
+      "Read the 2-minute summary",
+      "Skim the clinical gap if you like",
+      "Choose how to help when it feels clear"
+    ],
+    "curious_steps_aria": "Steps to understand the case",
+    "curious_cta": "See 2-minute summary",
+    "curious_caption": "No signup. No pressure.",
+    "clinician_title": "Medicine or research",
+    "clinician_desc": "You want clinical detail: markers, imaging, therapeutic lines.",
+    "clinician_steps": [
+      "Molecular profile and three tissue reads",
+      "Functional imaging and active targets",
+      "Form for second opinion or contact"
+    ],
+    "clinician_steps_aria": "Steps for clinical professionals",
+    "clinician_cta": "View clinical detail",
+    "clinician_caption": "Professional mode · ~6 min · printable.",
+    "press_title": "Press or outreach",
+    "press_desc": "You have an audience or cover health. You need verifiable facts.",
+    "press_steps": [
+      "Press room with real coverage",
+      "Case data ready to cite",
+      "Direct contact for interviews"
+    ],
+    "press_steps_aria": "Steps for journalists",
+    "press_cta": "Go to the press room",
+    "press_caption": "Verifiable kit. No spin.",
+    "tech_title": "Tech, data, or AI",
+    "tech_desc": "You want to contribute code, pipelines, or analysis to the open case.",
+    "tech_steps": [
+      "Public repo and documentation",
+      "Links to Beyond the Protocol",
+      "Contact with tech profile pre-selected"
+    ],
+    "tech_steps_aria": "Steps for technical profiles",
+    "tech_cta": "Write to the tech team",
+    "tech_caption": "Open code. Non-sensitive data public.",
+    "peer_title": "Patient or caregiver",
+    "peer_desc": "You're going through something similar or want to connect without pressure.",
+    "peer_steps": [
+      "Read the case at your pace",
+      "Write if you want to share experience",
+      "Follow on social if it helps"
+    ],
+    "peer_steps_aria": "Steps for patients and caregivers",
+    "peer_cta": "Write to Miriam",
+    "peer_caption": "We reply by email. No obligation.",
+    "chip_clinical": "Clinical review",
+    "chip_press": "Reach",
+    "chip_tech": "Tech & AI",
+    "chip_peer": "Peer support",
+    "chip_donate": "Fund research",
+    "brief_toggle": "2-minute case summary",
+    "brief_time": "2 min",
+    "brief_heading": "The essentials, in four ideas",
+    "brief_points": [
+      "Miriam has metastatic breast cancer with two biologies at once: luminal (HR+) and neuroendocrine (~80%). Spanish protocols only cover the first.",
+      "Without molecular rebiopsy and advanced panels, treatment is decided blind while the tumor evolves.",
+      "The campaign funds precision tests, second opinions, and a possible N-of-1 trial designed for her exact biology.",
+      "Every euro is documented. There are ways to help beyond money: clinical review, outreach, tech, or simply being here."
+    ],
+    "brief_outro": "To go deeper, The science has a summary for everyone and a professional mode with tables and imaging.",
+    "brief_cta_science": "View the science",
+    "brief_cta_help": "See all ways to help",
+    "hero_sr_summary": "Miriam González has an ultra-rare metastatic breast cancer with two biologies. This site funds precision tests that public healthcare does not cover. You can donate, read the science, collaborate by profile, or share the campaign."
   },
   "glossary": {
     "hint": "Tap or hover the highlighted words and markers to see what they mean."

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -25,7 +25,105 @@
     "language": "Idioma"
   },
   "a11y": {
-    "new_tab": "(se abre en una pestaña nueva)"
+    "new_tab": "(se abre en una pestaña nueva)",
+    "external_link": "Enlace externo",
+    "role_detected": "Perfil detectado: {role}. Puedes cambiarlo en el formulario.",
+    "skip_focused": "Contenido principal",
+    "more_ways": "Más formas de ayudar"
+  },
+  "pathways": {
+    "eyebrow": "¿Por dónde empiezo?",
+    "home_title": "Elige tu camino",
+    "home_sub": "No hace falta leerlo todo. Dinos quién eres y te llevamos al siguiente paso.",
+    "colabora_title": "Salta a tu perfil",
+    "colabora_sub": "Cinco vías, una por persona. Toca la tuya y baja directo a lo que te toca.",
+    "comfort": "Tómate el tiempo que necesites. Puedes volver cuando quieras; nada se pierde.",
+    "grid_aria": "Caminos según quién visita la web",
+    "chips_aria": "Ir directo a cada forma de ayudar",
+    "time_1": "~1 min",
+    "time_2": "~2 min",
+    "time_3": "~3 min",
+    "time_4": "~4 min",
+    "time_5": "~5 min",
+    "time_6": "~6 min",
+    "supporter_title": "Quiero ayudar ya",
+    "supporter_desc": "Conoces a Miriam o confías en la causa. Tu aportación financia el siguiente análisis.",
+    "supporter_steps": [
+      "Abres GoFundMe (pago seguro)",
+      "Eliges la cantidad que te encaje",
+      "Tu nombre aparece en la constelación de gracias"
+    ],
+    "supporter_steps_aria": "Pasos para apoyar económicamente",
+    "supporter_cta": "Apoyar a Miriam",
+    "supporter_caption": "Pago seguro. Recibo disponible. 100% al caso.",
+    "curious_title": "Acabo de llegar",
+    "curious_desc": "Quieres entender de qué va esto antes de decidir nada.",
+    "curious_steps": [
+      "Lee el resumen de 2 minutos",
+      "Mira la brecha clínica si te apetece",
+      "Elige cómo ayudar cuando lo tengas claro"
+    ],
+    "curious_steps_aria": "Pasos para entender el caso",
+    "curious_cta": "Ver resumen de 2 min",
+    "curious_caption": "Sin registro. Sin presión.",
+    "clinician_title": "Medicina o investigación",
+    "clinician_desc": "Buscas el detalle clínico: marcadores, imágenes, líneas terapéuticas.",
+    "clinician_steps": [
+      "Perfil molecular y tres lecturas del tejido",
+      "Imagen funcional y dianas activas",
+      "Formulario para segunda opinión o contacto"
+    ],
+    "clinician_steps_aria": "Pasos para profesionales clínicos",
+    "clinician_cta": "Ver detalle clínico",
+    "clinician_caption": "Modo profesional · ~6 min · imprimible.",
+    "press_title": "Prensa o difusión",
+    "press_desc": "Tienes audiencia o cubres salud. Necesitas hechos verificables.",
+    "press_steps": [
+      "Sala de prensa con cobertura real",
+      "Datos del caso listos para citar",
+      "Contacto directo para entrevistas"
+    ],
+    "press_steps_aria": "Pasos para periodistas",
+    "press_cta": "Ir a la sala de prensa",
+    "press_caption": "Kit verificable. Sin spin.",
+    "tech_title": "Tech, datos o IA",
+    "tech_desc": "Quieres aportar código, pipelines o análisis al caso abierto.",
+    "tech_steps": [
+      "Repo público y documentación",
+      "Enlaces a Beyond the Protocol",
+      "Contacto con perfil tech preseleccionado"
+    ],
+    "tech_steps_aria": "Pasos para perfiles técnicos",
+    "tech_cta": "Escribir al equipo tech",
+    "tech_caption": "Código abierto. Datos no sensibles públicos.",
+    "peer_title": "Paciente o cuidador",
+    "peer_desc": "Vives algo parecido o quieres conectar con Miriam sin exigirte nada.",
+    "peer_steps": [
+      "Lee el caso a tu ritmo",
+      "Escríbenos si quieres compartir experiencia",
+      "Síguela en redes si te ayuda"
+    ],
+    "peer_steps_aria": "Pasos para pacientes y cuidadores",
+    "peer_cta": "Escribir a Miriam",
+    "peer_caption": "Te respondemos por email. Sin compromiso.",
+    "chip_clinical": "Revisión clínica",
+    "chip_press": "Alcance",
+    "chip_tech": "Tech & IA",
+    "chip_peer": "Apoyo mutuo",
+    "chip_donate": "Financiar",
+    "brief_toggle": "Resumen del caso en 2 minutos",
+    "brief_time": "2 min",
+    "brief_heading": "Lo esencial, en cuatro ideas",
+    "brief_points": [
+      "Miriam tiene un cáncer de mama metastásico con dos biologías a la vez: luminal (HR+) y neuroendocrina (~80%). Los protocolos españoles solo cubren la primera.",
+      "Sin rebiopsia molecular y paneles avanzados, el tratamiento se decide a ciegas mientras el tumor evoluciona.",
+      "La campaña financia pruebas de precisión, segundas opiniones y un posible ensayo N-of-1 diseñado para su biología exacta.",
+      "Cada euro queda documentado. Hay formas de ayudar además del dinero: revisión clínica, difusión, tech o simplemente estar."
+    ],
+    "brief_outro": "Si quieres profundizar, La ciencia tiene un resumen para todos y un modo profesional con tablas e imágenes.",
+    "brief_cta_science": "Ver la ciencia",
+    "brief_cta_help": "Ver todas las formas de ayudar",
+    "hero_sr_summary": "Miriam González tiene un cáncer de mama metastásico ultra-raro con dos biologías. Esta web financia las pruebas de precisión que la sanidad pública no cubre. Puedes apoyar económicamente, leer la ciencia del caso, colaborar según tu perfil o compartir la campaña."
   },
   "glossary": {
     "hint": "Toca o pasa el cursor por las palabras y marcadores resaltados para ver qué significan."


### PR DESCRIPTION
## Auditoría comité UX · producto · psicología · diseño

Mejoras **no estructurales** para que cada tipo de visitante entienda el caso y encuentre su vía de ayuda.

### Qué cambia
- **VisitorPathways**: 6 perfiles en home (donante, curioso, clínico, prensa, tech, paciente) con tiempos estimados y pasos claros
- **Resumen 2 min** desplegable (progressive disclosure, sin presión)
- **Chips de salto** en `/colabora` hacia cada perfil (#revision-clinica, #alcance, #tech-ia, #apoyo-mutuo, #financiar)
- **A11y**: TL;DR sr-only en hero, skip-link con foco en main, perfil detectado en contacto
- **Neurodivergencia**: nota de confort, `prefers-contrast: more`, sin animación obligatoria
- **Barra móvil**: enlace «Más formas de ayudar» → /colabora

### Build
`pnpm generate` ✓ · 0 errores de enlaces