### PR TITLE
fix(responsive): espaciado y barra sticky solo móvil/tablet

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -92,6 +92,13 @@
     @apply py-20 sm:py-28;
   }
 
+  /* Espacio bajo el contenido cuando la barra de apoyo fija está activa (<lg). */
+  @media (max-width: 1023px) {
+    main {
+      padding-bottom: calc(4.5rem + env(safe-area-inset-bottom, 0px));
+    }
+  }
+
   /* Borde superior con el menú: la PRIMERA sección de cada página vive justo bajo
      el nav sticky, que ya aporta separación. Su top debe ser menor que el ritmo
      entre secciones (py-28 = 112px), que se reserva para los saltos intermedios.
@@ -945,7 +952,7 @@
   .pathway-grid {
     display: grid;
     gap: 1rem;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
   }
 
   .pathway-card {

--- a/app/components/DonationReturnPrompt.vue
+++ b/app/components/DonationReturnPrompt.vue
@@ -95,8 +95,8 @@ onBeforeUnmount(() => document.removeEventListener('visibilitychange', maybeShow
   background: #2d1b3d;
   box-shadow: 0 16px 40px -12px rgba(45, 27, 61, 0.5);
 }
-/* En móvil, sobre la barra de apoyo persistente. */
-@media (max-width: 639px) {
+/* Sobre la barra de apoyo persistente (<lg). En desktop queda abajo a la derecha. */
+@media (max-width: 1023px) {
   .drp {
     bottom: calc(88px + env(safe-area-inset-bottom, 0px));
   }

--- a/app/components/GoFundMeProgress.vue
+++ b/app/components/GoFundMeProgress.vue
@@ -74,7 +74,7 @@ const activeProgress = computed(() => {
   <!-- Card variant — dark editorial progress block -->
   <div
     v-if="card && data"
-    class="rounded-[24px] p-8 sm:p-10"
+    class="rounded-[24px] p-6 sm:p-8 lg:p-10"
     style="background: #2d1b3d; color: #faf6f0"
   >
     <p

--- a/app/components/MobileSupportBar.vue
+++ b/app/components/MobileSupportBar.vue
@@ -7,7 +7,7 @@
     leave-from-class="translate-y-0"
     leave-to-class="translate-y-full"
   >
-    <div v-if="visible" class="mobile-support-bar sm:hidden">
+    <div v-if="visible" class="mobile-support-bar lg:hidden">
       <a
         :href="GOFUNDME_URL"
         target="_blank"
@@ -35,7 +35,7 @@
  * Barra de apoyo persistente en móvil (plan Decisión 5, default B).
  * La cabecera oculta el botón de donar por debajo de `sm`; con ~80% del
  * tráfico en móvil hace falta un CTA siempre a mano, donde vive el pulgar.
- * · Solo en móvil (`sm:hidden`).
+ * · Solo en móvil y tablet estrecha (`lg:hidden`; desktop ≥1024px sin barra).
  * · Aparece tras pasar el hero.
  * · Se oculta cerca del footer/cierre (para no duplicar el CTA) y en /gracias.
  * · Respeta safe-area-inset-bottom y prefers-reduced-motion.
@@ -59,8 +59,14 @@ function anyCtaVisible(): boolean {
   return false
 }
 
+const DESKTOP_MIN = 1024
+
 function update() {
   if (typeof window === 'undefined') return
+  if (window.innerWidth >= DESKTOP_MIN) {
+    visible.value = false
+    return
+  }
   if (route.path.includes('gracias')) {
     visible.value = false
     return
@@ -83,6 +89,12 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
+@media (min-width: 1024px) {
+  .mobile-support-bar {
+    display: none !important;
+  }
+}
+
 .mobile-support-bar {
   position: fixed;
   left: 0;

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -270,19 +270,32 @@ const stats = computed(() => [
 
 .hero__grid {
   display: grid;
-  gap: 1.25rem;
+  gap: 1rem;
   align-items: start;
+}
+@media (max-width: 767px) {
+  /* Narrativa continua: titular → texto/CTA → retrato (evita hueco entre H1 y lede). */
+  .hero__head {
+    order: 1;
+  }
+  .hero__body {
+    order: 2;
+  }
+  .hero__portrait {
+    order: 3;
+    margin-top: 0.25rem;
+  }
 }
 @media (min-width: 640px) {
   .hero__grid {
-    gap: 2rem;
+    gap: 1.5rem;
   }
 }
 @media (min-width: 768px) {
   .hero__grid {
-    grid-template-columns: minmax(0, 1fr) minmax(240px, 38%);
-    column-gap: 3.5rem;
-    row-gap: 1.5rem;
+    grid-template-columns: minmax(0, 1fr) minmax(220px, 36%);
+    column-gap: clamp(2rem, 4vw, 3.25rem);
+    row-gap: 1.25rem;
   }
   .hero__head {
     grid-column: 1;
@@ -292,8 +305,9 @@ const stats = computed(() => [
     grid-column: 2;
     grid-row: 1 / span 2;
     justify-self: end;
+    align-self: start;
     width: 100%;
-    max-width: 380px;
+    max-width: min(380px, 100%);
   }
   .hero__body {
     grid-column: 1;
@@ -340,12 +354,12 @@ const stats = computed(() => [
   position: relative;
   margin: 0;
   width: 100%;
-  max-width: 200px;
+  max-width: 168px;
   margin-inline: auto;
 }
 @media (min-width: 640px) {
   .hero__portrait {
-    max-width: 280px;
+    max-width: 240px;
   }
 }
 @media (min-width: 768px) {
@@ -536,9 +550,9 @@ const stats = computed(() => [
 .hero__stats {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.5rem 1.25rem;
-  margin-top: 2.5rem;
-  padding-top: 2rem;
+  gap: 1.25rem 1rem;
+  margin-top: 2rem;
+  padding-top: 1.75rem;
   border-top: 1px solid rgba(45, 27, 61, 0.1);
 }
 @media (min-width: 640px) {
@@ -572,7 +586,7 @@ const stats = computed(() => [
   margin: 0;
   font-family: 'Fraunces', serif;
   font-weight: 600;
-  font-size: clamp(2.25rem, 4.2vw, 3.75rem);
+  font-size: clamp(1.875rem, 5vw, 3.75rem);
   line-height: 1;
   letter-spacing: -0.04em;
 }

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -80,7 +80,7 @@
              vivo y prueba social en un solo vistazo. -->
         <aside class="card-base bg-cream mb-10" :aria-label="$t('collaborate.trust_aria')">
           <p class="eyebrow mb-4 block">{{ $t('collaborate.trust_eyebrow') }}</p>
-          <div class="grid gap-6 sm:grid-cols-3 sm:items-start">
+          <div class="grid gap-6 lg:grid-cols-3 lg:items-start">
             <div class="flex flex-col">
               <h3 class="font-display font-semibold text-berenjena text-base mb-1.5">
                 {{ $t('collaborate.trust_transparency_title') }}

--- a/app/pages/equipo.vue
+++ b/app/pages/equipo.vue
@@ -13,7 +13,7 @@
         </p>
         <ul
           aria-labelledby="team-miriam"
-          class="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-9 mb-16 stagger-children"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-9 mb-16 stagger-children"
         >
           <li v-for="member in coreTeam" :key="member.name">
             <TeamPortrait :member="member" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -5,7 +5,7 @@
     <VisitorPathways variant="home" />
 
     <!-- La historia + en sus propias palabras (beat humano: persona antes que problema) -->
-    <section v-reveal class="py-24 sm:py-32 relative overflow-hidden" :aria-label="$t('home.story_eyebrow')" style="background: #2d1b3d; color: #faf6f0">
+    <section v-reveal class="py-20 sm:py-28 relative overflow-hidden" :aria-label="$t('home.story_eyebrow')" style="background: #2d1b3d; color: #faf6f0">
       <div class="absolute inset-0 opacity-[0.04]" style="background-image: radial-gradient(circle at 1px 1px, #faf6f0 1px, transparent 0); background-size: 32px 32px;" />
       <div class="relative section-wide">
         <p class="eyebrow block" style="color: #e8d4ed">
@@ -303,7 +303,7 @@
         <h2 class="heading-display text-3xl sm:text-4xl text-berenjena mb-6" style="letter-spacing: -0.03em">
           {{ $t('home.s10_intro') }}
         </h2>
-        <div class="grid sm:grid-cols-3 gap-6 text-left mt-12">
+        <div class="grid md:grid-cols-3 gap-6 text-left mt-12">
           <article class="card-base flex flex-col" style="background: #faf6f0">
             <p class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta mb-2">01</p>
             <h3 class="font-display font-semibold text-berenjena text-xl mb-3">{{ $t('home.s10_l1_title') }}</h3>


### PR DESCRIPTION
Solo CSS/layout, sin cambios de copy.

- Barra inferior de apoyo: solo <1024px (desktop sin botón sticky)
- Hero: sin hueco entre H1 y lede en móvil; retrato después del texto
- Padding inferior en main para que la barra no tape contenido
- Rejillas más seguras en colabora, home S10, equipo, pathways
- GoFundMe card con padding escalonado