### PR TITLE
fix(desktop): unificar shell ancho en home, footer y colabora

### DIFF
--- a/app/components/DonationsWall.vue
+++ b/app/components/DonationsWall.vue
@@ -5,7 +5,7 @@
     class="section-spacing bg-cream-card relative overflow-hidden scroll-mt-24"
     :aria-labelledby="'gracias-title'"
   >
-    <div class="section-container relative z-10">
+    <div class="section-wide relative z-10">
       <!-- Encabezado + la pieza: la frase manuscrita va ENCIMA del mapa
            (dentro de StarMap) y la nota de navegación + botón, debajo. -->
       <div class="mb-6">

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -328,6 +328,12 @@ const stats = computed(() => [
     max-width: 16ch;
   }
 }
+@media (min-width: 768px) {
+  /* Misma medida que lede/CTA: el titular no «estrecha» la columna en desktop. */
+  .hero__title {
+    max-width: 36rem;
+  }
+}
 
 /* Retrato */
 .hero__portrait {

--- a/app/components/SiteFooter.vue
+++ b/app/components/SiteFooter.vue
@@ -3,7 +3,7 @@
     <!-- Con el apoyo de — muro de logos uniforme: todos iguales, misma altura,
          centrados en rejilla y sin etiqueta de texto (logo wall limpio). -->
     <section class="bg-berenjena" :aria-label="$t('index.supported_by')">
-      <div class="section-container py-10 sm:py-12 text-center">
+      <div class="section-wide py-10 sm:py-12 text-center">
         <p class="text-cream/70 text-xs font-mono font-medium uppercase tracking-[0.12em] mb-8">
           {{ $t('index.supported_by') }}
         </p>

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -80,8 +80,8 @@
              vivo y prueba social en un solo vistazo. -->
         <aside class="card-base bg-cream mb-10" :aria-label="$t('collaborate.trust_aria')">
           <p class="eyebrow mb-4 block">{{ $t('collaborate.trust_eyebrow') }}</p>
-          <div class="grid gap-6 sm:grid-cols-3">
-            <div>
+          <div class="grid gap-6 sm:grid-cols-3 sm:items-start">
+            <div class="flex flex-col">
               <h3 class="font-display font-semibold text-berenjena text-base mb-1.5">
                 {{ $t('collaborate.trust_transparency_title') }}
               </h3>
@@ -93,13 +93,13 @@
                 <Icon name="ph:arrow-right" class="w-3.5 h-3.5" aria-hidden="true" />
               </NuxtLink>
             </div>
-            <div>
-              <h3 class="font-display font-semibold text-berenjena text-base mb-3">
+            <div class="flex flex-col min-w-0">
+              <h3 class="font-display font-semibold text-berenjena text-base mb-1.5">
                 {{ $t('collaborate.trust_campaign_title') }}
               </h3>
               <GoFundMeProgress />
             </div>
-            <div>
+            <div class="flex flex-col">
               <h3 class="font-display font-semibold text-berenjena text-base mb-1.5">
                 {{ $t('collaborate.trust_social_title') }}
               </h3>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -7,7 +7,7 @@
     <!-- La historia + en sus propias palabras (beat humano: persona antes que problema) -->
     <section v-reveal class="py-24 sm:py-32 relative overflow-hidden" :aria-label="$t('home.story_eyebrow')" style="background: #2d1b3d; color: #faf6f0">
       <div class="absolute inset-0 opacity-[0.04]" style="background-image: radial-gradient(circle at 1px 1px, #faf6f0 1px, transparent 0); background-size: 32px 32px;" />
-      <div class="relative section-container max-w-4xl">
+      <div class="relative section-wide">
         <p class="eyebrow block" style="color: #e8d4ed">
           {{ $t('home.story_eyebrow') }}
         </p>
@@ -62,7 +62,7 @@
       :aria-label="$t('home.s3_eyebrow')"
       style="border-top: 1px solid rgba(45,27,61,0.08); border-bottom: 1px solid rgba(45,27,61,0.08)"
     >
-      <div class="section-container max-w-5xl">
+      <div class="section-wide">
         <p class="eyebrow mb-4 block">{{ $t('home.s3_eyebrow') }}</p>
         <h2 class="heading-display text-3xl sm:text-5xl text-berenjena mb-4" style="letter-spacing: -0.03em">
           {{ $t('home.s3_heading') }}
@@ -193,7 +193,7 @@
     <!-- Hacia dónde va · objetivo N-of-1 + perfil molecular en una línea (detalle completo en /ciencia) -->
     <!-- Sin border-bottom: el separador aquí es la línea de latido (EcgDivider). -->
     <section v-reveal class="section-spacing bg-cream" :aria-label="$t('home.s8_eyebrow')">
-      <div class="section-container max-w-5xl">
+      <div class="section-wide">
         <p class="eyebrow mb-4 block">{{ $t('home.s8_eyebrow') }}</p>
         <h2 class="heading-display text-3xl sm:text-5xl text-berenjena mb-6" style="letter-spacing: -0.03em">
           {{ $t('home.s8_heading') }}
@@ -252,7 +252,7 @@
     <!-- S4 · ¿Por qué necesitamos tu ayuda? · Destino del dinero
          (aquí el separador es el propio cambio de color de sección) -->
     <section v-reveal class="section-spacing bg-cream-card" id="campaign" :aria-label="$t('home.s4_eyebrow')">
-      <div class="section-container max-w-5xl">
+      <div class="section-wide">
         <p class="eyebrow mb-4 block">{{ $t('home.s4_eyebrow') }}</p>
         <h2 class="heading-display text-3xl sm:text-5xl text-berenjena mb-6" style="letter-spacing: -0.03em">
           {{ $t('home.s4_heading') }}
@@ -298,7 +298,7 @@
 
     <!-- S10 · CTAs en escalera -->
     <section v-reveal class="section-spacing bg-cream" :aria-label="$t('home.s10_eyebrow')" style="border-top: 1px solid rgba(45,27,61,0.08)">
-      <div class="section-container max-w-5xl">
+      <div class="section-wide">
         <p class="eyebrow mb-4 block">{{ $t('home.s10_eyebrow') }}</p>
         <h2 class="heading-display text-3xl sm:text-4xl text-berenjena mb-6" style="letter-spacing: -0.03em">
           {{ $t('home.s10_intro') }}
@@ -349,7 +349,7 @@
     <EcgDivider class="bg-cream" />
 
     <section v-reveal class="section-spacing bg-cream" :aria-label="$t('home.pro_eyebrow')">
-      <div class="section-container max-w-3xl">
+      <div class="section-wide">
         <!-- D7: en desktop apila (título a todo el ancho arriba, botones debajo)
              en vez de texto|botones lado a lado, que estrujaba el título a 4
              líneas y dejaba hueco abajo. En móvil ya era flex-col → idéntico. -->
@@ -375,7 +375,7 @@
 
     <!-- Cierre · estado de la campaña + caso en prensa (lo último de todo) -->
     <section v-reveal class="section-spacing bg-cream-card" :aria-label="$t('home.s5_eyebrow')" style="border-top: 1px solid rgba(45,27,61,0.08)">
-      <div class="section-container max-w-5xl">
+      <div class="section-wide">
         <p class="eyebrow mb-3 block">{{ $t('home.s5_eyebrow') }}</p>
         <h2 class="font-display font-semibold text-berenjena text-2xl sm:text-3xl mb-6" style="letter-spacing: -0.02em">
           {{ $t('home.s5_heading') }}


### PR DESCRIPTION
## Problema
En desktop el contenido de la home «saltaba» respecto al nav/hero: las secciones intermedias usaban `section-container` centrado (896–1024px) mientras el hero, pathways y nav usan `section-wide` (1200px).

## Cambios
- **Home (`index.vue`)**: todas las secciones pasan a `section-wide`; los `max-w-*` en párrafos y cards se mantienen solo como medida de lectura.
- **Footer**: franja «Con el apoyo de» alineada al mismo shell que el cuerpo del footer.
- **`DonationsWall`**: shell ancho en `/colabora` para alinear con perfiles.
- **`/colabora`**: trust strip con columnas alineadas arriba y márgenes homogéneos.
- **Hero**: titular con `max-width: 36rem` en md+ (misma medida que lede/CTA).

## Verificación
- `pnpm generate` ✓