### PR TITLE
fix(ui): ritmo cronología e historia

### DIFF
--- a/app/pages/historia/index.vue
+++ b/app/pages/historia/index.vue
@@ -26,7 +26,7 @@
           v-if="chapters && chapters.length > 0"
           class="max-w-2xl mt-12"
         >
-          <nav :aria-label="$t('historia.chapters')" class="space-y-3 mb-12">
+          <nav :aria-label="$t('historia.chapters')" class="space-y-3">
             <NuxtLink
               v-for="chapter in chapters"
               :key="chapter.path"

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -79,11 +79,11 @@
               v-for="group in groups"
               :key="group.year"
               v-reveal
-              class="tl-group"
+              class="tl-group pt-10 first:pt-0"
             >
               <!-- Año = cabecera de capítulo: chip sólido que interrumpe el raíl.
                    No se confunde con los puntos redondos de los hitos. -->
-              <div class="relative pt-3 pb-5 first:pt-0">
+              <div class="relative pb-5">
                 <h2 class="tl-year nums">{{ group.year }}</h2>
               </div>
               <ul>


### PR DESCRIPTION
Continuación del pulido de UI (tras #92).

- Cronología (/timeline): corrige un bug latente de ritmo — `first:pt-0` matcheaba TODOS los chips de año, así que los saltos de capítulo quedaban más pegados que los huecos entre hitos. El espaciado pasa al elemento `.tl-group` → cada año nuevo respira (40px arriba / 20px bajo el chip).
- Historia (/historia): quita el `mb-12` que se sumaba al `py-28` de sección (~160px de hueco muerto sobre el footer) → gap canónico de 112px.
- Evidencia (/ciencia/evidencia): auditada (ES+EN, 1440+móvil) — ya pixel-tight, sin cambios.

Build verificado: `pnpm generate` OK — 0 errores, 0 páginas fallidas, 233 rutas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
