### PR TITLE
fix(conversion): P0 trust links, early campaign block, nav parity

### DIFF
--- a/app/components/SiteNav.vue
+++ b/app/components/SiteNav.vue
@@ -194,6 +194,8 @@ const navItems = [
   { key: 'science', to: { name: 'ciencia' } },
   { key: 'timeline', to: { name: 'timeline' } },
   { key: 'team', to: { name: 'equipo' } },
+  { key: 'press', to: { name: 'prensa' } },
+  { key: 'expenses', to: { name: 'gastos' } },
 ]
 // "Colabora" ahora vive en el array (antes era markup duplicado suelto).
 const allNav = [...navItems, { key: 'collaborate', to: 'colabora' as const }]

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -106,7 +106,7 @@
               <p class="text-sm text-tinta leading-relaxed mb-3">
                 {{ $t('collaborate.trust_social_body') }}
               </p>
-              <NuxtLink :to="localePath('gracias')" class="link-action text-sm text-miriam">
+              <NuxtLink :to="localePath('colabora') + '#gracias'" class="link-action text-sm text-miriam">
                 {{ $t('collaborate.trust_social_link') }}
                 <Icon name="ph:arrow-right" class="w-3.5 h-3.5" aria-hidden="true" />
               </NuxtLink>

--- a/app/pages/gracias.vue
+++ b/app/pages/gracias.vue
@@ -24,6 +24,10 @@
     </p>
 
     <div class="mt-9 flex flex-wrap gap-3 justify-center">
+      <NuxtLink :to="localePath('colabora') + '#gracias'" class="btn-secondary">
+        <Icon name="ph:star-four-fill" class="w-4 h-4" aria-hidden="true" />
+        {{ $t('thanksWall.find_star_label') }}
+      </NuxtLink>
       <button type="button" class="btn-secondary" @click="share">
         <Icon :name="copied ? 'ph:check-bold' : 'ph:share-network-fill'" class="w-4 h-4" aria-hidden="true" />
         {{ copied ? $t('thanks.copied') : $t('thanks.share') }}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,59 @@
   <div>
     <SectionHero />
 
+    <!-- Confianza temprana: progreso de campaña + prensa antes del segundo scroll -->
+    <section
+      v-reveal
+      class="py-12 sm:py-16 bg-cream-card"
+      :aria-label="$t('home.s5_eyebrow')"
+      style="border-bottom: 1px solid rgba(45,27,61,0.08)"
+    >
+      <div class="section-wide">
+        <p class="eyebrow mb-3 block">{{ $t('home.s5_eyebrow') }}</p>
+        <h2 class="font-display font-semibold text-berenjena text-xl sm:text-2xl mb-5" style="letter-spacing: -0.02em">
+          {{ $t('home.s5_heading') }}
+        </h2>
+        <GoFundMeProgress card />
+
+        <div
+          class="mt-8 pt-6 flex flex-wrap items-baseline gap-x-7 gap-y-3"
+          style="border-top: 1px solid rgba(45,27,61,0.08)"
+        >
+          <span class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta self-center">
+            {{ $t('home.s9_strip_label') }}
+          </span>
+          <a
+            :href="elPaisUrl"
+            target="_blank"
+            rel="noopener"
+            class="link-logo text-2xl sm:text-3xl"
+            @click="trackPress('El País')"
+          >El País<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
+          <a
+            :href="murciaUrl"
+            target="_blank"
+            rel="noopener"
+            class="link-logo text-2xl sm:text-3xl"
+            @click="trackPress('La Opinión de Murcia')"
+          >La Opinión de Murcia<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
+          <a
+            :href="la7Url"
+            target="_blank"
+            rel="noopener"
+            class="link-logo text-2xl sm:text-3xl"
+            @click="trackPress('La 7')"
+          >La 7<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
+          <NuxtLink
+            :to="localePath('prensa')"
+            class="link-action group sm:ml-auto self-center font-mono text-[12px] text-miriam"
+          >
+            {{ $t('home.s9_press_contact') }}
+            <Icon name="ph:arrow-right" class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+          </NuxtLink>
+        </div>
+      </div>
+    </section>
+
     <VisitorPathways variant="home" />
 
     <!-- La historia + en sus propias palabras (beat humano: persona antes que problema) -->
@@ -373,54 +426,6 @@
       </div>
     </section>
 
-    <!-- Cierre · estado de la campaña + caso en prensa (lo último de todo) -->
-    <section v-reveal class="section-spacing bg-cream-card" :aria-label="$t('home.s5_eyebrow')" style="border-top: 1px solid rgba(45,27,61,0.08)">
-      <div class="section-wide">
-        <p class="eyebrow mb-3 block">{{ $t('home.s5_eyebrow') }}</p>
-        <h2 class="font-display font-semibold text-berenjena text-2xl sm:text-3xl mb-6" style="letter-spacing: -0.02em">
-          {{ $t('home.s5_heading') }}
-        </h2>
-        <GoFundMeProgress card />
-
-        <!-- Caso en prensa · tira de medios + contacto de prensa (estilo prototipo) -->
-        <div
-          class="mt-10 pt-6 flex flex-wrap items-baseline gap-x-7 gap-y-3"
-          style="border-top: 1px solid rgba(45,27,61,0.08)"
-        >
-          <span class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta self-center">
-            {{ $t('home.s9_strip_label') }}
-          </span>
-          <a
-            :href="elPaisUrl"
-            target="_blank"
-            rel="noopener"
-            class="link-logo text-2xl sm:text-3xl"
-            @click="trackPress('El País')"
-          >El País<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
-          <a
-            :href="murciaUrl"
-            target="_blank"
-            rel="noopener"
-            class="link-logo text-2xl sm:text-3xl"
-            @click="trackPress('La Opinión de Murcia')"
-          >La Opinión de Murcia<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
-          <a
-            :href="la7Url"
-            target="_blank"
-            rel="noopener"
-            class="link-logo text-2xl sm:text-3xl"
-            @click="trackPress('La 7')"
-          >La 7<span class="sr-only"> {{ $t('a11y.new_tab') }}</span></a>
-          <NuxtLink
-            :to="localePath('prensa')"
-            class="link-action group sm:ml-auto self-center font-mono text-[12px] text-miriam"
-          >
-            {{ $t('home.s9_press_contact') }}
-            <Icon name="ph:arrow-right" class="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
-          </NuxtLink>
-        </div>
-      </div>
-    </section>
   </div>
 </template>
 


### PR DESCRIPTION
## Qué cambia (P0 auditoría)

1. **`/colabora`** — «Ver quién apoya» apunta a `#gracias` en la misma página (muro + constelación), no a `/gracias` vacía.
2. **`/gracias`** — CTA principal «Encuentra tu estrella» → `/colabora#gracias` para donantes post-GoFundMe.
3. **Home** — Bloque `GoFundMeProgress` + tira de prensa subido justo debajo del hero (antes de Pathways); se elimina el duplicado del cierre.
4. **Nav** — `Gastos` y `Prensa` visibles en cabecera desktop/móvil, alineado con footer.

## Verificación
- `pnpm lint` ✓

## Siguiente
P1: reorden home (historia antes de pathways, funnel colabora/gastos).