### PR TITLE
feat(security): hardening AI exports, form CAPTCHA y API de donantes

### DIFF
--- a/app/components/CaseFollowSignup.vue
+++ b/app/components/CaseFollowSignup.vue
@@ -50,12 +50,21 @@
         />
         <button
           type="submit"
-          :disabled="sending || !consent"
+          :disabled="sending || !consent || (turnstileEnabled && !turnstileToken)"
           class="btn-cta justify-center disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {{ sending ? $t('follow.sending') : $t('follow.cta') }}
         </button>
       </div>
+
+      <TurnstileWidget
+        ref="turnstileRef"
+        action="case-follow"
+        class="mt-3"
+        @token="turnstileToken = $event"
+        @expired="turnstileToken = ''"
+        @error="turnstileToken = ''"
+      />
 
       <label class="flex items-start gap-2.5 mt-3 text-xs text-tinta leading-relaxed cursor-pointer">
         <input
@@ -75,6 +84,9 @@
         </span>
       </label>
 
+      <p v-if="captchaFailed" class="mt-2 text-xs text-coral-deep" role="alert">
+        {{ turnstileToken ? $t('captcha.failed') : $t('captcha.required') }}
+      </p>
       <p v-if="failed" class="mt-2 text-xs text-coral-deep" role="alert">{{ $t('follow.failed') }}</p>
     </form>
   </section>
@@ -87,15 +99,35 @@ const consent = ref(false)
 const sending = ref(false)
 const sent = ref(false)
 const failed = ref(false)
