### PR TITLE
revert(copy): restaurar textos del hero

### DIFF
--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -8,59 +8,25 @@
 
     <div class="hero__shell section-wide">
       <div class="hero__grid">
-        <div class="hero__main">
-          <p class="hero__eyebrow eyebrow animate-fade-up">{{ $t('home.hero_eyebrow') }}</p>
+        <!-- Beat 1 · meta + titular -->
+        <div class="hero__head">
+          <div class="hero__meta animate-fade-up">
+            <span class="hero__eyebrow eyebrow">{{ $t('home.hero_eyebrow') }}</span>
+            <DaysWaitingCounter />
+          </div>
 
           <i18n-t
             keypath="hero.title"
             tag="h1"
             class="hero__title heading-display text-berenjena animate-fade-up"
-            style="animation-delay: 0.08s"
+            style="animation-delay: 0.1s"
           >
             <template #op><span class="italic text-miriam">{{ $t('hero.title_emphasis') }}</span></template>
           </i18n-t>
-
-          <p class="hero__lede text-tinta animate-fade-up" style="animation-delay: 0.14s">
-            {{ $t('hero.subtitle') }}
-          </p>
-
-          <div class="hero__actions animate-fade-up" style="animation-delay: 0.2s">
-            <a
-              href="https://gofund.me/3e25cae99"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="btn-cta hero__cta-primary"
-              @click="trackSupport('home_hero')"
-              data-support-cta
-            >
-              <Icon name="ph:heart-fill" class="heart-beat heart-beat--alive w-4 h-4 shrink-0" aria-hidden="true" />
-              {{ $t('hero.cta_donate') }}
-            </a>
-            <p class="hero__cta-note">{{ $t('home.hero_cta_donate_caption') }}</p>
-            <DaysWaitingCounter class="hero__counter" />
-            <NuxtLink
-              :to="localePath({ name: 'ciencia' })"
-              class="hero__science-link link-action group"
-              @click="trackScience('home_hero')"
-            >
-              {{ $t('hero.cta_science_link') }}
-              <Icon
-                name="ph:arrow-right"
-                class="w-4 h-4 transition-transform group-hover:translate-x-0.5"
-                aria-hidden="true"
-              />
-            </NuxtLink>
-          </div>
-
-          <p v-if="gofundme?.donationCount" class="hero__trust animate-fade-up" style="animation-delay: 0.26s">
-            <i18n-t keypath="home.hero_trust_line" tag="span">
-              <template #raised><strong class="text-berenjena nums">{{ raisedFormatted }}</strong></template>
-              <template #n><strong class="text-berenjena nums">{{ donorsFormatted }}</strong></template>
-            </i18n-t>
-          </p>
         </div>
 
-        <figure class="hero__portrait animate-fade-up" style="animation-delay: 0.12s">
+        <!-- Beat 2 · retrato -->
+        <figure class="hero__portrait animate-fade-up" style="animation-delay: 0.15s">
           <div class="hero__portrait-frame">
             <NuxtImg
               src="/img/miriam-avatar.webp"
@@ -68,13 +34,126 @@
               class="hero__portrait-img"
               width="640"
               height="640"
-              sizes="(max-width: 767px) 168px, (max-width: 1023px) 240px, 320px"
+              sizes="(max-width: 639px) 200px, (max-width: 1023px) 280px, 380px"
               format="webp"
               fetchpriority="high"
               decoding="async"
             />
           </div>
+
+          <span
+            class="hero__handle hero__handle--top"
+            aria-hidden="true"
+            translate="no"
+          >
+            @miriamgonp
+          </span>
+
+          <figcaption class="hero__portrait-tag">
+            <span>{{ $t('hero.photo_tag') }}</span>
+          </figcaption>
         </figure>
