### PR TITLE
fix(ui): hero equilibrado + pulido de espaciado

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -960,9 +960,9 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
-  @media (min-width: 1280px) {
+  @media (min-width: 1024px) {
     .pathway-grid {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -8,54 +8,49 @@
 
     <div class="hero__shell section-wide">
       <div class="hero__grid">
-        <!-- Fila superior: titular + retrato (misma altura visual, sin hueco lateral debajo) -->
-        <div class="hero__intro">
-          <div class="hero__head">
-            <div class="hero__meta animate-fade-up">
-              <span class="hero__eyebrow eyebrow">{{ $t('home.hero_eyebrow') }}</span>
-              <DaysWaitingCounter />
-            </div>
-
-            <i18n-t
-              keypath="hero.title"
-              tag="h1"
-              class="hero__title heading-display text-berenjena animate-fade-up"
-              style="animation-delay: 0.1s"
-            >
-              <template #op><span class="italic text-miriam">{{ $t('hero.title_emphasis') }}</span></template>
-            </i18n-t>
+        <div class="hero__head">
+          <div class="hero__meta animate-fade-up">
+            <span class="hero__eyebrow eyebrow">{{ $t('home.hero_eyebrow') }}</span>
           </div>
 
-          <figure class="hero__portrait animate-fade-up" style="animation-delay: 0.15s">
-            <div class="hero__portrait-frame">
-              <NuxtImg
-                src="/img/miriam-avatar.webp"
-                :alt="$t('home.s6_photo_alt')"
-                class="hero__portrait-img"
-                width="640"
-                height="640"
-                sizes="(max-width: 639px) 168px, (max-width: 1023px) 200px, 240px"
-                format="webp"
-                fetchpriority="high"
-                decoding="async"
-              />
-            </div>
-
-            <span
-              class="hero__handle hero__handle--top"
-              aria-hidden="true"
-              translate="no"
-            >
-              @miriamgonp
-            </span>
-
-            <figcaption class="hero__portrait-tag">
-              <span>{{ $t('hero.photo_tag') }}</span>
-            </figcaption>
-          </figure>
+          <i18n-t
+            keypath="hero.title"
+            tag="h1"
+            class="hero__title heading-display text-berenjena animate-fade-up"
+            style="animation-delay: 0.1s"
+          >
+            <template #op><span class="italic text-miriam">{{ $t('hero.title_emphasis') }}</span></template>
+          </i18n-t>
         </div>
 
-        <!-- Cuerpo a ancho completo bajo la intro -->
+        <figure class="hero__portrait animate-fade-up" style="animation-delay: 0.15s">
+          <div class="hero__portrait-frame">
+            <NuxtImg
+              src="/img/miriam-avatar.webp"
+              :alt="$t('home.s6_photo_alt')"
+              class="hero__portrait-img"
+              width="640"
+              height="640"
+              sizes="(max-width: 639px) 200px, (max-width: 767px) 280px, 400px"
+              format="webp"
+              fetchpriority="high"
+              decoding="async"
+            />
+          </div>
+
+          <span
+            class="hero__handle hero__handle--top"
+            aria-hidden="true"
+            translate="no"
+          >
+            @miriamgonp
+          </span>
+
+          <figcaption class="hero__portrait-tag">
+            <span>{{ $t('hero.photo_tag') }}</span>
+          </figcaption>
+        </figure>
+
         <div class="hero__body">
           <i18n-t
             keypath="hero.subtitle"
@@ -107,6 +102,7 @@
           </div>
 
           <div class="hero__status animate-fade-up" style="animation-delay: 0.34s">
+            <DaysWaitingCounter class="hero__status-counter" />
             <p
               v-if="gofundme?.donationCount"
               class="hero__social"
@@ -276,13 +272,6 @@ const stats = computed(() => [
   min-width: 0;
 }
 
-.hero__intro {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  min-width: 0;
-}
-
 .hero__head,
 .hero__body,
 .hero__portrait {
@@ -290,9 +279,6 @@ const stats = computed(() => [
 }
 
 @media (max-width: 767px) {
-  .hero__intro {
-    display: contents;
-  }
   .hero__head {
     order: 1;
   }
@@ -305,35 +291,15 @@ const stats = computed(() => [
   }
 }
 
-@media (min-width: 768px) and (max-width: 1023px) {
-  .hero__intro {
-    display: contents;
-  }
-  .hero__head {
-    order: 1;
-  }
-  .hero__body {
-    order: 2;
-  }
-  .hero__portrait {
-    order: 3;
-    max-width: 200px;
-    margin-inline: auto;
-    margin-top: 0.5rem;
-  }
-}
-
-@media (min-width: 1024px) {
-  /* Fila 1: titular + retrato. Fila 2: cuerpo a ancho completo (sin hueco lateral derecho). */
+@media (min-width: 768px) {
   .hero__grid {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) clamp(200px, 22vw, 260px);
-    column-gap: clamp(2rem, 3vw, 2.75rem);
-    row-gap: 1.5rem;
+    /* Pista de la foto más estrecha (~320–400px) + gutter normal → cierra el
+       «valle» central que dejaba el texto (36rem) frente a la foto anclada. */
+    grid-template-columns: minmax(0, 1fr) clamp(20rem, 26vw, 25rem);
+    column-gap: clamp(2rem, 3.5vw, 3.25rem);
+    row-gap: 1.25rem;
     align-items: start;
-  }
-  .hero__intro {
-    display: contents;
   }
   .hero__head {
     grid-column: 1;
@@ -341,23 +307,18 @@ const stats = computed(() => [
   }
   .hero__portrait {
     grid-column: 2;
-    grid-row: 1;
-    justify-self: end;
+    grid-row: 1 / span 2;
+    /* La pista gobierna el ancho (mata el bug de cascada 280px) y la foto se
+       ancla arriba, junto al titular, en vez de flotar centrada. */
+    justify-self: stretch;
     align-self: start;
     width: 100%;
-    max-width: 260px;
+    max-width: none;
+    margin-top: 0.5rem;
   }
   .hero__body {
-    grid-column: 1 / -1;
+    grid-column: 1;
     grid-row: 2;
-    max-width: none;
-  }
-  .hero__lede,
-  .hero__status {
-    max-width: 42rem;
-  }
-  .hero__cta {
-    max-width: 42rem;
   }
 }
 
@@ -395,22 +356,22 @@ const stats = computed(() => [
   }
 }
 
-/* Retrato */
+/* Retrato — el tamaño SOLO se fija en móvil/tablet (apilado). En desktop (≥768)
+   lo gobierna la pista del grid; sin max-width aquí para no pisar (bug de cascada). */
 .hero__portrait {
   position: relative;
   margin: 0;
   width: 100%;
-  max-width: 168px;
-  margin-inline: auto;
 }
-@media (min-width: 640px) {
+@media (max-width: 767px) {
   .hero__portrait {
-    max-width: 240px;
+    max-width: 200px;
+    margin-inline: auto;
   }
 }
-@media (min-width: 1024px) {
+@media (min-width: 640px) and (max-width: 767px) {
   .hero__portrait {
-    margin-inline: 0;
+    max-width: 280px;
   }
 }
 
@@ -448,20 +409,20 @@ const stats = computed(() => [
   }
 }
 .hero__handle--top {
-  right: 0.25rem;
-  top: 0.5rem;
+  right: 0.5rem;
+  top: -0.65rem;
 }
 @media (min-width: 640px) {
   .hero__handle--top {
-    right: 0.5rem;
-    top: 0.75rem;
+    right: -0.35rem;
+    top: 1.5rem;
   }
 }
 
 .hero__portrait-tag {
   display: flex;
   justify-content: center;
-  margin-top: 0.65rem;
+  margin-top: -0.85rem;
   position: relative;
   z-index: 2;
 }
@@ -545,6 +506,10 @@ const stats = computed(() => [
   max-width: 36rem;
   padding-top: 1.25rem;
   border-top: 1px solid rgba(45, 27, 61, 0.08);
+}
+/* El contador (píldora) no debe estirarse a todo el ancho del bloque flex. */
+.hero__status-counter {
+  align-self: flex-start;
 }
 @media (min-width: 640px) {
   .hero__status {

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -475,7 +475,7 @@
             : 'Each treatment line has held the disease for a while before the tumour escapes again: the pattern to expect when only the hormonal axis is targeted and the neuroendocrine component is left out.' }}
         </p>
         <ul class="space-y-3 mb-14" aria-labelledby="treatment-title">
-          <li v-for="tx in treatments" :key="tx.line" class="card-base flex items-center gap-4">
+          <li v-for="tx in treatments" :key="tx.line" class="card-base flex items-start gap-4">
             <span
               class="shrink-0 w-9 h-9 rounded-lg flex items-center justify-center font-mono text-xs font-bold"
               :class="tx.active ? 'bg-miriam-soft text-berenjena' : 'bg-cream text-tinta'"

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -138,7 +138,7 @@
                 <Icon name="ph:envelope-simple-fill" class="w-4 h-4" aria-hidden="true" />
                 {{ $t('collaborate.profile1_cta_label') }}
               </NuxtLink>
-              <p class="mt-2 text-xs text-tinta sm:min-h-[2.25rem]">{{ $t('collaborate.profile1_cta_caption') }}</p>
+              <p class="mt-2 text-xs text-tinta md:min-h-[2.25rem]">{{ $t('collaborate.profile1_cta_caption') }}</p>
             </div>
           </article>
 
@@ -163,7 +163,7 @@
                 <Icon name="ph:megaphone-simple-fill" class="w-4 h-4" aria-hidden="true" />
                 {{ $t('collaborate.profile3_cta_label') }}
               </NuxtLink>
-              <p class="mt-2 text-xs text-tinta sm:min-h-[2.25rem]">{{ $t('collaborate.profile3_cta_caption') }}</p>
+              <p class="mt-2 text-xs text-tinta md:min-h-[2.25rem]">{{ $t('collaborate.profile3_cta_caption') }}</p>
             </div>
           </article>
 
@@ -200,7 +200,7 @@
                 <Icon name="ph:envelope-simple-fill" class="w-4 h-4" aria-hidden="true" />
                 {{ $t('collaborate.profile4_cta_label') }}
               </NuxtLink>
-              <p class="mt-2 text-xs text-tinta sm:min-h-[2.25rem]">{{ $t('collaborate.profile4_cta_caption') }}</p>
+              <p class="mt-2 text-xs text-tinta md:min-h-[2.25rem]">{{ $t('collaborate.profile4_cta_caption') }}</p>
             </div>
           </article>
 
@@ -225,7 +225,7 @@
                 <Icon name="ph:envelope-simple-fill" class="w-4 h-4" aria-hidden="true" />
                 {{ $t('collaborate.profile5_cta_label') }}
               </NuxtLink>
-              <p class="mt-2 text-xs text-tinta sm:min-h-[2.25rem]">{{ $t('collaborate.profile5_cta_caption') }}</p>
+              <p class="mt-2 text-xs text-tinta md:min-h-[2.25rem]">{{ $t('collaborate.profile5_cta_caption') }}</p>
             </div>
           </article>
 
@@ -268,7 +268,7 @@
                 <Icon name="ph:heart-fill" class="heart-beat heart-beat--alive w-4 h-4" aria-hidden="true" />
                 {{ $t('collaborate.profile2_cta_label') }}
               </a>
-              <p class="mt-2 text-xs text-tinta sm:min-h-[2.25rem]">{{ $t('collaborate.profile2_cta_caption') }}</p>
+              <p class="mt-2 text-xs text-tinta md:min-h-[2.25rem]">{{ $t('collaborate.profile2_cta_caption') }}</p>
             </div>
           </article>
         </div>
@@ -300,7 +300,7 @@
         >
           {{ $t('collaborate.links_title') }}
         </h2>
-        <p class="text-tinta leading-relaxed mb-8 max-w-2xl">
+        <p class="text-tinta leading-relaxed mb-6 max-w-2xl">
           {{ $t('collaborate.links_sub') }}
         </p>
 

--- a/app/pages/contacto.vue
+++ b/app/pages/contacto.vue
@@ -160,9 +160,10 @@
               class="card-base space-y-5"
               @submit.prevent="onSubmit"
             >
-              <input type="hidden" name="form-name" value="contact" />
+              <input type="hidden" hidden name="form-name" value="contact" />
               <input
                 type="hidden"
+                hidden
                 name="subject"
                 value="Nuevo mensaje de contacto — helpmiriam.com"
               />

--- a/app/pages/equipo.vue
+++ b/app/pages/equipo.vue
@@ -26,7 +26,7 @@
         </h2>
         <ul
           aria-labelledby="team-medical"
-          class="grid sm:grid-cols-2 gap-4 mb-14 stagger-children"
+          class="grid sm:grid-cols-2 gap-4 mb-16 stagger-children"
         >
           <li v-for="member in medicalNetwork" :key="member.role">
             <TeamCard :member="member" />
@@ -77,6 +77,7 @@
                 v-for="(item, i) in notUsItems"
                 :key="i"
                 class="flex items-start gap-3.5 text-[15px] leading-relaxed"
+                :class="{ 'lg:col-span-2': i === notUsItems.length - 1 && notUsItems.length % 2 === 1 }"
               >
                 <span
                   class="shrink-0 mt-[11px] h-[2px] w-3.5 rounded-full"

--- a/app/pages/gastos.vue
+++ b/app/pages/gastos.vue
@@ -44,7 +44,7 @@
         <EcgDivider class="mb-8" />
 
         <!-- Coste de la rebiopsia: dos bloques (analizar ahora / preservar y bancar) -->
-        <div class="card-base mb-6">
+        <div class="card-base mb-8">
           <h2 class="font-display font-semibold text-berenjena text-lg mb-2">
             {{ $t('expenses.rebiopsy_title') }}
           </h2>
@@ -105,12 +105,12 @@
         </div>
 
         <!-- Coste vs objetivo: cierra la duda "¿40k lo cubre todo?" -->
-        <p class="text-sm text-tinta italic mb-6 max-w-2xl">
+        <p class="text-sm text-tinta italic mb-8 max-w-2xl">
           {{ $t('expenses.cost_vs_goal') }}
         </p>
 
         <!-- Desglose completo · cuenta itemizada -->
-        <div class="card-base mb-6">
+        <div class="card-base mb-8">
           <h2 class="font-display font-semibold text-berenjena text-lg mb-4">
             {{ $t('home.s4_list_intro') }}
           </h2>
@@ -131,7 +131,7 @@
         </div>
 
         <!-- Preguntas frecuentes de donantes -->
-        <div class="card-base mb-6">
+        <div class="card-base mb-8">
           <h2 class="font-display font-semibold text-berenjena text-lg mb-4">
             {{ $t('expenses.faq_title') }}
           </h2>

--- a/app/pages/gracias.vue
+++ b/app/pages/gracias.vue
@@ -24,11 +24,11 @@
     </p>
 
     <div class="mt-9 flex flex-wrap gap-3 justify-center">
-      <button type="button" class="btn-secondary" @click="share">
+      <button type="button" class="btn-secondary w-full sm:w-auto" @click="share">
         <Icon :name="copied ? 'ph:check-bold' : 'ph:share-network-fill'" class="w-4 h-4" aria-hidden="true" />
         {{ copied ? $t('thanks.copied') : $t('thanks.share') }}
       </button>
-      <NuxtLink :to="localePath('/')" class="btn-secondary">
+      <NuxtLink :to="localePath('/')" class="btn-secondary w-full sm:w-auto">
         {{ $t('thanks.home') }}
       </NuxtLink>
     </div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -303,7 +303,7 @@
         <h2 class="heading-display text-3xl sm:text-4xl text-berenjena mb-6" style="letter-spacing: -0.03em">
           {{ $t('home.s10_intro') }}
         </h2>
-        <div class="grid md:grid-cols-3 gap-6 text-left mt-12">
+        <div class="grid md:grid-cols-3 gap-6 text-left mt-8">
           <article class="card-base flex flex-col" style="background: #faf6f0">
             <p class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta mb-2">01</p>
             <h3 class="font-display font-semibold text-berenjena text-xl mb-3">{{ $t('home.s10_l1_title') }}</h3>

--- a/app/pages/mapa-metastasis.vue
+++ b/app/pages/mapa-metastasis.vue
@@ -675,7 +675,7 @@ const ticks = [
               'La revisión de los mejores patólogos de Vall d\'Hebron (VHIO) sobre la biopsia de 2024 confirma un carcinoma de mama con diferenciación neuroendocrina. Es decir: una misma enfermedad con dos componentes mezclados. Por eso tiene sentido mirarla con dos trazadores — cada uno “ve” una de las caras.',
               'The review by Vall d\'Hebron\'s (VHIO) top pathologists of the 2024 biopsy confirms a breast carcinoma with neuroendocrine differentiation. That is: a single disease with two intermingled components. That is why it makes sense to image it with two tracers — each one “sees” one of the faces.') }}
           </p>
-          <div class="grid md:grid-cols-2 gap-4 mb-5">
+          <div class="grid md:grid-cols-2 gap-4">
             <div class="card-base">
               <p class="font-semibold text-berenjena mb-1" :style="{ color: '#bb4128' }">
                 {{ L('Cara mama / luminal (agresiva)', 'Breast / luminal face (aggressive)') }}
@@ -735,12 +735,12 @@ const ticks = [
               'Maximum-intensity projection (the whole body at a glance), reconstructed from your DICOM. The intense areas outside the skeleton are normal uptake of each tracer (brain and heart on FDG; kidneys, spleen and liver on gallium); the metastases are the skeletal foci.') }}
           </p>
           <div class="grid grid-cols-2 gap-4 max-w-2xl">
-            <figure class="card-base !p-3">
-              <img src="/metastasis/gal_mip_hot.jpg" :alt="L('MIP Galio-68 DOTATOC', 'Ga-68 DOTATOC MIP')" class="w-full rounded-lg bg-black" loading="lazy" />
+            <figure class="card-base !p-3 flex flex-col">
+              <img src="/metastasis/gal_mip_hot.jpg" :alt="L('MIP Galio-68 DOTATOC', 'Ga-68 DOTATOC MIP')" class="w-full flex-1 min-h-0 object-contain rounded-lg bg-black" loading="lazy" />
               <figcaption class="text-xs text-center mt-2 font-semibold" :style="{ color: '#9d44ab' }">⁶⁸Ga-DOTATOC · {{ L('receptor', 'receptor') }}</figcaption>
             </figure>
-            <figure class="card-base !p-3">
-              <img src="/metastasis/fdg_mip_hot.jpg" :alt="L('MIP FDG', 'FDG MIP')" class="w-full rounded-lg bg-black" loading="lazy" />
+            <figure class="card-base !p-3 flex flex-col">
+              <img src="/metastasis/fdg_mip_hot.jpg" :alt="L('MIP FDG', 'FDG MIP')" class="w-full flex-1 min-h-0 object-contain rounded-lg bg-black" loading="lazy" />
               <figcaption class="text-xs text-center mt-2 font-semibold" :style="{ color: '#bb4128' }">¹⁸F-FDG · {{ L('azúcar', 'sugar') }}</figcaption>
             </figure>
           </div>
@@ -1246,12 +1246,12 @@ const ticks = [
                   'Sagittal (side) slice with CT in grey and PET overlaid in colour. Left, the receptor (gallium); right, the sugar (FDG). Compare which vertebrae light up with each tracer.') }}
           </p>
           <div class="grid grid-cols-2 gap-4 max-w-xl">
-            <figure class="card-base !p-3">
-              <img src="/metastasis/gal_spine.jpg" :alt="L('Fusión sagital Galio', 'Gallium sagittal fusion')" class="w-full rounded-lg bg-black" loading="lazy" />
+            <figure class="card-base !p-3 flex flex-col">
+              <img src="/metastasis/gal_spine.jpg" :alt="L('Fusión sagital Galio', 'Gallium sagittal fusion')" class="w-full flex-1 min-h-0 object-contain rounded-lg bg-black" loading="lazy" />
               <figcaption class="text-xs text-center mt-2 font-semibold" :style="{ color: '#9d44ab' }">⁶⁸Ga-DOTATOC</figcaption>
             </figure>
-            <figure class="card-base !p-3">
-              <img src="/metastasis/fdg_spine.jpg" :alt="L('Fusión sagital FDG', 'FDG sagittal fusion')" class="w-full rounded-lg bg-black" loading="lazy" />
+            <figure class="card-base !p-3 flex flex-col">
+              <img src="/metastasis/fdg_spine.jpg" :alt="L('Fusión sagital FDG', 'FDG sagittal fusion')" class="w-full flex-1 min-h-0 object-contain rounded-lg bg-black" loading="lazy" />
               <figcaption class="text-xs text-center mt-2 font-semibold" :style="{ color: '#bb4128' }">¹⁸F-FDG</figcaption>
             </figure>
           </div>

--- a/app/pages/prensa.vue
+++ b/app/pages/prensa.vue
@@ -166,7 +166,7 @@
 
         <!-- Contacto de prensa -->
         <section
-          class="mt-16 relative overflow-hidden rounded-card p-8 sm:p-12 max-w-4xl"
+          class="mt-16 relative overflow-hidden rounded-card p-8 sm:p-12"
           style="background: #2d1b3d; color: #faf6f0"
           aria-labelledby="press-contact-title"
         >


### PR DESCRIPTION
Pulido de UI tras el rediseño del hero (comité de diseño) + repaso quirúrgico de espaciado/alineación en todas las páginas.

**Hero**
- Cierra el "valle" central (pista de foto ~320–400px + gutter normal) y arregla el bug de cascada que dejaba la foto en 280px → foto a ~400px que llena la columna derecha.
- Foto anclada arriba junto al titular (no flotando centrada).
- Metadatos vivos agrupados en un solo bloque (días sin tratamiento · apoyo · lo último); arriba solo eyebrow + titular.
- Verificado a 1920 / 1440 / móvil 390.

**Pulido por página (quirúrgico, sin tocar copy ni comportamiento)**
home (escalera s10) · ciencia (badges tratamiento) · colabora (ritmo cabeceras + aire tablet) · gracias (botones móvil) · equipo (ritmo + panel "Lo que NO somos") · gastos (ritmo vertical) · prensa (panel contacto a ancho completo) · contacto (gap sobre el formulario) · mapa-metástasis (pares de imágenes PET a igual altura).

Build verificado localmente: `pnpm generate` OK — 0 errores, 0 páginas fallidas, 233 rutas prerenderizadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)