### PR TITLE
feat(equipo): incorporar a Mariú en el círculo cercano

### DIFF
--- a/content/en/team.yml
+++ b/content/en/team.yml
@@ -18,6 +18,11 @@ coreTeam:
     description: "Research doctorate. He advises on clinical trials and on translating findings into an N-of-1 approach."
     icon: ph:clipboard-text-fill
     color: gold
+  - role: "Biomedicine · translational"
+    name: Mariú
+    description: "Biomedicine and master's in clinical research (translational oncology, PRBB-Barcelona). Contributes independently and applies AI to the case's clinical and research workflow."
+    icon: ph:dna-fill
+    color: gold
   - role: "Technical advisory · breast"
     name: Víctor
     photo: /img/team/victor.webp

--- a/content/es/team.yml
+++ b/content/es/team.yml
@@ -18,6 +18,11 @@ coreTeam:
     description: "Doctor en investigación. Asesora en ensayos clínicos y en la traducción al abordaje N-of-1."
     icon: ph:clipboard-text-fill
     color: gold
+  - role: "Biomedicina · traslacional"
+    name: Mariú
+    description: "Biomedicina y máster en investigación clínica (oncología traslacional, PRBB-Barcelona). Aporta de forma independiente y aplica IA al uso clínico e investigacional del caso."
+    icon: ph:dna-fill
+    color: gold
   - role: "Asesoría técnica · mama"
     name: Víctor
     photo: /img/team/victor.webp


### PR DESCRIPTION
Añade a Mariú al core team tras Alejandro.

- Rol: Biomedicina · traslacional
- Sin foto: el componente muestra placeholder con «M»
- Cuando haya retrato: `/img/team/mariu.webp`