+
+        <!-- Beat 3 · brecha, acción, estado -->
+        <div class="hero__body">
+          <i18n-t
+            keypath="hero.subtitle"
+            tag="p"
+            class="hero__lede text-tinta animate-fade-up"
+            style="animation-delay: 0.2s"
+          >
+            <template #lead>
+              <strong class="font-semibold text-berenjena">{{ $t('hero.subtitle_lead', { age: caseData.currentAge }) }}</strong>
+            </template>
+            <template #twofaces>
+              <span class="two-faces">{{ $t('hero.twofaces') }}<svg
+                class="two-faces__stroke"
+                viewBox="0 0 100 8"
+                preserveAspectRatio="none"
+                aria-hidden="true"
+              >
+                <path class="tf-line" pathLength="1" d="M2 5.4 C 16 3.4, 38 7, 58 4.8 C 74 3.2, 90 6, 98 4.6" />
+              </svg></span>
+            </template>
+          </i18n-t>
+
+          <div class="hero__cta animate-fade-up" style="animation-delay: 0.3s">
+            <div class="hero__cta-cell">
+              <a
+                href="https://gofund.me/3e25cae99"
+                target="_blank"
+                rel="noopener noreferrer"
+                @click="trackSupport('home_hero')"
+                data-support-cta
+                class="btn-cta w-full justify-center"
+              >
+                <Icon name="ph:heart-fill" class="heart-beat heart-beat--alive w-4 h-4" aria-hidden="true" />
+                {{ $t('hero.cta_donate') }}
+              </a>
+              <p class="hero__cta-caption">{{ $t('home.hero_cta_donate_caption') }}</p>
+            </div>
+            <div class="hero__cta-cell">
+              <NuxtLink
+                :to="localePath({ name: 'ciencia' })"
+                class="btn-secondary w-full justify-center"
+                @click="trackScience('home_hero')"
+              >
+                <Icon name="ph:flask-fill" class="w-4 h-4" aria-hidden="true" />
+                {{ $t('hero.cta_science') }}
+              </NuxtLink>
+              <p class="hero__cta-caption">{{ $t('home.hero_cta_science_caption') }}</p>
+            </div>
+          </div>
+
+          <div class="hero__status animate-fade-up" style="animation-delay: 0.34s">
+            <p
+              v-if="gofundme?.donationCount"
+              class="hero__social"
+            >
+              <Icon name="ph:heart-fill" class="w-3.5 h-3.5 shrink-0 text-coral" aria-hidden="true" />
+              <i18n-t keypath="home.hero_social_proof" tag="span">
+                <template #n><strong class="text-berenjena nums">{{ donorsFormatted }}</strong></template>
+              </i18n-t>
+            </p>
+
+            <NuxtLink
+              v-if="latest"
+              :to="localePath({ name: 'timeline' }) + '#lo-ultimo'"
+              class="hero__latest group"
+            >
+              <span class="hero__latest-meta">
+                <span class="hero-live-dot h-2 w-2 shrink-0 rounded-full bg-coral" aria-hidden="true" />
+                <span class="font-mono uppercase text-[11px] tracking-[0.16em] font-semibold text-coral-deep">
+                  {{ $t('hero.latest_label') }}
+                </span>
+                <span v-if="latestAgo" class="font-mono text-[11px] text-tinta">· {{ latestAgo }}</span>
+              </span>
+              <span class="hero__latest-title">
+                {{ latest.title }}
+                <Icon
+                  name="ph:arrow-right"
+                  class="ml-1.5 inline-block w-3.5 h-3.5 align-[-2px] transition-transform group-hover:translate-x-0.5"
+                  aria-hidden="true"
+                />
+              </span>
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+
+      <!-- Cifras · panel alineado al shell -->
+      <div class="hero__stats animate-fade-up" style="animation-delay: 0.4s">
+        <div
+          v-for="(stat, i) in stats"
+          :key="stat.label"
+          class="hero__stat"
+          :class="{ 'hero__stat--firma': i === 3 }"
+        >
+          <p class="hero__stat-value nums" :class="i === 3 ? 'firma' : 'text-berenjena'">
+            {{ stat.value }}
+          </p>
+          <p class="hero__stat-label">{{ stat.label }}</p>
+        </div>
       </div>
     </div>
   </section>
