### PR TITLE
feat(marcas): página /marcas (· /en/brands) — dossier para marcas

### DIFF
--- a/app/components/SiteFooter.vue
+++ b/app/components/SiteFooter.vue
@@ -165,6 +165,7 @@ const navItems = [
   { key: 'team', to: '/equipo' },
   { key: 'press', to: '/prensa' },
   { key: 'collaborate', to: '/colabora' },
+  { key: 'brands', to: '/marcas' },
   { key: 'expenses', to: '/gastos' },
   { key: 'contact', to: '/contacto' },
 ]

--- a/app/pages/colabora.vue
+++ b/app/pages/colabora.vue
@@ -368,6 +368,7 @@ const quickLinks = computed<QuickLink[]>(() => {
     { label: locale.value === 'es' ? 'Inicio' : 'Home', url: homePath, external: false },
     { label: locale.value === 'es' ? 'La ciencia' : 'The science', url: sciencePath, external: false },
     { label: 'Timeline', url: timelinePath, external: false },
+    { label: locale.value === 'es' ? 'Marcas · co-creación' : 'Brands · co-creation', url: localePath('marcas'), external: false },
     { label: 'Repo · GitHub', url: 'https://github.com/beyondtheprotocol/miriam-gonzalez-case', external: true },
     { label: 'GoFundMe · ' + GOFUNDME_URL.replace('https://', ''), url: GOFUNDME_URL, external: true },
     { label: '@miriamgonp · Instagram', url: 'https://instagram.com/miriamgonp', external: true },

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -1,0 +1,618 @@
+<template>
+  <div>
+    <!--
+      ════════════════════════════════════════════════════════════
+        Página /marcas (· /en/brands) — «dossier para marcas» B2B.
+        UNLISTED: no vive en SiteNav, se reparte por enlace directo.
+        · Compuesta solo con tokens del design-system (cream/berenjena/
+          tinta/miriam/coral) + dos extensiones de marca (miriam-claro
+          y berenjena-2) para el énfasis e/o las tarjetas SOBRE oscuro.
+        · UN ACENTO POR BLOQUE: violeta = identidad (miriam / miriam-claro
+          en oscuro), coral = SOLO acción (botón «Hablemos» y la cifra
+          «38.897 €»). Crema, nunca blanco; texto berenjena, nunca negro.
+        · Tres bandas oscuras (hero · la prueba · cierre) llevan un cielo
+          decorativo (.band-fx): resplandor violeta centrado + estrellas
+          tenues hacia los bordes → no pisan el texto (zona tranquila).
+        · ?marca=Nombre personaliza el hero (cliente, sin romper SSR).
+        · Botón flotante → window.print(); estilos @media print mínimos.
+      ════════════════════════════════════════════════════════════
+    -->
+
+    <!-- ░░ 1 · HERO ░░ banda oscura -->
+    <section
+      v-reveal
+      class="relative overflow-hidden section-spacing bg-berenjena"
+      :aria-labelledby="'m-hero'"
+    >
+      <div class="band-fx" aria-hidden="true">
+        <div class="band-fx__stars"></div>
+        <div class="band-fx__glow"></div>
+      </div>
+      <div class="section-wide relative z-10">
+        <div class="grid lg:grid-cols-[1fr_auto] gap-10 lg:gap-16 items-center">
+          <div>
+            <p class="dark-eyebrow mb-5">{{ t('marcas.hero_eyebrow') }}</p>
+            <i18n-t
+              keypath="marcas.hero_title"
+              tag="h1"
+              id="m-hero"
+              class="heading-display text-cream text-4xl sm:text-5xl"
+              style="letter-spacing: -0.03em; line-height: 1.08"
+            >
+              <template #br><br /></template>
+              <template #em>
+                <em class="italic text-miriam-claro">{{ t('marcas.hero_title_em') }}</em>
+              </template>
+            </i18n-t>
+            <p class="mt-6 text-lg text-cream/85 leading-relaxed max-w-2xl">
+              {{ t('marcas.hero_subtitle') }}
+            </p>
+            <p class="mt-6 font-mono text-xs uppercase tracking-[0.16em] text-miriam-claro">
+              {{ t('marcas.hero_tagline') }}
+            </p>
+            <ClientOnly>
+              <p
+                v-if="marca"
+                class="mt-6 font-mono text-xs uppercase tracking-[0.12em] text-cream/70"
+              >
+                {{ t('marcas.hero_edition_label') }}
+                <b class="ml-1 font-semibold text-cream marca-name">{{ marca }}</b>
+              </p>
+            </ClientOnly>
+          </div>
+
+          <figure class="justify-self-center lg:justify-self-end m-0">
+            <NuxtImg
+              src="/img/miriam-avatar.webp"
+              alt=""
+              width="336"
+              height="336"
+              format="webp"
+              decoding="async"
+              class="w-[168px] h-[168px] rounded-full object-cover avatar-ring"
+            />
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <!-- ░░ 2 · LA HISTORIA ░░ crema -->
+    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-historia'">
+      <div class="section-wide">
+        <p class="eyebrow mb-3 block">{{ t('marcas.historia_eyebrow') }}</p>
+        <i18n-t
+          keypath="marcas.historia_title"
+          tag="h2"
+          id="m-historia"
+          class="heading-display text-3xl sm:text-4xl text-berenjena mb-6 max-w-3xl"
+          style="letter-spacing: -0.02em"
+        >
+          <template #em><em class="italic text-miriam">{{ t('marcas.historia_title_em') }}</em></template>
+        </i18n-t>
+
+        <i18n-t keypath="marcas.historia_p1" tag="p" class="text-lg text-tinta leading-relaxed mb-4 max-w-3xl">
+          <template #age>{{ caseData.currentAge }}</template>
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p1_b1') }}</strong></template>
+          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p1_b2') }}</strong></template>
+        </i18n-t>
+
+        <i18n-t keypath="marcas.historia_p2" tag="p" class="text-tinta leading-relaxed mb-6 max-w-3xl">
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p2_b1') }}</strong></template>
+          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p2_b2') }}</strong></template>
+          <template #b3><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p2_b3') }}</strong></template>
+        </i18n-t>
+
+        <div class="flex flex-wrap gap-2 mb-6">
+          <span v-for="(b, i) in badges" :key="i" class="badge-genomic">{{ rt(b) }}</span>
+        </div>
+
+        <i18n-t keypath="marcas.historia_foot" tag="p" class="text-sm text-tinta">
+          <template #link>
+            <NuxtLink :to="localePath({ name: 'ciencia' })" class="link-inline">{{ t('marcas.historia_foot_link') }}</NuxtLink>
+          </template>
+        </i18n-t>
+      </div>
+    </section>
+
+    <!-- ░░ 3 · LOS NÚMEROS ░░ crema-card -->
+    <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'m-numeros'">
+      <div class="section-wide">
+        <p class="eyebrow mb-3 block">{{ t('marcas.numeros_eyebrow') }}</p>
+        <i18n-t
+          keypath="marcas.numeros_title"
+          tag="h2"
+          id="m-numeros"
+          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
+          style="letter-spacing: -0.02em"
+        >
+          <template #em><em class="italic text-miriam">{{ t('marcas.numeros_title_em') }}</em></template>
+        </i18n-t>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-9 mb-10">
+          <div v-for="(s, i) in numerosStats" :key="i">
+            <p
+              class="font-display font-semibold tracking-tight nums"
+              :class="i === 1 ? 'text-miriam' : 'text-berenjena'"
+              style="font-size: clamp(2.5rem, 6vw, 3.75rem); line-height: 0.95"
+            >
+              {{ rt(s.value) }}
+            </p>
+            <p class="mt-2 font-mono uppercase text-[11px] tracking-[0.06em] text-tinta leading-snug">
+              {{ rt(s.caption) }}
+            </p>
+          </div>
+        </div>
+
+        <i18n-t keypath="marcas.numeros_growth" tag="p" class="text-tinta leading-relaxed mb-9 max-w-3xl">
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.numeros_growth_b1') }}</strong></template>
+          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.numeros_growth_b2') }}</strong></template>
+        </i18n-t>
+
+        <div class="data-card">
+          <table class="data-table data-table--cards">
+            <thead>
+              <tr>
+                <th scope="col">{{ t('marcas.numeros_th_canal') }}</th>
+                <th scope="col">{{ t('marcas.numeros_th_audiencia') }}</th>
+                <th scope="col">{{ t('marcas.numeros_th_senal') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(c, i) in channels" :key="i">
+                <td class="cell-head col-marker" :data-label="t('marcas.numeros_th_canal')">{{ rt(c.canal) }}</td>
+                <td class="nums" :data-label="t('marcas.numeros_th_audiencia')">{{ rt(c.audiencia) }}</td>
+                <td class="col-note cell-block" :data-label="t('marcas.numeros_th_senal')">{{ rt(c.senal) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="mt-4 text-xs text-tinta leading-relaxed">{{ t('marcas.numeros_foot') }}</p>
+      </div>
+    </section>
+
+    <!-- ░░ 4 · QUIÉN TE ESCUCHA ░░ crema -->
+    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-demo'">
+      <div class="section-wide">
+        <p class="eyebrow mb-3 block">{{ t('marcas.demo_eyebrow') }}</p>
+        <i18n-t
+          keypath="marcas.demo_title"
+          tag="h2"
+          id="m-demo"
+          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
+          style="letter-spacing: -0.02em"
+        >
+          <template #em><em class="italic text-miriam">{{ t('marcas.demo_title_em') }}</em></template>
+        </i18n-t>
+
+        <div class="grid md:grid-cols-3 gap-4 mb-8">
+          <article v-for="(card, ci) in demoCards" :key="ci" class="card-base bg-cream-card">
+            <h3 class="heading-display text-xl text-berenjena mb-4">{{ rt(card.title) }}</h3>
+            <ul class="space-y-2.5">
+              <li
+                v-for="(line, li) in card.lines"
+                :key="li"
+                class="flex gap-2.5 text-sm text-tinta leading-relaxed"
+              >
+                <span class="font-mono text-miriam text-xs mt-0.5 shrink-0" aria-hidden="true">·</span>
+                <span>{{ rt(line) }}</span>
+              </li>
+            </ul>
+          </article>
+        </div>
+
+        <i18n-t keypath="marcas.demo_eco" tag="p" class="text-tinta leading-relaxed max-w-3xl">
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.demo_eco_b1') }}</strong></template>
+        </i18n-t>
+      </div>
+    </section>
+
+    <!-- ░░ 5 · LA PRUEBA DE QUE MI GENTE ACTÚA ░░ banda oscura -->
+    <section
+      v-reveal
+      class="relative overflow-hidden section-spacing bg-berenjena"
+      :aria-labelledby="'m-prueba'"
+    >
+      <div class="band-fx" aria-hidden="true">
+        <div class="band-fx__stars"></div>
+        <div class="band-fx__glow"></div>
+      </div>
+      <div class="section-wide relative z-10">
+        <p class="dark-eyebrow mb-3">{{ t('marcas.prueba_eyebrow') }}</p>
+        <i18n-t
+          keypath="marcas.prueba_title"
+          tag="h2"
+          id="m-prueba"
+          class="heading-display text-3xl sm:text-4xl text-cream mb-8 max-w-3xl"
+          style="letter-spacing: -0.02em"
+        >
+          <template #em><em class="italic text-coral">{{ t('marcas.prueba_title_em') }}</em></template>
+        </i18n-t>
+
+        <div class="grid sm:grid-cols-3 gap-7 mb-10">
+          <div v-for="(s, i) in pruebaStats" :key="i">
+            <p
+              class="font-display font-semibold tracking-tight nums"
+              :class="i === 0 ? 'text-coral' : 'text-cream'"
+              style="font-size: clamp(2.25rem, 5.5vw, 3.25rem); line-height: 0.95"
+            >
+              {{ rt(s.value) }}
+            </p>
+            <p class="mt-2 font-mono uppercase text-[11px] tracking-[0.06em] text-cream/70 leading-snug">
+              {{ rt(s.caption) }}
+            </p>
+          </div>
+        </div>
+
+        <div class="rounded-2xl p-6 sm:p-7 mb-8 bg-berenjena-2 dark-card">
+          <h3 class="font-display font-semibold text-cream text-lg mb-3">{{ t('marcas.prueba_carlos_title') }}</h3>
+          <i18n-t keypath="marcas.prueba_carlos_p" tag="p" class="text-cream/85 leading-relaxed">
+            <template #b1><strong class="font-semibold text-cream">{{ t('marcas.prueba_carlos_p_b1') }}</strong></template>
+            <template #b2><strong class="font-semibold text-cream">{{ t('marcas.prueba_carlos_p_b2') }}</strong></template>
+          </i18n-t>
+        </div>
+
+        <h3 class="font-display font-semibold text-cream text-lg mb-4">{{ t('marcas.prueba_virals_title') }}</h3>
+        <div class="data-card mb-8">
+          <table class="data-table data-table--cards">
+            <thead>
+              <tr>
+                <th scope="col">{{ t('marcas.prueba_th_post') }}</th>
+                <th scope="col" class="th-right">{{ t('marcas.prueba_th_plays') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(v, i) in virals" :key="i">
+                <td class="cell-head col-note" :data-label="t('marcas.prueba_th_post')">
+                  {{ rt(v.post) }}
+                  <span
+                    v-if="i === 0"
+                    class="ml-2 inline-block align-middle font-mono uppercase text-[9px] tracking-[0.06em] px-1.5 py-0.5 rounded bg-miriam-soft text-berenjena"
+                  >{{ t('marcas.prueba_origen_tag') }}</span>
+                </td>
+                <td class="nums td-right" :data-label="t('marcas.prueba_th_plays')">{{ rt(v.plays) }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="rounded-2xl p-6 sm:p-7 bg-berenjena-2 dark-card">
+          <h3 class="font-display font-semibold text-cream text-lg mb-3">{{ t('marcas.prueba_linkedin_title') }}</h3>
+          <blockquote class="font-display italic text-cream/90 text-lg leading-relaxed mb-3">
+            {{ t('marcas.prueba_linkedin_quote') }}
+          </blockquote>
+          <p class="font-mono text-xs text-cream/70 tracking-wide nums">{{ t('marcas.prueba_linkedin_stats') }}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ░░ 6 · QUÉ GANAS TÚ ░░ crema-card -->
+    <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'m-ganas'">
+      <div class="section-wide">
+        <p class="eyebrow mb-3 block">{{ t('marcas.ganas_eyebrow') }}</p>
+        <i18n-t
+          keypath="marcas.ganas_title"
+          tag="h2"
+          id="m-ganas"
+          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
+          style="letter-spacing: -0.02em"
+        >
+          <template #em><em class="italic text-miriam">{{ t('marcas.ganas_title_em') }}</em></template>
+        </i18n-t>
+
+        <div class="grid sm:grid-cols-2 gap-4 mb-8">
+          <article v-for="(card, ci) in ganasCards" :key="ci" class="card-base bg-cream">
+            <h3 class="heading-display text-xl text-berenjena mb-2">{{ rt(card.title) }}</h3>
+            <p class="text-sm text-tinta leading-relaxed">{{ rt(card.desc) }}</p>
+          </article>
+        </div>
+
+        <i18n-t keypath="marcas.ganas_fit" tag="p" class="text-tinta leading-relaxed mb-8 max-w-3xl">
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b1') }}</strong></template>
+          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b2') }}</strong></template>
+          <template #b3><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b3') }}</strong></template>
+          <template #b4><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b4') }}</strong></template>
+        </i18n-t>
+
+        <div class="rounded-2xl p-6 sm:p-8 bg-berenjena">
+          <i18n-t keypath="marcas.ganas_model" tag="p" class="text-cream/90 leading-relaxed max-w-3xl">
+            <template #b1><strong class="font-semibold text-miriam-claro">{{ t('marcas.ganas_model_b1') }}</strong></template>
+            <template #b2><strong class="font-semibold text-cream">{{ t('marcas.ganas_model_b2') }}</strong></template>
+            <template #em><em class="italic text-cream">{{ t('marcas.ganas_model_em') }}</em></template>
+          </i18n-t>
+        </div>
+      </div>
+    </section>
+
+    <!-- ░░ 7 · MARCAS QUE YA SE ATREVIERON ░░ crema -->
+    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-partners'">
+      <div class="section-wide">
+        <p class="eyebrow mb-3 block">{{ t('marcas.partners_eyebrow') }}</p>
+        <i18n-t
+          keypath="marcas.partners_title"
+          tag="h2"
+          id="m-partners"
+          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
+          style="letter-spacing: -0.02em"
+        >
+          <template #em><em class="italic text-miriam">{{ t('marcas.partners_title_em') }}</em></template>
+        </i18n-t>
+
+        <div class="flex flex-wrap gap-3 mb-8">
+          <a
+            v-for="(p, i) in partners"
+            :key="i"
+            :href="rt(p.url)"
+            target="_blank"
+            rel="noopener"
+            class="partner-pill"
+          >{{ rt(p.label) }} →</a>
+        </div>
+
+        <div class="grid sm:grid-cols-2 gap-4 mb-8">
+          <figure
+            v-for="(q, i) in quotes"
+            :key="i"
+            class="card-base bg-cream-card m-0 quote-card"
+          >
+            <blockquote class="font-display italic text-berenjena text-lg leading-relaxed mb-3">{{ rt(q.quote) }}</blockquote>
+            <figcaption class="font-mono text-xs text-tinta tracking-wide">{{ rt(q.author) }}</figcaption>
+          </figure>
+        </div>
+
+        <i18n-t keypath="marcas.partners_press" tag="p" class="text-tinta">
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.partners_press_b1') }}</strong></template>
+        </i18n-t>
+      </div>
+    </section>
+
+    <!-- ░░ 8 · CIERRE / CTA ░░ banda oscura, centrada -->
+    <section
+      v-reveal
+      class="relative overflow-hidden section-spacing bg-berenjena"
+      :aria-labelledby="'m-cta'"
+    >
+      <div class="band-fx" aria-hidden="true">
+        <div class="band-fx__stars"></div>
+        <div class="band-fx__glow"></div>
+      </div>
+      <div class="section-wide relative z-10">
+        <div class="max-w-2xl mx-auto text-center">
+          <p class="dark-eyebrow mb-3">{{ t('marcas.cta_eyebrow') }}</p>
+          <i18n-t
+            keypath="marcas.cta_title"
+            tag="h2"
+            id="m-cta"
+            class="heading-display text-3xl sm:text-4xl text-cream mb-4"
+            style="letter-spacing: -0.02em"
+          >
+            <template #em><em class="italic text-coral">{{ t('marcas.cta_title_em') }}</em></template>
+          </i18n-t>
+          <p class="text-lg text-cream/85 leading-relaxed mb-8">{{ t('marcas.cta_p') }}</p>
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-8">
+            <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
+              {{ t('marcas.cta_button') }}
+            </NuxtLink>
+            <a
+              href="https://instagram.com/miriamgonp"
+              target="_blank"
+              rel="noopener"
+              translate="no"
+              class="font-mono text-sm text-cream/80 hover:text-cream underline underline-offset-4 decoration-cream/40 hover:decoration-cream transition-colors"
+            >{{ t('marcas.cta_secondary') }}</a>
+          </div>
+          <p class="font-display italic text-cream/80 text-lg">{{ t('marcas.cta_tagline') }}</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Botón flotante · descargar como PDF (oculto en impresión) -->
+    <button type="button" class="m-print-btn no-print" :aria-label="t('marcas.print_aria')" @click="printPdf">
+      {{ t('marcas.print') }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+const { t, tm, rt, locale } = useI18n()
+const localePath = useLocalePath()
+const route = useRoute()
+
+// ?marca=Nombre → edición personalizada en el hero. Se lee en cliente (la página
+// es estática); se sanea (trim) y se acota a ~40 caracteres.
+const marca = computed(() => {
+  const raw = route.query.marca
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (!value) return ''
+  return String(value).trim().slice(0, 40)
+})
+
+// Listas i18n (arrays en el JSON) — se resuelven hoja a hoja con rt() en el template.
+const badges = computed(() => tm('marcas.historia_badges') as unknown[])
+const numerosStats = computed(() => tm('marcas.numeros_stats') as Record<string, unknown>[])
+const channels = computed(() => tm('marcas.numeros_channels') as Record<string, unknown>[])
+const demoCards = computed(() => tm('marcas.demo_cards') as Record<string, unknown>[])
+const pruebaStats = computed(() => tm('marcas.prueba_stats') as Record<string, unknown>[])
+const virals = computed(() => tm('marcas.prueba_virals') as Record<string, unknown>[])
+const ganasCards = computed(() => tm('marcas.ganas_cards') as Record<string, unknown>[])
+const partners = computed(() => tm('marcas.partners') as Record<string, unknown>[])
+const quotes = computed(() => tm('marcas.partners_quotes') as Record<string, unknown>[])
+
+function printPdf() {
+  if (import.meta.client) window.print()
+}
+
+useSeoMeta({
+  title: () => t('marcas.meta_title'),
+  description: () => t('marcas.meta_description'),
+  ogTitle: () => t('marcas.meta_title'),
+  ogDescription: () => t('marcas.og_description'),
+  ogType: 'website',
+  twitterCard: 'summary_large_image',
+  twitterTitle: () => t('marcas.meta_title'),
+  twitterDescription: () => t('marcas.og_description'),
+})
+
+defineOgImage('Default.takumi', {
+  title: () => t('marcas.meta_title'),
+  description: () =>
+    locale.value === 'es'
+      ? 'Co-creación real para marcas. Una comunidad de ~248K que actúa.'
+      : 'Real co-creation for brands. A ~248K community that acts.',
+})
+</script>
+
+<script lang="ts">
+export default { name: 'MarcasPage' }
+</script>
+
+<style scoped>
+/* Eyebrow sobre banda oscura: el .eyebrow del DS es text-tinta (oscuro) e
+   invisible aquí; usamos crema atenuada (≈6:1 sobre berenjena). */
+.dark-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(250, 246, 240, 0.7);
+  display: block;
+}
+
+/* Anillo decorativo del avatar (violeta-soft translúcido). */
+.avatar-ring {
+  border: 3px solid rgba(232, 212, 237, 0.5);
+  box-shadow: 0 16px 40px -16px rgba(0, 0, 0, 0.6);
+}
+
+/* Nombre de la edición personalizada — subrayado discontinuo. */
+.marca-name {
+  text-decoration: underline;
+  text-decoration-style: dashed;
+  text-decoration-color: rgba(199, 125, 210, 0.8);
+  text-underline-offset: 4px;
+}
+
+/* Tarjetas elevadas sobre las bandas oscuras (cajas Carlos Roca / LinkedIn). */
+.dark-card {
+  border: 1px solid rgba(232, 212, 237, 0.14);
+}
+
+/* Pills de marcas partner — identidad violeta; se «encienden» a violeta sólido
+   al pasar/enfocar (señal clara de enlace). */
+.partner-pill {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: #e8d4ed;
+  color: #2d1b3d;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+.partner-pill:hover,
+.partner-pill:focus-visible {
+  background: #9d44ab;
+  color: #faf6f0;
+  transform: translateY(-1px);
+}
+
+.quote-card {
+  border-left: 4px solid #9d44ab;
+}
+
+/* Alineación a la derecha de la columna de reproducciones (solo ≥sm; en móvil
+   la tabla colapsa a tarjetas etiqueta/valor y manda el layout de cards). */
+@media (min-width: 640px) {
+  .th-right,
+  .td-right {
+    text-align: right;
+  }
+}
+
+/* ── Cielo decorativo de las bandas oscuras ──────────────────────────────────
+   Resplandor violeta centrado (zona tranquila tras el texto) + estrellas tenues
+   repartidas hacia los bordes. Estático (sin animación) → seguro siempre y sin
+   coste de contraste sobre el texto crema. */
+.band-fx {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+.band-fx__glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(58% 64% at 50% 42%, rgba(157, 68, 171, 0.22), transparent 72%);
+}
+.band-fx__stars {
+  position: absolute;
+  inset: 0;
+  background-repeat: no-repeat;
+  background-image:
+    radial-gradient(1.6px 1.6px at 8% 18%, rgba(232, 212, 237, 0.55), transparent 60%),
+    radial-gradient(1.2px 1.2px at 16% 72%, rgba(250, 246, 240, 0.4), transparent 60%),
+    radial-gradient(1.4px 1.4px at 24% 30%, rgba(232, 212, 237, 0.45), transparent 60%),
+    radial-gradient(1px 1px at 33% 86%, rgba(232, 212, 237, 0.4), transparent 60%),
+    radial-gradient(1.5px 1.5px at 45% 10%, rgba(250, 246, 240, 0.45), transparent 60%),
+    radial-gradient(1px 1px at 57% 90%, rgba(232, 212, 237, 0.4), transparent 60%),
+    radial-gradient(1.6px 1.6px at 68% 14%, rgba(232, 212, 237, 0.5), transparent 60%),
+    radial-gradient(1.2px 1.2px at 78% 78%, rgba(250, 246, 240, 0.4), transparent 60%),
+    radial-gradient(1.4px 1.4px at 86% 34%, rgba(232, 212, 237, 0.48), transparent 60%),
+    radial-gradient(1px 1px at 93% 64%, rgba(232, 212, 237, 0.42), transparent 60%),
+    radial-gradient(1.3px 1.3px at 11% 48%, rgba(232, 212, 237, 0.4), transparent 60%),
+    radial-gradient(1.1px 1.1px at 90% 12%, rgba(250, 246, 240, 0.4), transparent 60%);
+}
+
+/* Botón flotante de impresión — sobre la barra de apoyo móvil (<lg). */
+.m-print-btn {
+  position: fixed;
+  right: 1rem;
+  bottom: calc(5.25rem + env(safe-area-inset-bottom, 0px));
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 0.95rem;
+  border-radius: 999px;
+  background: #2d1b3d;
+  color: #faf6f0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  box-shadow: 0 12px 28px -10px rgba(45, 27, 61, 0.6);
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+.m-print-btn:hover {
+  background: #3d2752;
+  transform: translateY(-2px);
+}
+@media (min-width: 1024px) {
+  .m-print-btn {
+    right: 1.5rem;
+    bottom: 1.5rem;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .m-print-btn:hover {
+    transform: none;
+  }
+}
+
+/* Impresión: fuera el cielo decorativo y el botón; secciones sin cortarse.
+   (El cromo global —nav/footer/barra— ya lo oculta app/assets/css/main.css.) */
+@media print {
+  .no-print {
+    display: none !important;
+  }
+  .band-fx {
+    display: none !important;
+  }
+  section {
+    break-inside: avoid;
+  }
+}
+</style>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -842,6 +842,159 @@
     "links_sub": "If you don't know where to start, share the site. Getting the case in front of the right people —oncology, research or patients— is often the difference between finding a therapeutic target and not finding one.",
     "links_signature": "— Miriam González's team · Beyond the Protocol"
   },
+  "marcas": {
+    "meta_title": "Brands brave enough to co-create — helpmiriam.com",
+    "meta_description": "Real co-creation for brands: your brand inside the story of a tech creator researching her own ultra-rare cancer, before a ~248K community that acts.",
+    "og_description": "Real co-creation: your brand inside the story, not a logo on a banner. A ~248K community that moves money and mobilizes.",
+    "print": "↓ PDF Limited Edition",
+    "print_aria": "Download this dossier as PDF (opens the print dialog)",
+    "hero_eyebrow": "// brand dossier",
+    "hero_title": "I don't offer you followers.{br}I offer you a {em}.",
+    "hero_title_em": "community that acts",
+    "hero_subtitle": "Real co-creation: your brand inside the story of a tech creator researching her own ultra-rare cancer, out in the open.",
+    "hero_tagline": "// brands brave enough to co-create",
+    "hero_edition_label": "Edition prepared for:",
+    "hero_avatar_alt": "",
+    "historia_eyebrow": "// the story in 20 seconds",
+    "historia_title": "A story {em}.",
+    "historia_title_em": "impossible to ignore",
+    "historia_p1": "Miriam González ({'@'}miriamgonp), {age} years old, a software engineer and tech creator. She has an {b1} metastatic breast cancer (BC-NED, <1% of cases) and uses {b2} to research her own tumor, documenting it in the open.",
+    "historia_p1_b1": "ultra-rare",
+    "historia_p1_b2": "AI + precision oncology",
+    "historia_p2": "Real scientific backing: {b1} analyzes her samples · {b2} assists with the biopsy · the chair of the {b3} has taken an interest in her case.",
+    "historia_p2_b1": "Dana-Farber (Harvard)",
+    "historia_p2_b2": "Zurich",
+    "historia_p2_b3": "world's most important precision-oncology committee (WIN)",
+    "historia_badges": [
+      "Dana-Farber · Harvard",
+      "Zurich Hospital",
+      "WIN Committee"
+    ],
+    "historia_foot": "Full clinical detail at {link}. Data as of June 2026.",
+    "historia_foot_link": "helpmiriam.com/science",
+    "numeros_eyebrow": "// the numbers (verifiable)",
+    "numeros_title": "An audience that moves {em}.",
+    "numeros_title_em": "and converts",
+    "numeros_stats": [
+      { "value": "~248K", "caption": "total multichannel audience" },
+      { "value": "8.8%", "caption": "engagement by reach (IG)" },
+      { "value": "453K", "caption": "accounts reached / month · 3.6× followers" },
+      { "value": "+1M", "caption": "views / month (IG)" },
+      { "value": "63%", "caption": "of interaction = NEW audience" },
+      { "value": "72.5%", "caption": "real audience (Modash · above average)" }
+    ],
+    "numeros_growth": "📈 {b1} · {b2} (editorial consistency). Not a stalled account: it's growing.",
+    "numeros_growth_b1": "+4,734 new followers in the last month",
+    "numeros_growth_b2": "34 posts/month",
+    "numeros_th_canal": "Channel",
+    "numeros_th_audiencia": "Audience",
+    "numeros_th_senal": "Signal",
+    "numeros_channels": [
+      { "canal": "Instagram", "audiencia": "126.5K", "senal": "453K reach/month · 8.8% eng." },
+      { "canal": "X / Twitter (verified)", "audiencia": "41.2K", "senal": "~140K impressions/week" },
+      { "canal": "LinkedIn", "audiencia": "40.6K", "senal": "🏆 LinkedIn Top Voices 2022" },
+      { "canal": "TikTok", "audiencia": "23.2K", "senal": "228.5K likes" },
+      { "canal": "YouTube", "audiencia": "17K", "senal": "technology/programming channel" }
+    ],
+    "numeros_foot": "Sources: Instagram Insights · X Analytics · Modash · public profiles. June 2026. Screenshots available on request.",
+    "demo_eyebrow": "// who's listening",
+    "demo_title": "An adult, professional and {em} audience.",
+    "demo_title_em": "consumer",
+    "demo_cards": [
+      {
+        "title": "Instagram",
+        "lines": [
+          "Age: 25-44 = 73.5% (25-34: 44.7% · 35-44: 28.8%)",
+          "Gender: 65.9% men · 34.1% women",
+          "Geography: Spain and Latin America."
+        ]
+      },
+      {
+        "title": "X / Twitter",
+        "lines": [
+          "Geography: Spain 54% · Mexico 11% · Argentina 8%",
+          "Gender: 80.5% men (tech/professional profile)",
+          "Age: 25-44 (66%)"
+        ]
+      },
+      {
+        "title": "LinkedIn",
+        "lines": [
+          "Profile: professional and B2B — devs, engineering and decision-makers",
+          "Recognition: Top Voices 2022"
+        ]
+      }
+    ],
+    "demo_eco": "It's not an audience, it's an {b1}: 5 platforms (~248K) that reinforce one another — Instagram (mass, global Hispanic), LinkedIn (B2B/decision-makers, Top Voices), X (tech), TikTok (discovery) and YouTube (the case's long-form documentary). One collaboration, several audiences and formats.",
+    "demo_eco_b1": "ecosystem",
+    "prueba_eyebrow": "// proof that my people act",
+    "prueba_title": "Not passive likes. {em}",
+    "prueba_title_em": "They move money and mobilize.",
+    "prueba_stats": [
+      { "value": "38.897 €", "caption": "raised (100K goal) · proof of conversion" },
+      { "value": "~1,000", "caption": "donors = own/warm audience" },
+      { "value": "3,845", "caption": "clicks/month to the bio link" }
+    ],
+    "prueba_carlos_title": "🎙️ Real case — «Carlos Roca / Episode 100» campaign",
+    "prueba_carlos_p": "She mobilized her community toward a concrete goal: the campaign reels added up to {b1} in a few days. Proof of {b2} — exactly what a brand wants to activate.",
+    "prueba_carlos_p_b1": "≈335,000 views",
+    "prueba_carlos_p_b2": "mobilization on demand",
+    "prueba_virals_title": "Viral content (last 3 months)",
+    "prueba_th_post": "Post",
+    "prueba_th_plays": "Views",
+    "prueba_origen_tag": "ORIGIN POST",
+    "prueba_virals": [
+      { "post": "X · «…Twitter, work your magic»", "plays": "1,000,000" },
+      { "post": "IG · Coliseo «Looking for help with an ultra-rare case»", "plays": "753,487" },
+      { "post": "IG · «SPREAD KINDNESS / age 35»", "plays": "430,022" },
+      { "post": "IG · «about technology and programming / it's NOW»", "plays": "249,321" },
+      { "post": "IG · collab «the tech community gifts me a Mac»", "plays": "189,110" },
+      { "post": "IG · carousel «Gallium-68 PET · my cancer has two engines»", "plays": "56,474" }
+    ],
+    "prueba_linkedin_title": "🏆 LinkedIn — viral post (Top Voices 2022)",
+    "prueba_linkedin_quote": "«…metastatic breast cancer, the rarest 1%. They gave me 5 years, I'm already at 2. I don't sit still: I research my own tumor with AI and seek treatment with a team…»",
+    "prueba_linkedin_stats": "176,484 impressions · 2,291 reactions · 194 shares",
+    "ganas_eyebrow": "// what you gain",
+    "ganas_title": "Your brand {em}, not a logo on a banner.",
+    "ganas_title_em": "inside the story",
+    "ganas_cards": [
+      { "title": "Content co-creation", "desc": "reel / carousel / stories designed together, not ads slapped on." },
+      { "title": "Your brand in my open research", "desc": "presence in the case a whole community follows." },
+      { "title": "Product tested with no filters", "desc": "an honest review before an audience that trusts." },
+      { "title": "Challenges to my community and events", "desc": "I launch a challenge with your brand and my people mobilize; or I take you to your event (reel + stories)." }
+    ],
+    "ganas_fit": "{b1} where your product meets my real life — {b2} · {b3} (international hospitals, flights, fintech/currency exchange, car/charging) · {b4}. That's where the collaboration is authentic.",
+    "ganas_fit_b1": "Natural fits:",
+    "ganas_fit_b2": "tech and health",
+    "ganas_fit_b3": "travel and mobility",
+    "ganas_fit_b4": "self-care, fashion and healthy food",
+    "ganas_model": "The community donates, and I'm infinitely grateful 💜. To brands I propose something different: {b1}. {b2} collaboration by donation — your contribution funds the precision research and we co-create something memorable. {em} your sponsorship helps close the 100.000 € goal and funds the next molecular analysis.",
+    "ganas_model_b1": "co-create",
+    "ganas_model_b2": "Model:",
+    "ganas_model_em": "Hook:",
+    "partners_eyebrow": "// brands that already dared",
+    "partners_title": "You're not starting from scratch. {em}",
+    "partners_title_em": "There are already brands inside.",
+    "partners": [
+      { "label": "Tahe", "url": "https://tahecosmetics.com" },
+      { "label": "GitHub", "url": "https://github.com" },
+      { "label": "Notion", "url": "https://www.notion.com" },
+      { "label": "Never Surrender", "url": "https://neversurrender.com" }
+    ],
+    "partners_quotes": [
+      { "quote": "«Hi, Míriam! Check your DMs for a surprise. 🤍»", "author": "Notion ({'@'}NotionHQ), in public · 21.6K views" },
+      { "quote": "«It was a joy to spend this day with you and help you look even more like a goddess 💜🔥🔥»", "author": "Tahe ({'@'}taheoficial), verified partner brand · public comment" }
+    ],
+    "partners_press": "{b1} El País · La Opinión de Murcia · La 7.",
+    "partners_press_b1": "In the press:",
+    "cta_eyebrow": "// let's talk",
+    "cta_title": "Does your brand {em}?",
+    "cta_title_em": "dare",
+    "cta_p": "Real co-creation. The best deal you'll be offered this year.",
+    "cta_button": "Let's talk",
+    "cta_secondary": "{'@'}miriamgonp",
+    "cta_tagline": "Limited edition. No restock. Like me. 💜"
+  },
   "expenses": {
     "title": "Where the money goes",
     "subtitle": "Radical transparency: every euro, documented.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -13,6 +13,7 @@
     "contact": "Contact",
     "donate": "Support Miriam",
     "collaborate": "How to help",
+    "brands": "Brands",
     "expenses": "Expenses",
     "main_label": "Primary navigation",
     "mobile_label": "Mobile navigation",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -842,6 +842,159 @@
     "links_sub": "Si no sabes por dónde empezar, comparte la web. Que el caso llegue a quien corresponda —oncología, investigación o pacientes— es, muchas veces, la diferencia entre encontrar una diana terapéutica y no encontrarla.",
     "links_signature": "— Equipo Miriam González · Beyond the Protocol"
   },
+  "marcas": {
+    "meta_title": "Marcas que se atreven a co-crear — helpmiriam.com",
+    "meta_description": "Co-creación real para marcas: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro, ante una comunidad de ~248K que actúa.",
+    "og_description": "Co-creación real: tu marca dentro del relato, no un logo en un banner. Una comunidad de ~248K que mueve dinero y se moviliza.",
+    "print": "↓ PDF Edición Limitada",
+    "print_aria": "Descargar este dossier en PDF (abre el diálogo de impresión)",
+    "hero_eyebrow": "// dossier para marcas",
+    "hero_title": "No te ofrezco seguidores.{br}Te ofrezco una {em}.",
+    "hero_title_em": "comunidad que actúa",
+    "hero_subtitle": "Co-creación real: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro, en abierto.",
+    "hero_tagline": "// marcas que se atreven a co-crear",
+    "hero_edition_label": "Edición preparada para:",
+    "hero_avatar_alt": "",
+    "historia_eyebrow": "// la historia en 20 segundos",
+    "historia_title": "Una historia {em}.",
+    "historia_title_em": "imposible de ignorar",
+    "historia_p1": "Miriam González ({'@'}miriamgonp), {age} años, ingeniera de software y divulgadora tech. Tiene un cáncer de mama metastásico {b1} (BC-NED, <1% de los casos) y usa {b2} para investigar su propio tumor, documentándolo en abierto.",
+    "historia_p1_b1": "ultra-raro",
+    "historia_p1_b2": "IA + oncología de precisión",
+    "historia_p2": "Respaldo científico real: {b1} analiza sus muestras · {b2} ayuda con la biopsia · la jefa del {b3} se ha interesado por su caso.",
+    "historia_p2_b1": "Dana-Farber (Harvard)",
+    "historia_p2_b2": "Zúrich",
+    "historia_p2_b3": "comité de oncología de precisión más importante del mundo (WIN)",
+    "historia_badges": [
+      "Dana-Farber · Harvard",
+      "Hospital de Zúrich",
+      "Comité WIN"
+    ],
+    "historia_foot": "Detalle clínico completo en {link}. Datos a junio 2026.",
+    "historia_foot_link": "helpmiriam.com/ciencia",
+    "numeros_eyebrow": "// los números (verificables)",
+    "numeros_title": "Una audiencia que se mueve {em}.",
+    "numeros_title_em": "y convierte",
+    "numeros_stats": [
+      { "value": "~248K", "caption": "audiencia total multicanal" },
+      { "value": "8,8%", "caption": "engagement por alcance (IG)" },
+      { "value": "453K", "caption": "cuentas alcanzadas / mes · 3,6× seguidores" },
+      { "value": "+1M", "caption": "visualizaciones / mes (IG)" },
+      { "value": "63%", "caption": "de la interacción = audiencia NUEVA" },
+      { "value": "72,5%", "caption": "audiencia real (Modash · mejor que la media)" }
+    ],
+    "numeros_growth": "📈 {b1} · {b2} (constancia editorial). No es una cuenta estancada: sube.",
+    "numeros_growth_b1": "+4.734 seguidores nuevos en el último mes",
+    "numeros_growth_b2": "34 publicaciones/mes",
+    "numeros_th_canal": "Canal",
+    "numeros_th_audiencia": "Audiencia",
+    "numeros_th_senal": "Señal",
+    "numeros_channels": [
+      { "canal": "Instagram", "audiencia": "126,5K", "senal": "453K alcance/mes · 8,8% eng." },
+      { "canal": "X / Twitter (verificada)", "audiencia": "41,2K", "senal": "~140K impresiones/semana" },
+      { "canal": "LinkedIn", "audiencia": "40,6K", "senal": "🏆 LinkedIn Top Voices 2022" },
+      { "canal": "TikTok", "audiencia": "23,2K", "senal": "228,5K likes" },
+      { "canal": "YouTube", "audiencia": "17K", "senal": "canal de tecnología/programación" }
+    ],
+    "numeros_foot": "Fuentes: Instagram Insights · X Analytics · Modash · perfiles públicos. Junio 2026. Capturas disponibles bajo petición.",
+    "demo_eyebrow": "// quién te escucha",
+    "demo_title": "Audiencia adulta, profesional y {em}.",
+    "demo_title_em": "de consumo",
+    "demo_cards": [
+      {
+        "title": "Instagram",
+        "lines": [
+          "Edad: 25-44 = 73,5% (25-34: 44,7% · 35-44: 28,8%)",
+          "Género: 65,9% hombres · 34,1% mujeres",
+          "Geografía: España y Latinoamérica."
+        ]
+      },
+      {
+        "title": "X / Twitter",
+        "lines": [
+          "Geografía: España 54% · México 11% · Argentina 8%",
+          "Género: 80,5% hombres (perfil tech/profesional)",
+          "Edad: 25-44 (66%)"
+        ]
+      },
+      {
+        "title": "LinkedIn",
+        "lines": [
+          "Perfil: profesional y B2B — devs, ingeniería y decisores",
+          "Reconocimiento: Top Voices 2022"
+        ]
+      }
+    ],
+    "demo_eco": "No es un público, es un {b1}: 5 plataformas (~248K) que se refuerzan — Instagram (masivo, hispano global), LinkedIn (B2B/decisores, Top Voices), X (tech), TikTok (descubrimiento) y YouTube (el documental largo del caso). Una colaboración, varios públicos y formatos.",
+    "demo_eco_b1": "ecosistema",
+    "prueba_eyebrow": "// la prueba de que mi gente actúa",
+    "prueba_title": "No son likes pasivos. {em}",
+    "prueba_title_em": "Mueven dinero y se movilizan.",
+    "prueba_stats": [
+      { "value": "38.897 €", "caption": "recaudados (meta 100K) · prueba de conversión" },
+      { "value": "~1.000", "caption": "donantes = audiencia propia/cálida" },
+      { "value": "3.845", "caption": "clics/mes al enlace de la bio" }
+    ],
+    "prueba_carlos_title": "🎙️ Caso real — Campaña «Carlos Roca / Episodio 100»",
+    "prueba_carlos_p": "Movilizó a su comunidad hacia un objetivo concreto: los reels de campaña sumaron {b1} en pocos días. Prueba de {b2} — exactamente lo que una marca quiere activar.",
+    "prueba_carlos_p_b1": "≈335.000 reproducciones",
+    "prueba_carlos_p_b2": "movilización a la orden",
+    "prueba_virals_title": "Contenido viral (últimos 3 meses)",
+    "prueba_th_post": "Post",
+    "prueba_th_plays": "Reproducciones",
+    "prueba_origen_tag": "POST ORIGEN",
+    "prueba_virals": [
+      { "post": "X · «…Twitter haz tu magia»", "plays": "1.000.000" },
+      { "post": "IG · Coliseo «Busco ayuda para un caso ultra raro»", "plays": "753.487" },
+      { "post": "IG · «SPREAD KINDNESS / 35 años»", "plays": "430.022" },
+      { "post": "IG · «de tecnología y programación / es AHORA»", "plays": "249.321" },
+      { "post": "IG · colab «la comunidad tech me regala un Mac»", "plays": "189.110" },
+      { "post": "IG · carrusel «PET Galio-68 · mi cáncer tiene dos motores»", "plays": "56.474" }
+    ],
+    "prueba_linkedin_title": "🏆 LinkedIn — post viral (Top Voices 2022)",
+    "prueba_linkedin_quote": "«…cáncer de mama metastásico del 1% más raro. Me dieron 5 años, ya llevo 2. No me quedo quieta: investigo mi propio tumor con IA y busco tratamiento con un equipo…»",
+    "prueba_linkedin_stats": "176.484 impresiones · 2.291 reacciones · 194 compartidos",
+    "ganas_eyebrow": "// qué ganas tú",
+    "ganas_title": "Tu marca {em}, no un logo en un banner.",
+    "ganas_title_em": "dentro del relato",
+    "ganas_cards": [
+      { "title": "Co-creación de contenido", "desc": "reel / carrusel / stories pensados juntas, no publi pegada." },
+      { "title": "Tu marca en mi research abierto", "desc": "presencia en el caso que sigue toda una comunidad." },
+      { "title": "Producto probado sin filtros", "desc": "review honesta ante una audiencia que confía." },
+      { "title": "Retos a mi comunidad y eventos", "desc": "lanzo un reto con tu marca y mi gente se moviliza; o te llevo a tu evento (reel + stories)." }
+    ],
+    "ganas_fit": "{b1} donde tu producto se cruza con mi vida real — {b2} · {b3} (hospitales internacionales, vuelos, fintech/cambio de divisa, coche/recarga) · {b4}. Ahí la colaboración es auténtica.",
+    "ganas_fit_b1": "Encajes naturales:",
+    "ganas_fit_b2": "tech y salud",
+    "ganas_fit_b3": "viajes y movilidad",
+    "ganas_fit_b4": "autocuidado, moda y comida sana",
+    "ganas_model": "La comunidad dona, y lo agradezco infinito 💜. A las marcas les propongo algo distinto: {b1}. {b2} colaboración por donación — tu aporte financia la investigación de precisión y co-creamos algo memorable. {em} tu patrocinio ayuda a cerrar la meta de 100.000 € y financia el próximo análisis molecular.",
+    "ganas_model_b1": "co-crear",
+    "ganas_model_b2": "Modelo:",
+    "ganas_model_em": "Gancho:",
+    "partners_eyebrow": "// marcas que ya se atrevieron",
+    "partners_title": "No empiezas de cero. {em}",
+    "partners_title_em": "Ya hay marcas dentro.",
+    "partners": [
+      { "label": "Tahe", "url": "https://tahecosmetics.com" },
+      { "label": "GitHub", "url": "https://github.com" },
+      { "label": "Notion", "url": "https://www.notion.com" },
+      { "label": "Never Surrender", "url": "https://neversurrender.com" }
+    ],
+    "partners_quotes": [
+      { "quote": "«¡Hola, Míriam! Revisa tus mensajes directos para ver una sorpresa. 🤍»", "author": "Notion ({'@'}NotionHQ), en público · 21,6K visualizaciones" },
+      { "quote": "«Fue un gustazo compartir contigo este día y ayudarte a lucir aún más diosa 💜🔥🔥»", "author": "Tahe ({'@'}taheoficial), marca partner verificada · comentario público" }
+    ],
+    "partners_press": "{b1} El País · La Opinión de Murcia · La 7.",
+    "partners_press_b1": "En prensa:",
+    "cta_eyebrow": "// hablemos",
+    "cta_title": "¿Tu marca {em}?",
+    "cta_title_em": "se atreve",
+    "cta_p": "Co-creación real. El mejor trato que te van a ofrecer este año.",
+    "cta_button": "Hablemos",
+    "cta_secondary": "{'@'}miriamgonp",
+    "cta_tagline": "Edición limitada. Sin reposición. Como yo. 💜"
+  },
   "expenses": {
     "title": "Destino del dinero",
     "subtitle": "Transparencia radical: cada euro, documentado.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -13,6 +13,7 @@
     "contact": "Contacto",
     "donate": "Apoyar a Miriam",
     "collaborate": "Cómo ayudar",
+    "brands": "Marcas",
     "expenses": "Gastos",
     "main_label": "Navegación principal",
     "mobile_label": "Navegación móvil",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -123,6 +123,7 @@ export default defineNuxtConfig({
       'prensa': { en: '/press' },
       'contacto': { en: '/contact' },
       'colabora': { en: '/collaborate' },
+      'marcas': { en: '/brands' },
       'gastos': { en: '/expenses' },
       'gracias': { en: '/thank-you' },
       'aviso-legal': { en: '/legal-notice' },
@@ -136,6 +137,10 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       crawlLinks: true,
+      // /marcas (y /en/brands) es una página B2B SIN enlace en la navegación, así
+      // que crawlLinks no la descubre: hay que listarla explícitamente para que
+      // se prerenderice como HTML estático.
+      routes: ['/marcas', '/en/brands'],
       // /design-system/ es un export estático en public/, no una ruta de Nuxt.
       // crawlLinks lo descubre desde /colabora, intenta prerenderizarlo, da 404
       // y aborta el build. Lo ignoramos: el archivo estático se copia igual.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,7 +33,14 @@ export default {
           // sobre cream. El violeta sigue siendo prácticamente el mismo.
           DEFAULT: '#9d44ab',
           soft: '#e8d4ed',        // var(--color-miriam-soft) — badge genómico bg
+          // Violeta claro para ÉNFASIS sobre fondos oscuros (berenjena): el miriam
+          // DEFAULT no contrasta sobre berenjena, este sí (5.46:1, pasa WCAG AA).
+          // Usado en el dossier /marcas (titulares e identidad sobre bandas oscuras).
+          claro: '#c77dd2',
         },
+        // Berenjena un punto más violácea para tarjetas elevadas SOBRE las bandas
+        // oscuras (cajas «Carlos Roca» / LinkedIn en /marcas). Texto crema: 12.8:1.
+        'berenjena-2': '#3a2350',
         coral: {
           DEFAULT: '#ff6b47',     // var(--color-cta) — ÚNICO color de acción (fondos / decoración)
           hover: '#e5573a',


### PR DESCRIPTION
Nueva página B2B **«Marcas que se atreven a co-crear»** en `/marcas` (ES) · `/en/brands` (EN), recreando el dossier one-pager con el design-system del sitio.

### Qué incluye
- 8 secciones: hero · la historia · los números (tabla multicanal) · quién te escucha · la prueba (cifras + virales + LinkedIn) · qué ganas tú · marcas que ya se atrevieron · cierre/CTA.
- **Bilingüe**: copy ES verbatim del dossier + traducción EN fiel (mismas claves i18n).
- **Tokens del sitio** (cream/berenjena/tinta/miriam/coral, Fraunces/Source Sans 3/JetBrains Mono); añadidos `miriam-claro` #c77dd2 y `berenjena-2` #3a2350. Un acento por bloque: violeta = identidad, coral = SOLO acción (botón + cifra 38.897 €).
- Bandas oscuras con cielo decorativo **estático** (glow violeta + estrellas) que respeta contraste AA y `prefers-reduced-motion`.
- **Edad vía `caseData`** (single source). Carlos Roca: solo movilización (~335k), sin resultado. Citas Notion/Tahe verbatim.
- `?marca=Nombre` personaliza el hero. Botón flotante → `window.print()` + estilos `@media print`.
- SEO (`useSeoMeta` + `defineOgImage` Takumi), `i18n.pages` y **prerender explícito** de ambas rutas.

### Decisiones (revisar)
- **Sin enlace en la navegación** (es un dossier B2B que se reparte por enlace directo). Se prerenderiza por ruta explícita. ¿Lo enlazo desde /colabora o el footer?
- Solo la **página** (one-pager). El **deck** (PDF para enviar a marcas) es una pieza aparte, no incluida.
- **«POST ORIGEN»** en violeta (no coral) para respetar «coral = solo acción».

### Verificación
- `pnpm generate` ✅ limpio (Total errors: 0); `/marcas.html` y `/en/brands.html` prerenderizados. Sin mojibake, sin placeholders i18n sin resolver, `@handles` correctos.
- Construido y verificado en worktree aislado (sesión concurrente con `nuxt dev` intacta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)