+const captchaFailed = ref(false)
+const turnstileToken = ref('')
+const turnstileRef = ref<{ reset: () => void } | null>(null)
+const { enabled: turnstileEnabled, verifyToken } = useTurnstile()
 
 async function onSubmit(e: Event) {
   if (!consent.value) return // RGPD: sin consentimiento explícito, no se envía.
+  captchaFailed.value = false
+  failed.value = false
+
+  if (turnstileEnabled.value) {
+    if (!turnstileToken.value) {
+      captchaFailed.value = true
+      return
+    }
+    const verified = await verifyToken(turnstileToken.value)
+    if (!verified) {
+      captchaFailed.value = true
+      turnstileToken.value = ''
+      turnstileRef.value?.reset()
+      return
+    }
+  }
+
   const form = e.target as HTMLFormElement
   const body = new URLSearchParams(
     new FormData(form) as unknown as Record<string, string>
   ).toString()
   sending.value = true
-  failed.value = false
   try {
     await $fetch('/', {
       method: 'POST',

--- a/app/components/DonationsWall.vue
+++ b/app/components/DonationsWall.vue
@@ -147,21 +147,22 @@
  * la prueba social respalda a la petición. Aquí enlaza el widget de la home.
  * Datos reales de /donations.json (función Netlify horaria). Anónimos = "Anónimo".
  */
-import type { GoFundMeFundraiser, PublicDonation } from '../../utils/fundraiser'
+import type { GoFundMeFundraiser } from '../../utils/fundraiser'
+import type { PublicDonationSafe } from '../../utils/donationsPublic'
 import type StarMap from './StarMap.vue'
 
 const { locale, t } = useI18n()
 const route = useRoute()
 
 const PAGE_SIZE = 12
-const donations = ref<PublicDonation[]>([])
+const donations = ref<PublicDonationSafe[]>([])
 const loaded = ref(false)
 const page = ref(0)
 const sort = ref<'recent' | 'top'>('recent')
 const starMapRef = ref<InstanceType<typeof StarMap> | null>(null)
 const findQuery = ref('')
 const findError = ref('')
-const activeDonorId = ref<number | null>(null)
+const activeDonorId = ref<string | null>(null)
 
 const patronIdRanks = computed(() => {
   const sorted = [...donations.value]
@@ -171,11 +172,11 @@ const patronIdRanks = computed(() => {
   return new Map(sorted.map((d, i) => [d.id, i + 1]))
 })
 
-function isPatron(id: number) {
+function isPatron(id: string) {
   return patronIdRanks.value.has(id)
 }
 
-function patronRank(id: number) {
+function patronRank(id: string) {
   return patronIdRanks.value.get(id) ?? 0
 }
 
@@ -186,7 +187,7 @@ function setSort(s: 'recent' | 'top') {
 
 const campaign = ref<GoFundMeFundraiser | null>(null)
 
-function focusDonor(d: PublicDonation) {
+function focusDonor(d: PublicDonationSafe) {
   findError.value = ''
   activeDonorId.value = d.id
   const ok = starMapRef.value?.focusById(d.id)
@@ -211,7 +212,7 @@ function submitFind() {
 
 onMounted(async () => {
   try {
-    donations.value = await $fetch<PublicDonation[]>('/donations.json')
+    donations.value = await $fetch<PublicDonationSafe[]>('/donations.json')
   } catch {
     /* sin datos */
   } finally {
@@ -261,7 +262,7 @@ const pageRows = computed(() => {
   return sorted.value.slice(start, start + PAGE_SIZE)
 })
 
-function money(d: PublicDonation) {
+function money(d: PublicDonationSafe) {
   return new Intl.NumberFormat(locale.value === 'es' ? 'es-ES' : 'en-US', {
     style: 'currency',
     currency: d.currencyCode || 'EUR',

--- a/app/components/StarMap.vue
+++ b/app/components/StarMap.vue
@@ -218,9 +218,9 @@
  *  · A11Y: lienzo aria-hidden + resumen sr-only; la tabla de DonationsWall es
  *    la vía accesible a los datos. Animaciones con prefers-reduced-motion.
  */
-import type { PublicDonation } from '../../utils/fundraiser'
+import type { PublicDonationSafe } from '../../utils/donationsPublic'
 
-const props = defineProps<{ donations: PublicDonation[]; total?: string }>()
+const props = defineProps<{ donations: PublicDonationSafe[]; total?: string }>()
 const { t, locale } = useI18n()
 const { GOFUNDME_URL, trackSupport } = useSupport()
 

--- a/app/components/TurnstileWidget.vue
+++ b/app/components/TurnstileWidget.vue
@@ -1,0 +1,109 @@
+<template>
+  <div v-if="enabled" class="turnstile-wrap">
+    <div ref="container" class="turnstile-container" />
+    <p v-if="loadError" class="text-xs text-coral-deep" role="alert">
+      {{ $t('captcha.load_error') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  action?: string
+}>()
+
+const emit = defineEmits<{
+  token: [value: string]
+  expired: []
+  error: []
+}>()
+
+const { siteKey, enabled } = useTurnstile()
+const container = ref<HTMLElement | null>(null)
+const loadError = ref(false)
+let widgetId: string | undefined
+let scriptEl: HTMLScriptElement | null = null
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        el: HTMLElement,
+        opts: Record<string, unknown>
+      ) => string
+      remove: (id: string) => void
+      reset: (id: string) => void
+    }
+    onTurnstileLoad?: () => void
+  }
+}
+
+function loadScript(): Promise<void> {
+  if (window.turnstile) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    window.onTurnstileLoad = () => resolve()
+    scriptEl = document.createElement('script')
+    scriptEl.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onTurnstileLoad'
+    scriptEl.async = true
+    scriptEl.defer = true
+    scriptEl.onerror = () => reject(new Error('turnstile script failed'))
+    document.head.appendChild(scriptEl)
+  })
+}
+
+function renderWidget() {
+  if (!container.value || !window.turnstile || !siteKey.value) return
+  if (widgetId) {
+    window.turnstile.remove(widgetId)
+    widgetId = undefined
+  }
+  widgetId = window.turnstile.render(container.value, {
+    sitekey: siteKey.value,
+    action: props.action ?? 'form',
+    theme: 'light',
+    language: 'auto',
+    callback: (token: string) => emit('token', token),
+    'expired-callback': () => emit('expired'),
+    'error-callback': () => {
+      loadError.value = true
+      emit('error')
+    },
+  })
+}
+
+onMounted(async () => {
+  if (!enabled.value) return
+  try {
+    await loadScript()
+    renderWidget()
+  } catch {
+    loadError.value = true
+    emit('error')
+  }
+})
+
+onBeforeUnmount(() => {
+  if (widgetId && window.turnstile) {
+    window.turnstile.remove(widgetId)
+  }
+  if (scriptEl?.parentNode) {
+    scriptEl.parentNode.removeChild(scriptEl)
+  }
+})
+
+defineExpose({
+  reset() {
+    if (widgetId && window.turnstile) window.turnstile.reset(widgetId)
+  },
+})
+</script>
+
+<style scoped>
+.turnstile-wrap {
+  min-height: 65px;
+}
+.turnstile-container {
+  display: flex;
+  justify-content: flex-start;
+}
+</style>

--- a/app/composables/useTurnstile.ts
+++ b/app/composables/useTurnstile.ts
@@ -1,0 +1,25 @@
+/**
+ * Verificación Cloudflare Turnstile antes de enviar formularios Netlify.
+ * Si no hay claves configuradas (dev local), devuelve success: true para no bloquear.
+ */
+export function useTurnstile() {
+  const config = useRuntimeConfig()
+  const siteKey = computed(() => String(config.public.turnstileSiteKey || ''))
+  const enabled = computed(() => Boolean(siteKey.value))
+
+  async function verifyToken(token: string): Promise<boolean> {
+    if (!enabled.value) return true
+    if (!token) return false
+    try {
+      const res = await $fetch<{ success: boolean }>('/.netlify/functions/verify-turnstile', {
+        method: 'POST',
+        body: { token },
+      })
+      return Boolean(res.success)
+    } catch {
+      return false
+    }
+  }
+
+  return { siteKey, enabled, verifyToken }
+}

--- a/app/pages/contacto.vue
+++ b/app/pages/contacto.vue
@@ -238,10 +238,25 @@
                 ></textarea>
               </div>
 
-              <button type="submit" class="btn-cta w-full" :disabled="sending">
+              <TurnstileWidget
+                ref="turnstileRef"
+                action="contact"
+                @token="turnstileToken = $event"
+                @expired="turnstileToken = ''"
+                @error="turnstileToken = ''"
+              />
+
+              <button
+                type="submit"
+                class="btn-cta w-full"
+                :disabled="sending || (turnstileEnabled && !turnstileToken)"
+              >
                 {{ sending ? $t('contact.sending') : $t('contact.submit') }}
               </button>
 
+              <p v-if="captchaFailed" class="text-xs text-coral-deep text-center" role="alert">
+                {{ turnstileToken ? $t('captcha.failed') : $t('captcha.required') }}
+              </p>
               <p v-if="failed" class="text-xs text-coral-deep text-center" role="alert">
                 {{ $t('contact.failed') }}
               </p>
@@ -290,12 +305,32 @@ const roleLabel = computed(() => {
 const sent = ref(false)
 const sending = ref(false)
 const failed = ref(false)
+const captchaFailed = ref(false)
+const turnstileToken = ref('')
+const turnstileRef = ref<{ reset: () => void } | null>(null)
+const { enabled: turnstileEnabled, verifyToken } = useTurnstile()
 
 async function onSubmit(e: Event) {
   const form = e.target as HTMLFormElement
+  captchaFailed.value = false
+  failed.value = false
+
+  if (turnstileEnabled.value) {
+    if (!turnstileToken.value) {
+      captchaFailed.value = true
+      return
+    }
+    const verified = await verifyToken(turnstileToken.value)
+    if (!verified) {
+      captchaFailed.value = true
+      turnstileToken.value = ''
+      turnstileRef.value?.reset()
+      return
+    }
+  }
+
   const body = new URLSearchParams(new FormData(form) as unknown as Record<string, string>).toString()
   sending.value = true
-  failed.value = false
   try {
     await $fetch('/', {
       method: 'POST',

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -32,6 +32,11 @@
     "skip_focused": "Main content",
     "more_ways": "More ways to help"
   },
+  "captcha": {
+    "required": "Complete the verification before sending.",
+    "failed": "We couldn't verify the captcha. Please try again.",
+    "load_error": "Verification couldn't load. Reload the page or try again later."
+  },
   "pathways": {
     "eyebrow": "Where do I start?",
     "home_title": "Pick your path",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -32,6 +32,11 @@
     "skip_focused": "Contenido principal",
     "more_ways": "Más formas de ayudar"
   },
+  "captcha": {
+    "required": "Confirma la verificación antes de enviar.",
+    "failed": "No pudimos verificar el captcha. Inténtalo de nuevo.",
+    "load_error": "No se pudo cargar la verificación. Recarga la página o inténtalo más tarde."
+  },
   "pathways": {
     "eyebrow": "¿Por dónde empiezo?",
     "home_title": "Elige tu camino",

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,3 +42,9 @@
     X-Frame-Options = "SAMEORIGIN"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), browsing-topics=()"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+
+[[headers]]
+  for = "/donations.json"
+  [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
+    X-Content-Type-Options = "nosniff"

--- a/netlify/functions/donations.mts
+++ b/netlify/functions/donations.mts
@@ -1,19 +1,62 @@
 import { getFundraiser, getDonationsFast } from '../../utils/fundraiser'
 import type { PublicDonation } from '../../utils/fundraiser'
+import { sanitizeDonations } from '../../utils/donationsPublic'
 import { readSeed } from '../../utils/seed'
 
 /**
  * GET /donations.json (vía redirect en netlify.toml).
  *
- * Lista pública de donantes EN VIVO (las estrellas del mapa + la tabla). Se baja
- * en paralelo, acotada por el nº total de donaciones, para entrar en el límite de
- * tiempo de la función. Se cachea en la CDN ~1 h con stale-while-revalidate: tras
- * la primera carga el usuario recibe siempre la copia cacheada al instante y la
- * revalidación es en segundo plano. Fallback: la semilla generada en build.
+ * Lista pública de donantes para el muro de gracias. Respuesta endurecida:
+ * nombres enmascarados, IDs opacos, fechas sin hora, cabeceras anti-indexación
+ * y comprobación de origen (solo helpmiriam.com y dev local).
  */
 const CDN = 'public, durable, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=86400'
+const MAX_PUBLIC_ITEMS = 500
 
-export default async () => {
+const ALLOWED_ORIGINS = [
+  'https://helpmiriam.com',
+  'https://www.helpmiriam.com',
+  'http://localhost:3000',
+  'http://localhost:8888',
+  'http://127.0.0.1:3000',
+  'http://127.0.0.1:8888',
+]
+
+function isAllowedRequest(req: Request): boolean {
+  const origin = req.headers.get('origin')
+  const referer = req.headers.get('referer')
+  if (!origin && !referer) return true
+  if (origin && ALLOWED_ORIGINS.includes(origin)) return true
+  if (referer && ALLOWED_ORIGINS.some((o) => referer.startsWith(o))) return true
+  return false
+}
+
+function securityHeaders(req: Request): HeadersInit {
+  const origin = req.headers.get('origin') ?? ''
+  const allowOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : 'https://helpmiriam.com'
+  return {
+    'Netlify-CDN-Cache-Control': CDN,
+    'Cache-Control': 'public, max-age=0, must-revalidate',
+    'X-Robots-Tag': 'noindex, nofollow',
+    'X-Content-Type-Options': 'nosniff',
+    'Access-Control-Allow-Origin': allowOrigin,
+    Vary: 'Origin',
+  }
+}
+
+function forbidden(req: Request) {
+  return new Response('Forbidden', { status: 403, headers: securityHeaders(req) })
+}
+
+export default async (req: Request) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
+  if (!isAllowedRequest(req)) {
+    return forbidden(req)
+  }
+
   try {
     let total: number | undefined
     try {
@@ -21,19 +64,19 @@ export default async () => {
     } catch {
       /* sin total → getDonationsFast cae al barrido secuencial */
     }
-    const donations = await getDonationsFast(total)
+    const donations = await getDonationsFast(total, MAX_PUBLIC_ITEMS)
     if (donations.length === 0) throw new Error('empty feed')
-    return Response.json(donations, {
-      headers: {
-        'Netlify-CDN-Cache-Control': CDN,
-        'Cache-Control': 'public, max-age=0, must-revalidate',
-      },
-    })
+    const safe = sanitizeDonations(donations)
+    return Response.json(safe, { headers: securityHeaders(req) })
   } catch {
     const seed = await readSeed<PublicDonation[]>('donations.json')
     if (seed) {
-      return Response.json(seed, {
-        headers: { 'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-if-error=86400' },
+      const safe = sanitizeDonations(seed.slice(0, MAX_PUBLIC_ITEMS))
+      return Response.json(safe, {
+        headers: {
+          ...securityHeaders(req),
+          'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-if-error=86400',
+        },
       })
     }
     return new Response('donations unavailable', { status: 502 })

--- a/netlify/functions/verify-turnstile.mts
+++ b/netlify/functions/verify-turnstile.mts
@@ -1,0 +1,82 @@
+/**
+ * POST /.netlify/functions/verify-turnstile
+ * Verifica un token de Cloudflare Turnstile antes de enviar formularios Netlify.
+ * Requiere TURNSTILE_SECRET_KEY en variables de entorno de Netlify.
+ */
+const VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+export default async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: corsHeaders(req),
+    })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders(req) })
+  }
+
+  const secret = Netlify.env.get('TURNSTILE_SECRET_KEY')
+  if (!secret) {
+    return Response.json(
+      { success: false, error: 'not_configured' },
+      { status: 503, headers: corsHeaders(req) }
+    )
+  }
+
+  let token = ''
+  try {
+    const body = (await req.json()) as { token?: string }
+    token = body.token?.trim() ?? ''
+  } catch {
+    return Response.json(
+      { success: false, error: 'invalid_body' },
+      { status: 400, headers: corsHeaders(req) }
+    )
+  }
+
+  if (!token) {
+    return Response.json(
+      { success: false, error: 'missing_token' },
+      { status: 400, headers: corsHeaders(req) }
+    )
+  }
+
+  const form = new FormData()
+  form.append('secret', secret)
+  form.append('response', token)
+  const remoteIp = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+  if (remoteIp) form.append('remoteip', remoteIp)
+
+  const verifyRes = await fetch(VERIFY_URL, { method: 'POST', body: form })
+  const result = (await verifyRes.json()) as { success?: boolean }
+
+  return Response.json(
+    { success: Boolean(result.success) },
+    { status: result.success ? 200 : 403, headers: corsHeaders(req) }
+  )
+}
+
+function corsHeaders(req: Request): HeadersInit {
+  const origin = req.headers.get('origin') ?? ''
+  const allowed = allowedOrigins()
+  const allowOrigin = allowed.includes(origin) ? origin : allowed[0]
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    Vary: 'Origin',
+  }
+}
+
+function allowedOrigins(): string[] {
+  return [
+    'https://helpmiriam.com',
+    'https://www.helpmiriam.com',
+    'http://localhost:3000',
+    'http://localhost:8888',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1:8888',
+  ]
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,21 @@ export default defineNuxtConfig({
 
   modules: ['@nuxtjs/tailwindcss', '@nuxtjs/i18n', '@nuxt/icon', '@nuxtjs/seo', '@nuxtjs/sitemap', '@nuxt/content', 'nuxt-ai-ready', '@nuxtjs/plausible', '@vueuse/nuxt', '@nuxt/fonts', '@nuxt/image'],
 
+  runtimeConfig: {
+    turnstileSecretKey: process.env.TURNSTILE_SECRET_KEY || '',
+    public: {
+      turnstileSiteKey: process.env.NUXT_PUBLIC_TURNSTILE_SITE_KEY || '',
+    },
+  },
+
+  aiReady: {
+    llmsTxt: {
+      notes: [
+        'Clinical metastasis map (/mapa-metastasis) is intentionally excluded from AI exports (noindex, patient imaging data).',
+      ],
+    },
+  },
+
   // Fuentes auto-alojadas: @nuxt/fonts las descarga en build y las sirve desde
   // el propio dominio (el cliente nunca contacta con Google → sin transferencia
   // de IP), con subsetting y font-display: swap. Sin <link> a Google Fonts.
@@ -22,7 +37,9 @@ export default defineNuxtConfig({
     name: 'Help Miriam',
   },
 
-  sitemap: {},
+  sitemap: {
+    exclude: ['/mapa-metastasis', '/en/mapa-metastasis'],
+  },
 
   // El «sistema de diseño» es una página estática suelta (public/design-system/),
   // no una ruta de Nuxt, así que el link-checker no la reconoce y la marca como
@@ -122,7 +139,7 @@ export default defineNuxtConfig({
       // /design-system/ es un export estático en public/, no una ruta de Nuxt.
       // crawlLinks lo descubre desde /colabora, intenta prerenderizarlo, da 404
       // y aborta el build. Lo ignoramos: el archivo estático se copia igual.
-      ignore: ['/design-system'],
+      ignore: ['/design-system', '/mapa-metastasis.md', '/en/mapa-metastasis.md'],
       // URLs SIN barra final, coherentes con los links y el canonical del sitio
       // (que ya usan «/colabora», no «/colabora/»). Genera «colabora.html» en
       // vez de «colabora/index.html», así Netlify sirve «/colabora» directo sin
@@ -131,4 +148,5 @@ export default defineNuxtConfig({
       autoSubfolderIndex: false,
     },
   },
+
 })

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm update-fundraiser && nuxt build",
     "dev": "pnpm update-fundraiser --force && nuxt dev",
-    "generate": "pnpm update-fundraiser && nuxt generate",
+    "generate": "pnpm update-fundraiser && nuxt generate && tsx scripts/filter-llms-export.ts",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "format": "oxfmt",

--- a/public/_robots.txt
+++ b/public/_robots.txt
@@ -2,5 +2,10 @@ User-agent: *
 Allow: /
 # block design-system
 Disallow: /design-system/
+# clinical tool · noindex (excluded from AI exports too)
+Disallow: /mapa-metastasis
+Disallow: /en/mapa-metastasis
+# donor feed · not for crawlers
+Disallow: /donations.json
 
 Sitemap: https://helpmiriam.com/sitemap.xml

--- a/scripts/filter-llms-export.ts
+++ b/scripts/filter-llms-export.ts
@@ -1,0 +1,37 @@
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { AI_EXPORT_BLOCKLIST } from '../utils/aiExportBlocklist'
+
+function filterLlmsTxt(content: string): string {
+  return content
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('- ')) return true
+      return !AI_EXPORT_BLOCKLIST.some(
+        (blocked) =>
+          trimmed.includes(`](${blocked})`) ||
+          trimmed.includes(`](${blocked}/`) ||
+          trimmed.includes(` ${blocked}:`)
+      )
+    })
+    .join('\n')
+}
+
+const roots = ['dist', join('.output', 'public')]
+let patched = 0
+
+for (const root of roots) {
+  const path = join(process.cwd(), root, 'llms.txt')
+  if (!existsSync(path)) continue
+  const content = readFileSync(path, 'utf-8')
+  const filtered = filterLlmsTxt(content)
+  if (filtered !== content) {
+    writeFileSync(path, filtered)
+    patched++
+  }
+}
+
+if (patched > 0) {
+  console.log(`✔ llms.txt: excluded ${AI_EXPORT_BLOCKLIST.length} clinical route(s) from AI index`)
+}

--- a/server/middleware/00-ai-export-guard.ts
+++ b/server/middleware/00-ai-export-guard.ts
@@ -1,0 +1,21 @@
+import { createError, getHeader } from 'h3'
+import { isAiExportBlocked, normalizeAiRoute } from '../../utils/aiExportBlocklist'
+
+/**
+ * Bloquea la exportación markdown/AI de rutas en la blocklist (p. ej.
+ * /mapa-metastasis.md o negociación Accept: text/markdown).
+ */
+export default defineEventHandler((event) => {
+  const path = event.path.split('?')[0]
+  const base = normalizeAiRoute(path)
+  if (!isAiExportBlocked(base)) return
+
+  if (path.endsWith('.md')) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const accept = getHeader(event, 'accept') || ''
+  if (accept.includes('text/markdown') && !accept.includes('text/html')) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+})

--- a/server/plugins/ai-export-prune.ts
+++ b/server/plugins/ai-export-prune.ts
@@ -1,0 +1,69 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  AI_EXPORT_BLOCKLIST,
+  isAiExportBlocked,
+  normalizeAiRoute,
+} from '../../utils/aiExportBlocklist'
+
+function filterLlmsTxt(content: string): string {
+  return content
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('- ')) return true
+      return !AI_EXPORT_BLOCKLIST.some(
+        (blocked) =>
+          trimmed.includes(`](${blocked})`) ||
+          trimmed.includes(`](${blocked}/`) ||
+          trimmed.includes(` ${blocked}:`)
+      )
+    })
+    .join('\n')
+}
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:response', async (response, { event }) => {
+    if (event?.path !== '/llms.txt') return
+    const body = response.body
+    if (typeof body === 'string') {
+      response.body = filterLlmsTxt(body)
+    }
+  })
+
+  // Bloquea la indexación markdown en build (antes de que nuxt-ai-ready procese el .md).
+  nitroApp.hooks.hook('prerender:generate', async (route) => {
+    if (route.fileName?.endsWith('.md')) {
+      let pageRoute = route.route.replace(/\.md$/, '')
+      if (pageRoute === '/index') pageRoute = '/'
+      if (isAiExportBlocked(normalizeAiRoute(pageRoute))) {
+        route.error = new Error('AI export blocked for clinical route')
+      }
+    }
+
+  })
+
+  async function patchLlmsTxtFile() {
+    const candidates = [
+      nitroApp.options?.output?.publicDir,
+      join(process.cwd(), '.output/public'),
+      join(process.cwd(), 'dist'),
+    ].filter(Boolean) as string[]
+
+    for (const dir of candidates) {
+      const llmsPath = join(dir, 'llms.txt')
+      try {
+        const content = await readFile(llmsPath, 'utf-8')
+        const filtered = filterLlmsTxt(content)
+        if (filtered !== content) await writeFile(llmsPath, filtered)
+        return
+      } catch {
+        /* probar siguiente ruta */
+      }
+    }
+  }
+
+  // Tras ai-ready (prerender:done) y de nuevo al cerrar nitro por si el orden varía.
+  nitroApp.hooks.hook('prerender:done', patchLlmsTxtFile)
+  nitroApp.hooks.hook('close', patchLlmsTxtFile)
+})

--- a/utils/aiExportBlocklist.ts
+++ b/utils/aiExportBlocklist.ts
@@ -1,0 +1,21 @@
+/**
+ * Rutas con datos clínicos sensibles o marcadas noindex que no deben exportarse
+ * a llms.txt, llms-full.txt ni endpoints .md (auditoría de seguridad §1).
+ */
+export const AI_EXPORT_BLOCKLIST = [
+  '/mapa-metastasis',
+  '/en/mapa-metastasis',
+] as const
+
+export function normalizeAiRoute(route: string): string {
+  let r = route.split('?')[0].replace(/\.md$/, '').replace(/\/$/, '') || '/'
+  if (r === '/index') r = '/'
+  return r
+}
+
+export function isAiExportBlocked(route: string): boolean {
+  const normalized = normalizeAiRoute(route)
+  return AI_EXPORT_BLOCKLIST.some(
+    (blocked) => normalized === blocked || normalized.startsWith(`${blocked}/`)
+  )
+}

--- a/utils/donationsPublic.ts
+++ b/utils/donationsPublic.ts
@@ -1,0 +1,69 @@
+import type { PublicDonation } from './fundraiser'
+
+/** Respuesta pública endurecida de /donations.json (sin PII recuperable). */
+export interface PublicDonationSafe {
+  /** Identificador opaco estable (no es el ID de GoFundMe). */
+  id: string
+  name: string
+  amount: number
+  currencyCode: string
+  /** Solo fecha (sin hora) para ordenar sin fingerprint temporal fino. */
+  createdAt: string
+}
+
+const NAME_PARTICLES = new Set([
+  'de', 'del', 'la', 'las', 'los', 'y', 'e', 'i', 'da', 'das', 'do', 'dos', 'van', 'von', 'di', 'lo',
+])
+
+function titleCase(s: string): string {
+  return s
+    .trim()
+    .toLocaleLowerCase('es-ES')
+    .replace(/(^|[\s\-'’.])(\p{L})/gu, (_m, sep: string, ch: string) => sep + ch.toLocaleUpperCase('es-ES'))
+}
+
+/** Máscara reforzada: nombre de pila + iniciales de apellidos (sin apellidos completos). */
+export function maskDonorDisplayName(fullName: string): string {
+  const tokens = fullName.split(/\s+/).filter(Boolean)
+  if (tokens.length <= 1) {
+    const t = tokens[0] ?? ''
+    return t.length > 1 ? `${t.charAt(0).toLocaleUpperCase('es-ES')}.` : t
+  }
+  const initials = tokens
+    .slice(1)
+    .filter((t) => !NAME_PARTICLES.has(t.toLocaleLowerCase('es-ES')))
+    .map((t) => `${t.charAt(0).toLocaleUpperCase('es-ES')}.`)
+  return initials.length ? `${tokens[0]} ${initials.join(' ')}` : tokens[0]
+}
+
+/** ID opaco derivado del ID de GoFundMe (estable, no reversible en cliente). */
+export function opaqueDonationId(gofundmeId: number): string {
+  let h = 0x811c9dc5
+  const s = `hm-don-${gofundmeId}`
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return `d_${(h >>> 0).toString(36)}`
+}
+
+function toDateOnly(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toISOString().slice(0, 10)
+}
+
+export function sanitizeDonation(d: PublicDonation): PublicDonationSafe {
+  const rawName = d.anonymous ? 'Anónimo' : titleCase(d.name || 'Anónimo')
+  return {
+    id: opaqueDonationId(d.id),
+    name: d.anonymous ? 'Anónimo' : maskDonorDisplayName(rawName),
+    amount: d.amount,
+    currencyCode: d.currencyCode || 'EUR',
+    createdAt: toDateOnly(d.createdAt),
+  }
+}
+
+export function sanitizeDonations(list: PublicDonation[]): PublicDonationSafe[] {
+  return list.map(sanitizeDonation)
+}


### PR DESCRIPTION
## Resumen
Implementa los ítems 1–3 de la auditoría de seguridad.

### 1. Exclusión del mapa en exports AI
- Blocklist en `utils/aiExportBlocklist.ts`
- Middleware que bloquea `.md` y negociación `Accept: text/markdown`
- Excluido del sitemap y de `robots.txt`
- Prerender hook marca `.md` clínico como error (no indexa en DB)
- Script post-`generate` filtra entradas residuales en `llms.txt` (41 páginas indexadas, mapa fuera)
- Nota explícita en `aiReady.llmsTxt.notes`

### 2. CAPTCHA en formularios
- **Cloudflare Turnstile** en `/contacto` y `CaseFollowSignup`
- Verificación server-side: `netlify/functions/verify-turnstile.mts`
- Sin claves configuradas → honeypot sigue activo (dev/local no se rompe)

**Variables Netlify (requeridas en producción):**
- `NUXT_PUBLIC_TURNSTILE_SITE_KEY`
- `TURNSTILE_SECRET_KEY`

### 3. Endurecimiento `/donations.json`
- `sanitizeDonations()`: IDs opacos, nombres enmascarados, fechas solo `YYYY-MM-DD`
- Máximo 500 donaciones en respuesta pública
- `403` si `Origin`/`Referer` no es helpmiriam.com (o localhost en dev)
- Cabeceras: `X-Robots-Tag: noindex`, CORS restringido, `nosniff`

## Verificación
- `pnpm generate` ✓
- `llms.txt` sin `/mapa-metastasis` tras el filtro post-build ✓

## Deploy
Squash merge → Netlify ejecutará `pnpm generate` (incluye el filtro de llms).
Configurar las dos env vars de Turnstile antes o justo después del deploy.