### PR TITLE
fix(ciencia): implicación TROP-2→sacituzumab/Dato-DXd en panel IHQ

### DIFF
--- a/content/en/science.yml
+++ b/content/en/science.yml
@@ -175,7 +175,7 @@ panelRows:
   - component: Extended IHC + HLA typing
     method: 'IHC + RNAscope from the FFPE block (Core 1); HLA derived from sequencing'
     targets: 'ER, PR, HER2, FGFR1, SSTR2, TROP-2, B7-H3, DLL3, CgA, SYN, INSM1, Rb, Cyclin E1; HLA I/II'
-    implication: 'HER2-low→T-DXd · SSTR2→PRRT · DLL3→anti-DLL3 · Cyclin E1 / Rb loss→CDK4/6i resistance'
+    implication: 'TROP-2→sacituzumab/Dato-DXd · SSTR2→PRRT · DLL3→anti-DLL3 · Cyclin E1 / Rb loss→CDK4/6i resistance'
   - component: Immunopeptidomics (HLA peptidome)
     method: 'FRESH core to the lab as soon as possible, ischaemia ≤30 min (Core 3)'
     targets: 'Peptides actually presented on HLA (from ~15 mg → thousands of peptides)'

--- a/content/es/science.yml
+++ b/content/es/science.yml
@@ -178,7 +178,7 @@ panelRows:
   - component: IHQ extendida + tipado HLA
     method: 'IHQ + RNAscope del bloque FFPE (Core 1); HLA derivado de la secuenciación'
     targets: 'ER, PR, HER2, FGFR1, SSTR2, TROP-2, B7-H3, DLL3, CgA, SYN, INSM1, Rb, Cyclin E1; HLA I/II'
-    implication: 'HER2-low→T-DXd · SSTR2→PRRT · DLL3→anti-DLL3 · Cyclin E1 / pérdida de Rb→resistencia a CDK4/6i'
+    implication: 'TROP-2→sacituzumab/Dato-DXd · SSTR2→PRRT · DLL3→anti-DLL3 · Cyclin E1 / pérdida de Rb→resistencia a CDK4/6i'
   - component: Inmunopeptidómica (HLA-peptidoma)
     method: 'Core FRESCO al laboratorio cuanto antes, isquemia ≤30 min (Core 3)'
     targets: 'Péptidos realmente presentados en HLA (de ~15 mg → miles de péptidos)'


### PR DESCRIPTION
Actualiza la línea de implicación de la fila «IHQ extendida + tipado HLA» del panel de rebiopsia:

- Antes: `HER2-low→T-DXd · SSTR2→PRRT · …`
- Ahora: `TROP-2→sacituzumab/Dato-DXd · SSTR2→PRRT · …`

Coherente con la retirada previa de HER2-ultralow/HER2-low (#74). Cambio aplicado en ES y EN (solo valor del campo `implication`, sin tocar claves ni componentes).

**No incluye** nada del trabajo en curso del mapa de metástasis (rama `feat/mapa-dashboard`).

Verificación: diff = 2 líneas (ES+EN); escalares YAML entre comillas simples sin comillas internas, indentación intacta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)