@@ -82,7 +161,7 @@
 
 <script setup lang="ts">
 const localePath = useLocalePath()
-const { locale } = useI18n()
+const { locale, t } = useI18n()
 const { trackSupport, trackScience } = useSupport()
 
 type GoFundMeFundraiser = import('../../utils/fundraiser').GoFundMeFundraiser
@@ -104,6 +183,46 @@ onMounted(() => {
   refreshFundraiser()
 })
 
+const { data: latest } = await useAsyncData(
+  `hero-latest-${locale.value}`,
+  async () => {
+    if (locale.value === 'en') {
+      const en = await queryCollection('timeline_en').first()
+      if (en?.entries?.length) return en.entries[en.entries.length - 1]
+    }
+    const es = await queryCollection('timeline_es').first()
+    const entries = es?.entries ?? []
+    return entries.length ? entries[entries.length - 1] : null
+  },
+  { watch: [locale] }
+)
+
+const ES_MONTHS: Record<string, number> = {
+  ene: 0, feb: 1, mar: 2, abr: 3, may: 4, jun: 5,
+  jul: 6, ago: 7, sep: 8, oct: 9, nov: 10, dic: 11,
+}
+function parseTimelineDate(s?: string): Date | null {
+  if (!s) return null
+  const m = s.toLowerCase().match(/(\d{1,2})?\s*([a-zñ]{3,})\.?\s*(\d{4})/)
+  if (m) {
+    const mon = ES_MONTHS[(m[2] ?? '').slice(0, 3)]
+    if (mon !== undefined) return new Date(Number(m[3]), mon, m[1] ? Number(m[1]) : 1)
+  }
+  const y = s.match(/^\s*(\d{4})\s*$/)
+  if (y) return new Date(Number(y[1]), 0, 1)
+  const d = new Date(s)
+  return isNaN(+d) ? null : d
+}
+const latestAgo = computed(() => {
+  const d = parseTimelineDate((latest.value as { date?: string } | null)?.date)
+  if (!d) return null
+  const days = Math.floor((Date.now() - d.getTime()) / 86400000)
+  if (days < 0) return null
+  if (days === 0) return t('hero.updated_today')
+  if (days === 1) return t('hero.updated_ago_one')
+  return t('hero.updated_ago', { n: days })
+})
+
 const raisedFormatted = computed(() => {
   if (!gofundme.value) return '—'
   return formatCurrency(
@@ -119,168 +238,119 @@ const donorsFormatted = computed(() => {
     gofundme.value.donationCount
   )
 })
+
+const stats = computed(() => [
+  { value: raisedFormatted.value, label: t('hero.stat_raised_label') },
+  { value: donorsFormatted.value, label: t('hero.stat_donors_label') },
+  { value: caseData.specialists, label: t('hero.stat_specialists_label', { countries: caseData.countries }) },
+  { value: t('hero.stat_ne_value'), label: t('hero.stat_ne_label') },
+])
 </script>
 
 <style scoped>
-/* Shell */
+/* ── Shell & rejilla ───────────────────────────────────────────────────────
+   Una sola escala vertical (8px base). Columna izq = flujo narrativo;
+   columna dcha = retrato anclado arriba, sin huecos flotantes en desktop. */
 .hero__shell {
   padding-top: 1.75rem;
-  padding-bottom: 2.5rem;
+  padding-bottom: 3rem;
 }
 @media (min-width: 640px) {
   .hero__shell {
-    padding-top: 3.5rem;
-    padding-bottom: 3.5rem;
+    padding-top: 4rem;
+    padding-bottom: 4.5rem;
   }
 }
 @media (min-width: 1024px) {
   .hero__shell {
-    padding-top: 4.5rem;
-    padding-bottom: 4rem;
+    padding-top: 5rem;
+    padding-bottom: 5rem;
   }
 }
 
-/* Grid: una fila en desktop — sin span 2 que deja hueco bajo el retrato */
 .hero__grid {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
   align-items: start;
+}
+@media (min-width: 640px) {
+  .hero__grid {
+    gap: 2rem;
+  }
 }
 @media (min-width: 768px) {
   .hero__grid {
-    grid-template-columns: minmax(0, 1fr) clamp(200px, 30vw, 320px);
-    column-gap: clamp(2rem, 4vw, 3.25rem);
-    row-gap: 0;
+    grid-template-columns: minmax(0, 1fr) minmax(240px, 38%);
+    column-gap: 3.5rem;
+    row-gap: 1.5rem;
   }
-  .hero__main {
+  .hero__head {
     grid-column: 1;
     grid-row: 1;
-    min-width: 0;
   }
   .hero__portrait {
     grid-column: 2;
-    grid-row: 1;
+    grid-row: 1 / span 2;
     justify-self: end;
     width: 100%;
-    max-width: 320px;
+    max-width: 380px;
+  }
+  .hero__body {
+    grid-column: 1;
+    grid-row: 2;
   }
 }
 
-.hero__main {
+/* Meta: eyebrow + contador en la misma línea que cronología */
+.hero__meta {
   display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.625rem;
 }
-@media (min-width: 640px) {
-  .hero__main {
-    gap: 1.25rem;
-  }
-}
-
 .hero__eyebrow {
   margin: 0;
-  max-width: 36rem;
+  line-height: 1.35;
+  max-width: 28rem;
 }
 
 .hero__title {
-  margin: 0;
+  margin-top: 1.25rem;
   font-size: clamp(1.8125rem, 4.2vw, 3.25rem);
   letter-spacing: -0.03em;
   line-height: 1.08;
-  max-width: 20ch;
+  max-width: 14ch;
   text-wrap: balance;
 }
-@media (min-width: 768px) {
+@media (min-width: 640px) {
   .hero__title {
-    max-width: 14ch;
-  }
-}
-@media (min-width: 1024px) {
-  .hero__title {
+    margin-top: 1.5rem;
     max-width: 16ch;
   }
 }
-
-.hero__lede {
-  margin: 0;
-  font-size: 1rem;
-  line-height: 1.55;
-  max-width: 36rem;
-}
-@media (min-width: 640px) {
-  .hero__lede {
-    font-size: 1.125rem;
-    line-height: 1.5;
-  }
-}
-
-.hero__actions {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.625rem;
-  max-width: 22rem;
-  width: 100%;
-}
-@media (min-width: 480px) {
-  .hero__actions {
-    max-width: 24rem;
-  }
-}
-
-.hero__cta-primary {
-  width: 100%;
-  justify-content: center;
-}
-
-.hero__cta-note {
-  margin: 0;
-  font-size: 0.75rem;
-  line-height: 1.45;
-  color: #3a3340;
-}
-
-.hero__counter {
-  margin-top: 0.125rem;
-}
-
-.hero__science-link {
-  margin-top: 0.25rem;
-  font-size: 0.875rem;
-}
-
-.hero__trust {
-  margin: 0;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.08);
-  font-size: 0.875rem;
-  line-height: 1.45;
-  color: #3a3340;
-  max-width: 36rem;
-}
 @media (min-width: 768px) {
-  .hero__trust {
-    margin-top: 0.25rem;
+  /* Misma medida que lede/CTA: el titular no «estrecha» la columna en desktop. */
+  .hero__title {
+    max-width: 36rem;
   }
 }
 
-/* Retrato limpio — sin pills que desbordan la rejilla */
+/* Retrato */
 .hero__portrait {
+  position: relative;
   margin: 0;
   width: 100%;
-  max-width: 168px;
-  justify-self: center;
+  max-width: 200px;
+  margin-inline: auto;
 }
 @media (min-width: 640px) {
   .hero__portrait {
-    max-width: 220px;
+    max-width: 280px;
   }
 }
 @media (min-width: 768px) {
   .hero__portrait {
-    justify-self: end;
-    align-self: start;
-    max-width: 100%;
+    margin-inline: 0;
   }
 }
 
@@ -298,24 +368,266 @@ const donorsFormatted = computed(() => {
   object-fit: cover;
 }
 
-/* Móvil: texto primero, foto después del bloque de acción (menos interrupción) */
-@media (max-width: 767px) {
-  .hero__grid {
-    grid-template-areas:
-      'main'
-      'portrait';
+.hero__handle {
+  position: absolute;
+  z-index: 2;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: #9d44ab;
+  color: #faf6f0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  box-shadow: 0 8px 20px -8px rgba(45, 27, 61, 0.45);
+  transform: rotate(2deg);
+}
+@media (min-width: 640px) {
+  .hero__handle {
+    font-size: 11px;
+    padding: 0.45rem 0.85rem;
   }
-  .hero__main {
-    grid-area: main;
+}
+.hero__handle--top {
+  right: 0.5rem;
+  top: -0.65rem;
+}
+@media (min-width: 640px) {
+  .hero__handle--top {
+    right: -0.35rem;
+    top: 1.5rem;
   }
-  .hero__portrait {
-    grid-area: portrait;
-    max-width: 140px;
-    margin-inline: auto;
-    order: 2;
+}
+
+.hero__portrait-tag {
+  display: flex;
+  justify-content: center;
+  margin-top: -0.85rem;
+  position: relative;
+  z-index: 2;
+}
+.hero__portrait-tag span {
+  display: inline-block;
+  border-radius: 999px;
+  background: #2d1b3d;
+  color: #faf6f0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 0.4rem 0.9rem;
+  box-shadow: 0 10px 24px -12px rgba(45, 27, 61, 0.55);
+}
+@media (min-width: 640px) {
+  .hero__portrait-tag span {
+    font-size: 11px;
   }
-  .hero__main {
-    order: 1;
+}
+
+/* Cuerpo textual */
+.hero__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-width: 0;
+}
+@media (min-width: 640px) {
+  .hero__body {
+    gap: 1.5rem;
   }
+}
+
+.hero__lede {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.55;
+  max-width: 36rem;
+}
+@media (min-width: 640px) {
+  .hero__lede {
+    font-size: 1.25rem;
+    line-height: 1.5;
+  }
+}
+
+/* CTAs · misma anchura y captions alineadas */
+.hero__cta {
+  display: grid;
+  gap: 1rem;
+  max-width: 36rem;
+}
+@media (min-width: 480px) {
+  .hero__cta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem 1.25rem;
+  }
+}
+
+.hero__cta-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.hero__cta-caption {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: #3a3340;
+  min-height: 2.25rem;
+}
+
+/* Estado · bloque encuadrado, sin zona muerta */
+.hero__status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  max-width: 36rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(45, 27, 61, 0.08);
+}
+@media (min-width: 640px) {
+  .hero__status {
+    padding-top: 1.5rem;
+    gap: 1rem;
+  }
+}
+
+.hero__social {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: #3a3340;
+}
+
+.hero__latest {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.hero__latest-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.hero__latest-title {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: #9d44ab;
+  text-decoration: underline;
+  text-decoration-color: rgba(157, 68, 171, 0.5);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.15s ease;
+}
+.hero__latest:hover .hero__latest-title {
+  text-decoration-color: #9d44ab;
+}
+
+/* Stats · rejilla cerrada, alturas iguales */
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem 1.25rem;
+  margin-top: 2.5rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(45, 27, 61, 0.1);
+}
+@media (min-width: 640px) {
+  .hero__stats {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0;
+    margin-top: 3rem;
+    padding-top: 2.25rem;
+  }
+}
+
+.hero__stat {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  min-height: 4.5rem;
+}
+@media (min-width: 640px) {
+  .hero__stat {
+    padding-inline: 1.75rem;
+    border-left: 1px solid rgba(45, 27, 61, 0.14);
+    min-height: 5rem;
+  }
+  .hero__stat:first-child {
+    padding-left: 0;
+    border-left: 0;
+  }
+}
+
+.hero__stat-value {
+  margin: 0;
+  font-family: 'Fraunces', serif;
+  font-weight: 600;
+  font-size: clamp(2.25rem, 4.2vw, 3.75rem);
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.hero__stat-label {
+  margin: 0.625rem 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  line-height: 1.35;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #3a3340;
+}
+
+/* «dos caras» */
+.two-faces {
+  position: relative;
+  font-style: italic;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.two-faces__stroke {
+  position: absolute;
+  left: -1.5%;
+  bottom: -0.22em;
+  width: 103%;
+  height: 0.34em;
+  overflow: visible;
+  pointer-events: none;
+}
+.tf-line {
+  fill: none;
+  stroke: #9d44ab;
+  stroke-width: 2.6;
+  stroke-linecap: round;
+}
+@media (prefers-reduced-motion: no-preference) {
+  .tf-line {
+    stroke-dasharray: 1;
+    stroke-dashoffset: 1;
+    animation: tf-draw 0.55s ease-out 0.8s forwards;
+  }
+  @keyframes tf-draw {
+    to { stroke-dashoffset: 0; }
+  }
+}
+
+.hero-live-dot {
+  animation: hero-pulse 2s ease-in-out 3;
+}
+@keyframes hero-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 107, 71, 0.4); }
+  50% { box-shadow: 0 0 0 7px rgba(255, 107, 71, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hero-live-dot { animation: none; }
 }
 </style>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -129,7 +129,7 @@
     "brief_outro": "To go deeper, The science has a summary for everyone and a professional mode with tables and imaging.",
     "brief_cta_science": "View the science",
     "brief_cta_help": "See all ways to help",
-    "hero_sr_summary": "Miriam González has metastatic breast cancer with two biologies. Public healthcare does not cover the precision tests she needs. You can support the campaign or read the clinical case in The science."
+    "hero_sr_summary": "Miriam González has an ultra-rare metastatic breast cancer with two biologies. This site funds precision tests that public healthcare does not cover. You can donate, read the science, collaborate by profile, or share the campaign."
   },
   "glossary": {
     "hint": "Tap or hover the highlighted words and markers to see what they mean."
@@ -243,8 +243,7 @@
     "title": "A rare cancer, {op}.",
     "title_short": "A rare cancer, a real opportunity.",
     "title_emphasis": "a real opportunity",
-    "subtitle": "Spanish protocols only cover half of her tumor. This campaign funds the precision tests that are missing.",
-    "cta_science_link": "See the science behind the case",
+    "subtitle": "{lead} has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
     "twofaces": "two sides",
     "subtitle_lead": "Miriam, {age},",
     "cta_donate": "Support Miriam",
@@ -545,11 +544,10 @@
     "s10_l3_text": "Every euro funds research applied to the case: deep sequencing, molecular rebiopsy, international second opinions, N-of-1 trial.",
     "s10_l3_button": "Support Miriam",
     "s10_l3_caption": "Secure payment. Receipt available. 100% to Miriam's case.",
-    "hero_cta_donate_caption": "Secure payment · Receipt available · 100% to the case.",
+    "hero_cta_donate_caption": "Every euro funds clinical research applied to her case.",
     "hero_cta_science_caption": "Open the full molecular profile in The science.",
     "hero_social_proof": "Already supported by {n} people · featured in El País",
-    "hero_trust_line": "{raised} raised · {n} people · El País",
-    "hero_eyebrow": "Metastatic breast · two biologies",
+    "hero_eyebrow": "Metastatic breast cancer · Ultra-rare molecular profile",
     "story_eyebrow": "The story",
     "story_heading": "A diagnosis that fit no protocol.",
     "story_p1": "At 33, Miriam was diagnosed with a metastatic breast cancer so rare it is seen in ",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -129,7 +129,7 @@
     "brief_outro": "Si quieres profundizar, La ciencia tiene un resumen para todos y un modo profesional con tablas e imágenes.",
     "brief_cta_science": "Ver la ciencia",
     "brief_cta_help": "Ver todas las formas de ayudar",
-    "hero_sr_summary": "Miriam González tiene cáncer de mama metastásico con dos biologías. La sanidad pública no cubre las pruebas de precisión que necesita. Puedes apoyar la campaña o leer el caso clínico en La ciencia."
+    "hero_sr_summary": "Miriam González tiene un cáncer de mama metastásico ultra-raro con dos biologías. Esta web financia las pruebas de precisión que la sanidad pública no cubre. Puedes apoyar económicamente, leer la ciencia del caso, colaborar según tu perfil o compartir la campaña."
   },
   "glossary": {
     "hint": "Toca o pasa el cursor por las palabras y marcadores resaltados para ver qué significan."
@@ -243,8 +243,7 @@
     "title": "Un cáncer raro, {op} real.",
     "title_short": "Un cáncer raro, una oportunidad real.",
     "title_emphasis": "una oportunidad",
-    "subtitle": "Los protocolos españoles solo cubren la mitad de su tumor. Esta campaña financia las pruebas de precisión que faltan.",
-    "cta_science_link": "Ver la ciencia del caso",
+    "subtitle": "{lead} tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
     "twofaces": "dos caras",
     "subtitle_lead": "Miriam, {age} años,",
     "cta_donate": "Apoyar a Miriam",
@@ -568,11 +567,10 @@
     "s10_l3_text": "Cada euro financia investigación aplicada al caso: secuenciación profunda, rebiopsia molecular, segundas opiniones internacionales, ensayo N-of-1.",
     "s10_l3_button": "Apoyar a Miriam",
     "s10_l3_caption": "Pago seguro. Recibo disponible. 100% al caso de Miriam.",
-    "hero_cta_donate_caption": "Pago seguro · Recibo disponible · 100% al caso.",
+    "hero_cta_donate_caption": "Cada euro va a investigación clínica aplicada a su caso.",
     "hero_cta_science_caption": "Accede al perfil molecular completo en La ciencia.",
     "hero_social_proof": "Ya nos apoyan {n} personas · visto en El País",
-    "hero_trust_line": "{raised} recaudados · {n} personas · El País",
-    "hero_eyebrow": "Mama metastásica · dos biologías",
+    "hero_eyebrow": "Cáncer de mama metastásico · Perfil molecular ultra-raro",
     "story_eyebrow": "La historia",
     "story_heading": "Un diagnóstico que no cabía en ningún protocolo.",
     "story_p1": "Con 33 años, a Miriam le diagnosticaron un cáncer de mama metastásico tan raro que se ve en ",


### PR DESCRIPTION
Revert del PR #86 (destilación de copy del hero). Los textos vuelven a como estaban antes.

## Restaurado
- Subtítulo completo con «dos caras» y edad de Miriam
- Eyebrow «Perfil molecular ultra-raro»
- Caption del CTA de donación original
- Panel de stats, «Lo último» de cronología, @miriamgonp, etc.

## Se mantiene (solo estructura, sin tocar copy)
- Enlaces a `/colabora#gracias` (#87)
- Nav con Gastos + Prensa (#87)
- Bloque GoFundMe + prensa subido en home (#87) — **avísame si también quieres revertir esto**

No mergeo sin tu OK.