### PR TITLE
Marketing: rediseño de /marcas (review de Adri)

### DIFF
--- a/app/components/MarcasContactPrompt.vue
+++ b/app/components/MarcasContactPrompt.vue
@@ -7,17 +7,27 @@
     leave-from-class="opacity-100 translate-y-0"
     leave-to-class="opacity-0 translate-y-3"
   >
-    <div v-if="visible" class="mcp" role="dialog" aria-live="polite" :aria-label="$t('marcas.popup_title')">
+    <div
+      v-if="visible"
+      ref="panel"
+      class="mcp"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="mcp-title"
+      aria-describedby="mcp-text"
+      tabindex="-1"
+      @keydown="onKeydown"
+    >
       <Icon name="ph:handshake" class="w-5 h-5 shrink-0 text-miriam-claro mt-0.5" aria-hidden="true" />
       <div class="min-w-0">
-        <p class="text-sm font-semibold text-cream leading-snug">{{ $t('marcas.popup_title') }}</p>
-        <p class="text-xs text-cream/75 leading-snug mt-0.5">{{ $t('marcas.popup_text') }}</p>
+        <p id="mcp-title" class="text-sm font-semibold text-cream leading-snug">{{ $t('marcas.popup_title') }}</p>
+        <p id="mcp-text" class="text-xs text-cream/75 leading-snug mt-0.5">{{ $t('marcas.popup_text') }}</p>
         <NuxtLink :to="localePath('contacto')" class="mcp__cta" @click="dismiss">
           {{ $t('marcas.popup_cta') }}
           <Icon name="ph:arrow-right" class="w-3.5 h-3.5" aria-hidden="true" />
         </NuxtLink>
       </div>
-      <button type="button" class="mcp__close" :aria-label="$t('marcas.popup_dismiss')" @click="dismiss">
+      <button ref="closeBtn" type="button" class="mcp__close" :aria-label="$t('marcas.popup_dismiss')" @click="dismiss">
         <Icon name="ph:x-bold" class="w-4 h-4" aria-hidden="true" />
       </button>
     </div>
@@ -29,42 +39,156 @@
  * Pop-up de contacto SOLO para /marcas (· /en/brands).
  * Sustituye, en esta ruta, el aviso de donación (DonationReturnPrompt): aquí se
  * negocia una colaboración, no se pide donativo. Apunta a /contacto, nunca a
- * GoFundMe. Aparece una sola vez por sesión, tras unos segundos en la página, y
- * es descartable. Si el visitante ya lo cerró, no vuelve. Sin auto-popup molesto:
- * solo se monta en /marcas (ver v-if en la página) y respeta reduced-motion.
+ * GoFundMe.
+ *
+ * Disparo EXIT-INTENT (decisión Miriam, "lo más accesible y marketiniano"), no
+ * por tiempo:
+ *  · Desktop: aparece SOLO al intuir salida — el cursor abandona el viewport por
+ *    arriba/fuera (mouseleave con clientY ≤ 0). Sin temporizador.
+ *  · Móvil/táctil: no hay exit-intent fiable → disparo discreto tras scroll
+ *    profundo (≈70 % de la página), una sola vez.
+ * Una vez por sesión y descartable (✕ o Esc). Si ya se cerró, no vuelve.
+ * Accesible: role=dialog + aria-modal, foco al abrir, focus-trap con Tab,
+ * Esc cierra, se restaura el foco al elemento previo, respeta reduced-motion.
+ * Solo se monta en /marcas (ver v-if en la página).
  */
 const localePath = useLocalePath()
 const visible = ref(false)
-const DELAY_MS = 6000
-let timer: ReturnType<typeof setTimeout> | null = null
 
-function show() {
-  if (visible.value) return
-  let done: string | null = null
+const panel = ref<HTMLElement | null>(null)
+const closeBtn = ref<HTMLElement | null>(null)
+let lastFocused: HTMLElement | null = null
+
+const SESSION_KEY = 'hm_marcas_prompt_done'
+
+function alreadyDone(): boolean {
   try {
-    done = sessionStorage.getItem('hm_marcas_prompt_done')
+    return sessionStorage.getItem(SESSION_KEY) === '1'
   } catch {
-    return
+    // Sin sessionStorage (modo privado estricto) tratamos como "ya hecho":
+    // mejor no insistir que arriesgar repetir el pop-up.
+    return true
   }
-  if (done) return
-  visible.value = true
 }
 
-function dismiss() {
-  visible.value = false
+function markDone() {
   try {
-    sessionStorage.setItem('hm_marcas_prompt_done', '1')
+    sessionStorage.setItem(SESSION_KEY, '1')
   } catch {
     /* noop */
   }
 }
 
-onMounted(() => {
-  timer = setTimeout(show, DELAY_MS)
-})
-onBeforeUnmount(() => {
-  if (timer) clearTimeout(timer)
-})
+function open() {
+  if (visible.value || alreadyDone()) return
+  // Marcamos "hecho" en cuanto se abre: cuenta como su única aparición de la
+  // sesión aunque el visitante lo ignore (no solo al cerrarlo).
+  markDone()
+  teardownTriggers()
+  if (typeof document !== 'undefined') {
+    lastFocused = document.activeElement as HTMLElement | null
+  }
+  visible.value = true
+  // Tras pintar, llevamos el foco al panel para que Esc y el focus-trap operen.
+  nextTick(() => panel.value?.focus())
+}
+
+function dismiss() {
+  if (!visible.value) return
+  visible.value = false
+  markDone()
+  // Devuelve el foco a donde estaba (p. ej. el enlace que el visitante miraba),
+  // salvo que ese elemento ya no exista en el DOM.
+  if (lastFocused && document.contains(lastFocused)) {
+    lastFocused.focus()
+  }
+  lastFocused = null
+}
+
+// ── Accesibilidad: Esc cierra + focus-trap con Tab dentro del panel ──────────
+function focusables(): HTMLElement[] {
+  if (!panel.value) return []
+  return Array.from(
+    panel.value.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((el) => el.offsetParent !== null || el === document.activeElement)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    dismiss()
+    return
+  }
+  if (e.key !== 'Tab') return
+  const items = focusables()
+  if (items.length === 0) {
+    e.preventDefault()
+    panel.value?.focus()
+    return
+  }
+  const first = items[0]
+  const last = items[items.length - 1]
+  const active = document.activeElement
+  // Ciclo cerrado: Shift+Tab desde el primero → último; Tab desde el último →
+  // primero; y si el foco escapó del panel (estaba en el contenedor), lo reatamos.
+  if (e.shiftKey) {
+    if (active === first || active === panel.value) {
+      e.preventDefault()
+      last.focus()
+    }
+  } else if (active === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+// ── Disparadores: exit-intent (desktop) · scroll profundo (táctil) ───────────
+let scrollHandler: (() => void) | null = null
+
+function onMouseOut(e: MouseEvent) {
+  // El cursor sale del viewport por la parte superior (zona de pestañas/cerrar).
+  // relatedTarget/toElement nulos ⇒ salió de la ventana, no a otro elemento.
+  const to = e.relatedTarget as Node | null
+  if (!to && e.clientY <= 0) open()
+}
+
+function onDeepScroll() {
+  if (typeof window === 'undefined') return
+  const doc = document.documentElement
+  const max = doc.scrollHeight - window.innerHeight
+  if (max <= 0) return
+  if (window.scrollY / max >= 0.7) open()
+}
+
+function setupTriggers() {
+  if (typeof window === 'undefined' || alreadyDone()) return
+  const coarse =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(hover: none), (pointer: coarse)').matches
+  if (coarse) {
+    // Táctil: sin exit-intent fiable → scroll profundo, pasivo, una vez.
+    scrollHandler = onDeepScroll
+    window.addEventListener('scroll', scrollHandler, { passive: true })
+    onDeepScroll()
+  } else {
+    // Desktop: intención de salida por la parte superior del viewport.
+    document.addEventListener('mouseout', onMouseOut)
+  }
+}
+
+function teardownTriggers() {
+  if (typeof window === 'undefined') return
+  document.removeEventListener('mouseout', onMouseOut)
+  if (scrollHandler) {
+    window.removeEventListener('scroll', scrollHandler)
+    scrollHandler = null
+  }
+}
+
+onMounted(setupTriggers)
+onBeforeUnmount(teardownTriggers)
 </script>
 
 <style scoped>
@@ -86,10 +210,20 @@ onBeforeUnmount(() => {
   background: #2d1b3d;
   box-shadow: 0 16px 40px -12px rgba(45, 27, 61, 0.5);
 }
-/* Sobre la barra de apoyo persistente (<lg). En desktop, abajo a la derecha. */
+/* Foco programático del contenedor al abrir: sin anillo (el aro accesible vive en
+   los controles internos vía :focus-visible). El trap necesita un tabindex=-1
+   enfocable, pero no debe dibujar outline en la tarjeta. */
+.mcp:focus {
+  outline: none;
+}
+
+/* Móvil (<lg): en /marcas la barra de apoyo NO se monta (ahí no hay donación),
+   pero SÍ está el botón flotante del dossier (.m-print-btn, ~bottom 5.25rem).
+   Elevamos el pop-up por encima de él para que nunca se solapen. En desktop,
+   abajo a la derecha (bottom: 1rem del .mcp base). */
 @media (max-width: 1023px) {
   .mcp {
-    bottom: calc(88px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(8.75rem + env(safe-area-inset-bottom, 0px));
   }
 }
 .mcp__cta {

--- a/app/components/MarcasContactPrompt.vue
+++ b/app/components/MarcasContactPrompt.vue
@@ -1,0 +1,125 @@
+<template>
+  <Transition
+    enter-active-class="transition-all duration-300 ease-out motion-reduce:transition-none"
+    enter-from-class="opacity-0 translate-y-3"
+    enter-to-class="opacity-100 translate-y-0"
+    leave-active-class="transition-all duration-200 ease-in motion-reduce:transition-none"
+    leave-from-class="opacity-100 translate-y-0"
+    leave-to-class="opacity-0 translate-y-3"
+  >
+    <div v-if="visible" class="mcp" role="dialog" aria-live="polite" :aria-label="$t('marcas.popup_title')">
+      <Icon name="ph:handshake" class="w-5 h-5 shrink-0 text-miriam-claro mt-0.5" aria-hidden="true" />
+      <div class="min-w-0">
+        <p class="text-sm font-semibold text-cream leading-snug">{{ $t('marcas.popup_title') }}</p>
+        <p class="text-xs text-cream/75 leading-snug mt-0.5">{{ $t('marcas.popup_text') }}</p>
+        <NuxtLink :to="localePath('contacto')" class="mcp__cta" @click="dismiss">
+          {{ $t('marcas.popup_cta') }}
+          <Icon name="ph:arrow-right" class="w-3.5 h-3.5" aria-hidden="true" />
+        </NuxtLink>
+      </div>
+      <button type="button" class="mcp__close" :aria-label="$t('marcas.popup_dismiss')" @click="dismiss">
+        <Icon name="ph:x-bold" class="w-4 h-4" aria-hidden="true" />
+      </button>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+/**
+ * Pop-up de contacto SOLO para /marcas (· /en/brands).
+ * Sustituye, en esta ruta, el aviso de donación (DonationReturnPrompt): aquí se
+ * negocia una colaboración, no se pide donativo. Apunta a /contacto, nunca a
+ * GoFundMe. Aparece una sola vez por sesión, tras unos segundos en la página, y
+ * es descartable. Si el visitante ya lo cerró, no vuelve. Sin auto-popup molesto:
+ * solo se monta en /marcas (ver v-if en la página) y respeta reduced-motion.
+ */
+const localePath = useLocalePath()
+const visible = ref(false)
+const DELAY_MS = 6000
+let timer: ReturnType<typeof setTimeout> | null = null
+
+function show() {
+  if (visible.value) return
+  let done: string | null = null
+  try {
+    done = sessionStorage.getItem('hm_marcas_prompt_done')
+  } catch {
+    return
+  }
+  if (done) return
+  visible.value = true
+}
+
+function dismiss() {
+  visible.value = false
+  try {
+    sessionStorage.setItem('hm_marcas_prompt_done', '1')
+  } catch {
+    /* noop */
+  }
+}
+
+onMounted(() => {
+  timer = setTimeout(show, DELAY_MS)
+})
+onBeforeUnmount(() => {
+  if (timer) clearTimeout(timer)
+})
+</script>
+
+<style scoped>
+/* Misma familia visual que DonationReturnPrompt (tarjeta berenjena flotante),
+   pero acento violeta (identidad) en vez de coral (acción/donación). */
+.mcp {
+  position: fixed;
+  z-index: 60;
+  left: 1rem;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  max-width: 23rem;
+  margin-left: auto;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: #2d1b3d;
+  box-shadow: 0 16px 40px -12px rgba(45, 27, 61, 0.5);
+}
+/* Sobre la barra de apoyo persistente (<lg). En desktop, abajo a la derecha. */
+@media (max-width: 1023px) {
+  .mcp {
+    bottom: calc(88px + env(safe-area-inset-bottom, 0px));
+  }
+}
+.mcp__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  margin-top: 0.45rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #c77dd2; /* miriam-claro — identidad sobre oscuro */
+  text-decoration: none;
+}
+.mcp__cta:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+.mcp__close {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: rgba(250, 246, 240, 0.6);
+  padding: 2px;
+}
+.mcp__close:hover {
+  color: #faf6f0;
+}
+.mcp__cta:focus-visible,
+.mcp__close:focus-visible {
+  outline: 2px solid #c77dd2;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+</style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -13,13 +13,25 @@
       <slot />
     </main>
     <SiteFooter />
-    <MobileSupportBar />
-    <DonationReturnPrompt />
+    <!-- /marcas (· /en/brands) negocia colaboración, NO donativo: ahí no se monta
+         ningún CTA de donación global (ni la barra "Donar" móvil ni el aviso de
+         retorno). En esa ruta la página monta su propio MarcasContactPrompt. -->
+    <MobileSupportBar v-if="!isBrandsRoute" />
+    <DonationReturnPrompt v-if="!isBrandsRoute" />
   </div>
 </template>
 
 <script setup lang="ts">
 const { locale } = useI18n()
+const route = useRoute()
+
+// ¿Estamos en la landing de marcas? (es: /marcas · en: /en/brands). Se normaliza
+// la barra final para que /marcas/ también cuente. Guarda por ruta: NO afecta al
+// resto del sitio, donde los CTA de donación se mantienen intactos.
+const isBrandsRoute = computed(() => {
+  const path = route.path.replace(/\/+$/, '') || '/'
+  return path === '/marcas' || path === '/en/brands'
+})
 
 function focusMain() {
   nextTick(() => {

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -62,6 +62,11 @@
       :aria-labelledby="'m-hero'"
     >
       <div class="band-fx" aria-hidden="true"></div>
+      <!-- Vida sutil SOLO en el hero: constelación crema + motivo molecular muy
+           tenue (la identidad científica del sitio). Capa encima de la retícula
+           compartida, mismo crema (#faf6f0), baja opacidad, estática. Sin glow
+           lila ni color custom. -->
+      <div class="band-life" aria-hidden="true"></div>
       <div class="section-wide relative z-10">
         <div class="grid lg:grid-cols-[1fr_auto] gap-10 lg:gap-16 items-center">
           <div>
@@ -306,14 +311,16 @@
           <p class="text-lg text-cream/85 leading-relaxed mb-8 max-w-xl mx-auto">{{ t('marcas.cta_p') }}</p>
           <!-- Cierre con UN solo CTA: contactar. El enlace de dossier se retiró
                aquí (redundante con el del hero, el de la dossier-row y el botón
-               flotante) para que el cierre empuje una única acción. -->
+               flotante) para que el cierre empuje una única acción. El
+               cta_microcopy («benéfico/profesional») se retiró: ya vive en el
+               hero (hero_context) y repetirlo re-justificaba el cierre. -->
           <div class="flex justify-center mb-6">
             <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
               {{ t('marcas.cta_button') }}
             </NuxtLink>
           </div>
-          <p class="text-sm text-cream/85 leading-relaxed mb-6 max-w-xl mx-auto">{{ t('marcas.cta_podcast') }}</p>
-          <p class="font-mono text-xs text-cream/65 max-w-md mx-auto leading-relaxed">{{ t('marcas.cta_microcopy') }}</p>
+          <!-- Teaser final (abre boca, sin desvelar): el detalle va al dossier. -->
+          <p class="text-sm text-cream/85 leading-relaxed max-w-xl mx-auto">{{ t('marcas.cta_podcast') }}</p>
         </div>
       </div>
     </section>
@@ -584,6 +591,61 @@ export default { name: 'MarcasPage' }
   background-size: 32px 32px;
 }
 
+/* ── Vida del hero (capa .band-life, SOLO en la banda superior) ───────────────
+   Da aire y vida ON-BRAND a la banda oscura sin reintroducir el resplandor lila
+   que Miriam pidió quitar: TODO en crema (#faf6f0), baja opacidad, estático.
+     · Constelación: puntos crema dispersos de tamaños distintos (estrellas),
+       irregulares —no la retícula regular de .band-fx— para que «respire».
+     · Motivo molecular/neuro: hexágono de nodos+enlaces (la identidad
+       científica del sitio y del avatar) en SVG inline crema, muy tenue,
+       desplazado a la derecha para no competir con el titular.
+   Capa por encima de .band-fx; ambas suman a la misma retícula del resto del
+   sitio. Sin glow lila, sin color custom, sin animación → sin coste de contraste. */
+.band-life {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+  /* Constelación crema: cada radial-gradient es una «estrella». Posiciones y
+     tamaños variados → cielo disperso, no malla. Opacidad por capa muy baja. */
+  background-image:
+    radial-gradient(1.5px 1.5px at 12% 22%, rgba(250, 246, 240, 0.5), transparent 60%),
+    radial-gradient(1px 1px at 26% 64%, rgba(250, 246, 240, 0.38), transparent 60%),
+    radial-gradient(1.5px 1.5px at 38% 14%, rgba(250, 246, 240, 0.45), transparent 60%),
+    radial-gradient(1px 1px at 54% 78%, rgba(250, 246, 240, 0.34), transparent 60%),
+    radial-gradient(2px 2px at 68% 30%, rgba(250, 246, 240, 0.42), transparent 60%),
+    radial-gradient(1px 1px at 82% 58%, rgba(250, 246, 240, 0.36), transparent 60%),
+    radial-gradient(1.5px 1.5px at 90% 18%, rgba(250, 246, 240, 0.4), transparent 60%),
+    radial-gradient(1px 1px at 46% 44%, rgba(250, 246, 240, 0.3), transparent 60%);
+  background-repeat: no-repeat;
+}
+/* Motivo molecular/neuro: hexágono de nodos+enlaces en crema, muy tenue. SVG
+   inline (sin pedir asset). A la derecha y recortado por el borde → sugiere, no
+   ilustra. Oculto en pantallas muy estrechas para no recargar el móvil. */
+.band-life::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: -3rem;
+  width: 360px;
+  height: 360px;
+  transform: translateY(-50%);
+  opacity: 0.07;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' fill='none' stroke='%23faf6f0' stroke-width='1.4'%3E%3Cpolygon points='100,40 152,70 152,130 100,160 48,130 48,70'/%3E%3Cline x1='100' y1='40' x2='100' y2='100'/%3E%3Cline x1='152' y1='70' x2='100' y2='100'/%3E%3Cline x1='152' y1='130' x2='100' y2='100'/%3E%3Cline x1='100' y1='160' x2='100' y2='100'/%3E%3Cline x1='48' y1='130' x2='100' y2='100'/%3E%3Cline x1='48' y1='70' x2='100' y2='100'/%3E%3Cline x1='100' y1='40' x2='30' y2='18'/%3E%3Cline x1='152' y1='130' x2='190' y2='168'/%3E%3Cline x1='48' y1='130' x2='14' y2='150'/%3E%3Ccircle cx='100' cy='100' r='4.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='100' cy='40' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='152' cy='70' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='152' cy='130' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='100' cy='160' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='48' cy='130' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='48' cy='70' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='30' cy='18' r='2.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='190' cy='168' r='2.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='14' cy='150' r='2.5' fill='%23faf6f0' stroke='none'/%3E%3C/svg%3E");
+}
+@media (max-width: 640px) {
+  .band-life::after {
+    width: 220px;
+    height: 220px;
+    right: -4rem;
+    opacity: 0.05;
+  }
+}
+
 /* Botón flotante de descarga del dossier — sobre la barra de apoyo móvil (<lg).
    Color = tokens del DS (berenjena/crema, vía @apply); el hover reutiliza el
    mismo valor que .btn-dark:hover del DS (no hay utilidad Tailwind para ese
@@ -627,7 +689,8 @@ export default { name: 'MarcasPage' }
   .no-print {
     display: none !important;
   }
-  .band-fx {
+  .band-fx,
+  .band-life {
     display: none !important;
   }
   section {

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -10,9 +10,10 @@
         · UN ACENTO POR BLOQUE: violeta = identidad (miriam / miriam-claro
           en oscuro), coral = SOLO acción (botones CTA). Crema, nunca
           blanco; texto berenjena, nunca negro.
-        · Dos bandas oscuras (hero · cierre) llevan un cielo decorativo
-          (.band-fx): resplandor violeta centrado + estrellas tenues hacia
-          los bordes → no pisan el texto (zona tranquila).
+        · Dos bandas oscuras (hero · cierre) = berenjena plano (bg-berenjena) +
+          la MISMA retícula de puntos crema al 4 % que las bandas oscuras del
+          resto del sitio (index.vue / equipo.vue). Sin tinte violeta: el fondo
+          es exactamente el del resto de la web (.band-fx).
         · ?marca=Nombre personaliza el hero (cliente, sin romper SSR).
         · Botón flotante → descarga el dossier (public/dossier-marcas-deck.pdf).
         · Pop-up de contacto propio (MarcasContactPrompt): SOLO aquí, apunta a
@@ -53,10 +54,7 @@
       class="relative overflow-hidden section-spacing bg-berenjena"
       :aria-labelledby="'m-hero'"
     >
-      <div class="band-fx" aria-hidden="true">
-        <div class="band-fx__stars"></div>
-        <div class="band-fx__glow"></div>
-      </div>
+      <div class="band-fx" aria-hidden="true"></div>
       <div class="section-wide relative z-10">
         <div class="grid lg:grid-cols-[1fr_auto] gap-10 lg:gap-16 items-center">
           <div>
@@ -83,8 +81,9 @@
               <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
                 {{ t('marcas.hero_cta') }}
               </NuxtLink>
-              <a href="/dossier-marcas-deck.pdf" download class="link-inline link-inline--invert font-mono text-sm">
+              <a href="/dossier-marcas-deck.pdf" download class="link-action group font-mono text-sm text-cream">
                 {{ t('marcas.hero_cta_dossier') }}
+                <Icon name="ph:download-simple" class="w-4 h-4 transition-transform group-hover:translate-y-0.5" aria-hidden="true" />
               </a>
             </div>
 
@@ -272,10 +271,7 @@
       class="cta-band relative overflow-hidden bg-berenjena"
       :aria-labelledby="'m-cta'"
     >
-      <div class="band-fx" aria-hidden="true">
-        <div class="band-fx__stars"></div>
-        <div class="band-fx__glow"></div>
-      </div>
+      <div class="band-fx" aria-hidden="true"></div>
       <div class="section-wide relative z-10">
         <div class="max-w-2xl mx-auto text-center">
           <p class="dark-eyebrow mb-4">{{ t('marcas.cta_eyebrow') }}</p>
@@ -293,8 +289,9 @@
             <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
               {{ t('marcas.cta_button') }}
             </NuxtLink>
-            <a href="/dossier-marcas-deck.pdf" download class="link-inline link-inline--invert font-mono text-sm">
+            <a href="/dossier-marcas-deck.pdf" download class="link-action group font-mono text-sm text-cream">
               {{ t('marcas.cta_dossier') }}
+              <Icon name="ph:download-simple" class="w-4 h-4 transition-transform group-hover:translate-y-0.5" aria-hidden="true" />
             </a>
           </div>
           <p class="text-sm text-cream/85 leading-relaxed mb-6 max-w-xl mx-auto">{{ t('marcas.cta_podcast') }}</p>
@@ -303,8 +300,10 @@
       </div>
     </section>
 
-    <!-- Botón flotante · descarga el dossier en PDF (oculto en impresión) -->
+    <!-- Botón flotante · descarga el dossier en PDF (oculto en impresión).
+         Icono de descarga = misma señal que los enlaces de dossier del cuerpo. -->
     <a href="/dossier-marcas-deck.pdf" download class="m-print-btn no-print" style="text-decoration: none" :aria-label="t('marcas.print_aria')">
+      <Icon name="ph:download-simple" class="w-4 h-4 shrink-0" aria-hidden="true" />
       {{ t('marcas.print') }}
     </a>
 
@@ -451,9 +450,12 @@ export default { name: 'MarcasPage' }
   border-top: 1px solid rgba(45, 27, 61, 0.08);
 }
 
-/* Pills de marcas partner — identidad violeta; se «encienden» a violeta sólido
-   al pasar/enfocar (señal clara de enlace). */
+/* Pills de marcas partner — misma base que el badge genómico del DS
+   (bg-miriam-soft + text-berenjena, vía @apply: sin hex a mano); identidad
+   violeta que se «enciende» a violeta sólido (bg-miriam + crema) al pasar/
+   enfocar → señal clara de enlace. */
 .partner-pill {
+  @apply bg-miriam-soft text-berenjena;
   display: inline-flex;
   align-items: center;
   font-family: 'JetBrains Mono', monospace;
@@ -461,15 +463,12 @@ export default { name: 'MarcasPage' }
   font-weight: 500;
   padding: 0.4rem 0.85rem;
   border-radius: 999px;
-  background: #e8d4ed;
-  color: #2d1b3d;
   text-decoration: none;
   transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 .partner-pill:hover,
 .partner-pill:focus-visible {
-  background: #9d44ab;
-  color: #faf6f0;
+  @apply bg-miriam text-cream;
   transform: translateY(-1px);
 }
 
@@ -496,14 +495,13 @@ export default { name: 'MarcasPage' }
   }
 }
 .encajes-group__label {
+  @apply text-berenjena border-l-[3px] border-miriam;
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #2d1b3d;
   padding-left: 0.6rem;
-  border-left: 3px solid #9d44ab;
   margin-bottom: 0.85rem;
 }
 .encajes-list {
@@ -515,12 +513,12 @@ export default { name: 'MarcasPage' }
   gap: 0.55rem;
 }
 .encaje-item {
+  @apply text-tinta;
   display: flex;
   align-items: baseline;
   gap: 0.65rem;
   font-size: 14.5px;
   line-height: 1.5;
-  color: #3a3340;
 }
 .encaje-dash {
   flex-shrink: 0;
@@ -537,43 +535,31 @@ export default { name: 'MarcasPage' }
   border-top: 1px solid rgba(45, 27, 61, 0.1);
 }
 
-/* ── Cielo decorativo de las bandas oscuras ──────────────────────────────────
-   Resplandor violeta centrado (zona tranquila tras el texto) + estrellas tenues
-   repartidas hacia los bordes. Estático (sin animación) → seguro siempre y sin
-   coste de contraste sobre el texto crema. */
+/* ── Textura de las bandas oscuras ───────────────────────────────────────────
+   MISMA que el resto del sitio: las bandas berenjena de la home (index.vue, banda
+   "la historia") y del equipo (equipo.vue, panel "lo que NO somos") llevan una
+   retícula de puntos crema tenue al 4 % sobre berenjena plano —sin tinte violeta—.
+   Antes esta página añadía un resplandor lila + estrellas que teñían la banda y
+   la hacían distinta al resto (feedback de Miriam: "el fondo/el lila no coincide").
+   Ahora el fondo es EXACTAMENTE el del resto del sitio: berenjena (bg-berenjena)
+   + esta retícula. Estático → seguro siempre y sin coste de contraste. */
 .band-fx {
   position: absolute;
   inset: 0;
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
-}
-.band-fx__glow {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(58% 64% at 50% 42%, rgba(157, 68, 171, 0.22), transparent 72%);
-}
-.band-fx__stars {
-  position: absolute;
-  inset: 0;
-  background-repeat: no-repeat;
-  background-image:
-    radial-gradient(1.6px 1.6px at 8% 18%, rgba(232, 212, 237, 0.55), transparent 60%),
-    radial-gradient(1.2px 1.2px at 16% 72%, rgba(250, 246, 240, 0.4), transparent 60%),
-    radial-gradient(1.4px 1.4px at 24% 30%, rgba(232, 212, 237, 0.45), transparent 60%),
-    radial-gradient(1px 1px at 33% 86%, rgba(232, 212, 237, 0.4), transparent 60%),
-    radial-gradient(1.5px 1.5px at 45% 10%, rgba(250, 246, 240, 0.45), transparent 60%),
-    radial-gradient(1px 1px at 57% 90%, rgba(232, 212, 237, 0.4), transparent 60%),
-    radial-gradient(1.6px 1.6px at 68% 14%, rgba(232, 212, 237, 0.5), transparent 60%),
-    radial-gradient(1.2px 1.2px at 78% 78%, rgba(250, 246, 240, 0.4), transparent 60%),
-    radial-gradient(1.4px 1.4px at 86% 34%, rgba(232, 212, 237, 0.48), transparent 60%),
-    radial-gradient(1px 1px at 93% 64%, rgba(232, 212, 237, 0.42), transparent 60%),
-    radial-gradient(1.3px 1.3px at 11% 48%, rgba(232, 212, 237, 0.4), transparent 60%),
-    radial-gradient(1.1px 1.1px at 90% 12%, rgba(250, 246, 240, 0.4), transparent 60%);
+  opacity: 0.04;
+  background-image: radial-gradient(circle at 1px 1px, #faf6f0 1px, transparent 0);
+  background-size: 32px 32px;
 }
 
-/* Botón flotante de descarga del dossier — sobre la barra de apoyo móvil (<lg). */
+/* Botón flotante de descarga del dossier — sobre la barra de apoyo móvil (<lg).
+   Color = tokens del DS (berenjena/crema, vía @apply); el hover reutiliza el
+   mismo valor que .btn-dark:hover del DS (no hay utilidad Tailwind para ese
+   tono concreto). Layout fijo/pill: bespoke por necesidad (FAB). */
 .m-print-btn {
+  @apply bg-berenjena text-cream;
   position: fixed;
   right: 1rem;
   bottom: calc(5.25rem + env(safe-area-inset-bottom, 0px));
@@ -583,8 +569,6 @@ export default { name: 'MarcasPage' }
   gap: 0.4rem;
   padding: 0.6rem 0.95rem;
   border-radius: 999px;
-  background: #2d1b3d;
-  color: #faf6f0;
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
   letter-spacing: 0.04em;
@@ -592,7 +576,7 @@ export default { name: 'MarcasPage' }
   transition: transform 0.15s ease, background 0.2s ease;
 }
 .m-print-btn:hover {
-  background: #3d2752;
+  background: #3d2752; /* = .btn-dark:hover (DS, main.css) */
   transform: translateY(-2px);
 }
 @media (min-width: 1024px) {

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -132,33 +132,46 @@
         </i18n-t>
         <p class="text-lg text-tinta leading-relaxed mb-9 max-w-3xl">{{ t('marcas.pilares_intro') }}</p>
 
-        <div class="grid sm:grid-cols-2 gap-4 mb-10">
-          <article v-for="(card, ci) in pilaresCards" :key="ci" class="card-base bg-cream-card pillar-card">
-            <span class="pillar-num font-mono text-xs text-miriam" aria-hidden="true">0{{ ci + 1 }}</span>
-            <h3 class="heading-display text-xl text-berenjena mb-2">{{ rt(card.title) }}</h3>
-            <p class="text-sm text-tinta leading-relaxed mb-3">{{ rt(card.what) }}</p>
-            <p class="text-sm text-berenjena leading-relaxed font-medium pillar-gain">{{ rt(card.gain) }}</p>
+        <!-- 4 pilares — formato editorial: número-guía + titular + qué + qué te llevas.
+             Sin caja ni borde marcado: el peso lo da la tipografía y un filete fino
+             entre filas (mismo lenguaje que la home). El número violeta ata la
+             identidad; el "qué te llevas" se distingue por peso, no por recuadro. -->
+        <div class="pilares grid sm:grid-cols-2 gap-x-12 lg:gap-x-16 mb-12">
+          <article v-for="(card, ci) in pilaresCards" :key="ci" class="pilar">
+            <p class="pilar-head">
+              <span class="pilar-num font-mono text-xs text-miriam" aria-hidden="true">0{{ ci + 1 }}</span>
+              <span class="heading-display text-xl text-berenjena">{{ rt(card.title) }}</span>
+            </p>
+            <p class="text-sm text-tinta leading-relaxed mb-2.5">{{ rt(card.what) }}</p>
+            <p class="text-sm text-berenjena leading-relaxed font-medium pilar-gain">{{ rt(card.gain) }}</p>
           </article>
         </div>
 
         <!-- Encajes naturales — dónde el producto se cruza con la vida real,
-             en tags agrupados por categoría. Idea de Adri: aunque ya haya una
-             marca del sector, sigue habiendo sitio (menciones). -->
-        <div class="encajes mb-10">
+             agrupados por categoría. Aire editorial (sin chips ni recuadros): el
+             rótulo de grupo lleva la identidad violeta y cada encaje es una línea
+             con un guion-acento fino (mismo lenguaje que "Lo que no somos"). Idea
+             de Adri: aunque ya haya una marca del sector, sigue habiendo sitio. -->
+        <div class="encajes mb-12">
           <h3 class="heading-display text-xl text-berenjena mb-2">{{ t('marcas.encajes_title') }}</h3>
-          <p class="text-sm text-tinta leading-relaxed mb-6 max-w-3xl">{{ t('marcas.encajes_intro') }}</p>
+          <p class="text-sm text-tinta leading-relaxed mb-7 max-w-3xl">{{ t('marcas.encajes_intro') }}</p>
           <div class="encajes-grid">
             <div v-for="(g, gi) in encajesGroups" :key="gi" class="encajes-group">
               <p class="encajes-group__label">{{ rt(g.label) }}</p>
-              <ul class="encajes-tags">
-                <li v-for="(tag, ti) in (g.tags as string[])" :key="ti" class="encaje-tag">{{ tag }}</li>
+              <ul class="encajes-list">
+                <li v-for="(tag, ti) in (g.tags as unknown[])" :key="ti" class="encaje-item">
+                  <span class="encaje-dash" aria-hidden="true"></span>
+                  <span>{{ rt(tag) }}</span>
+                </li>
               </ul>
             </div>
           </div>
         </div>
 
-        <!-- Dossier en primer plano + CTA de contacto -->
-        <div class="rounded-2xl p-6 sm:p-7 bg-cream-card flex flex-col sm:flex-row sm:items-center gap-5 sm:gap-8">
+        <!-- Dossier en primer plano + CTA de contacto. Filete fino superior en vez
+             de caja rellena: separa el cierre del bloque sin añadir otro recuadro
+             (mismo divisor editorial que la tira de prensa de la home). -->
+        <div class="dossier-row flex flex-col sm:flex-row sm:items-center gap-5 sm:gap-8">
           <p class="text-base text-berenjena leading-relaxed flex-1 m-0">
             {{ t('marcas.pilares_dossier_line') }}
             <a href="/dossier-marcas-deck.pdf" download class="link-inline font-medium">{{ t('marcas.pilares_dossier_cta') }}</a>
@@ -399,21 +412,43 @@ export default { name: 'MarcasPage' }
   text-underline-offset: 4px;
 }
 
-/* Tarjetas de los 4 pilares — numeradas y con borde violeta de identidad a la
-   izquierda; el "qué te llevas" (.pillar-gain) se separa con una fina regla. */
-.pillar-card {
-  position: relative;
-  border-left: 4px solid #9d44ab;
-}
-.pillar-num {
-  position: absolute;
-  top: 1rem;
-  right: 1.1rem;
-  letter-spacing: 0.08em;
-}
-.pillar-gain {
-  padding-top: 0.65rem;
+/* 4 pilares — formato editorial, sin caja. Cada pilar es una columna de texto
+   separada de la anterior por un filete fino (no un recuadro). El número violeta
+   precede al titular como índice de lectura; el "qué te llevas" (.pilar-gain) se
+   separa con la misma regla fina, manteniendo la jerarquía por peso, no por borde. */
+.pilar {
+  padding-top: 1.6rem;
+  margin-top: 1.6rem;
   border-top: 1px solid rgba(45, 27, 61, 0.1);
+}
+/* Las dos primeras filas (1 col móvil → la 1.ª; 2 cols ≥sm → las dos de arriba)
+   no llevan filete ni espacio superior: el bloque arranca limpio. */
+.pilares > .pilar:first-child {
+  padding-top: 0;
+  margin-top: 0;
+  border-top: 0;
+}
+@media (min-width: 640px) {
+  .pilares > .pilar:nth-child(2) {
+    padding-top: 0;
+    margin-top: 0;
+    border-top: 0;
+  }
+}
+.pilar-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.5rem;
+}
+.pilar-num {
+  letter-spacing: 0.08em;
+  flex-shrink: 0;
+}
+.pilar-gain {
+  margin-top: 0.6rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid rgba(45, 27, 61, 0.08);
 }
 
 /* Pills de marcas partner — identidad violeta; se «encienden» a violeta sólido
@@ -446,17 +481,18 @@ export default { name: 'MarcasPage' }
 }
 
 /* ── Encajes naturales ───────────────────────────────────────────────────────
-   Tags estáticos (no enlaces) agrupados por categoría. Mismos tokens que las
-   pills de partner pero en versión "neutra" (sin acción): no se encienden a
-   violeta sólido para no leerse como enlace. El borde violeta del título de
-   grupo ata el bloque a la identidad de la página. */
+   Listas editoriales agrupadas por categoría — sin chips ni recuadros. El rótulo
+   de grupo lleva el filete violeta de identidad; cada encaje es una línea con un
+   guion-acento fino (mismo lenguaje que "Lo que no somos" del equipo). El aire y
+   la tipografía hacen el trabajo: limpio, no "cajón". */
 .encajes-grid {
   display: grid;
-  gap: 1.5rem 2rem;
+  gap: 2rem 2.5rem;
 }
 @media (min-width: 640px) {
   .encajes-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 2.25rem 3rem;
   }
 }
 .encajes-group__label {
@@ -468,27 +504,37 @@ export default { name: 'MarcasPage' }
   color: #2d1b3d;
   padding-left: 0.6rem;
   border-left: 3px solid #9d44ab;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.85rem;
 }
-.encajes-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+.encajes-list {
   list-style: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
 }
-.encaje-tag {
-  display: inline-flex;
-  align-items: center;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12.5px;
-  font-weight: 500;
-  padding: 0.35rem 0.75rem;
+.encaje-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: #3a3340;
+}
+.encaje-dash {
+  flex-shrink: 0;
+  width: 0.85rem;
+  height: 2px;
   border-radius: 999px;
-  background: rgba(232, 212, 237, 0.55);
-  color: #2d1b3d;
-  border: 1px solid rgba(157, 68, 171, 0.18);
+  background: rgba(157, 68, 171, 0.6);
+  transform: translateY(-0.32em);
+}
+
+/* Fila del dossier — cierre del bloque con filete fino superior (sin caja). */
+.dossier-row {
+  padding-top: 1.75rem;
+  border-top: 1px solid rgba(45, 27, 61, 0.1);
 }
 
 /* ── Cielo decorativo de las bandas oscuras ──────────────────────────────────

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -131,36 +131,41 @@
         </i18n-t>
         <p class="text-lg text-tinta leading-relaxed mb-9 max-w-3xl">{{ t('marcas.pilares_intro') }}</p>
 
-        <!-- 4 pilares — formato editorial: número-guía + titular + qué + qué te llevas.
-             Sin caja ni borde marcado: el peso lo da la tipografía y un filete fino
-             entre filas (mismo lenguaje que la home). El número violeta ata la
-             identidad; el "qué te llevas" se distingue por peso, no por recuadro. -->
-        <div class="pilares grid sm:grid-cols-2 gap-x-12 lg:gap-x-16 mb-12">
-          <article v-for="(card, ci) in pilaresCards" :key="ci" class="pilar">
-            <p class="pilar-head">
-              <span class="pilar-num font-mono text-xs text-miriam" aria-hidden="true">0{{ ci + 1 }}</span>
-              <span class="heading-display text-xl text-berenjena">{{ rt(card.title) }}</span>
+        <!-- 4 pilares — tarjeta del sistema (mismo patrón que la "escalera de CTAs"
+             de la home: .card-base sobre crema, número mono de índice, titular
+             Fraunces, cuerpo en tinta). El "qué te llevas" cierra la tarjeta tras
+             un filete fino, precedido de una flecha violeta de acento, para que se
+             lea como el beneficio y no como otro párrafo. Cuerpo de tarjeta
+             on-brand, sin el borde grueso del round-2 que rompía el vibe. -->
+        <div class="pilares grid sm:grid-cols-2 gap-5 mb-12">
+          <article v-for="(card, ci) in pilaresCards" :key="ci" class="pilar card-base flex flex-col" style="background: #faf6f0">
+            <p class="pilar-num font-mono uppercase text-[11px] tracking-[0.12em] text-tinta mb-2" aria-hidden="true">0{{ ci + 1 }}</p>
+            <h3 class="heading-display text-xl text-berenjena mb-3">{{ rt(card.title) }}</h3>
+            <p class="text-sm text-tinta leading-relaxed mb-4 flex-1">{{ rt(card.what) }}</p>
+            <p class="pilar-gain text-sm text-berenjena leading-relaxed font-medium">
+              <Icon name="ph:arrow-right" class="pilar-gain__icon w-3.5 h-3.5 text-miriam shrink-0" aria-hidden="true" />
+              <span>{{ rt(card.gain) }}</span>
             </p>
-            <p class="text-sm text-tinta leading-relaxed mb-2.5">{{ rt(card.what) }}</p>
-            <p class="text-sm text-berenjena leading-relaxed font-medium pilar-gain">{{ rt(card.gain) }}</p>
           </article>
         </div>
 
         <!-- Encajes naturales — dónde el producto se cruza con la vida real,
-             agrupados por categoría. Aire editorial (sin chips ni recuadros): el
-             rótulo de grupo lleva la identidad violeta y cada encaje es una línea
-             con un guion-acento fino (mismo lenguaje que "Lo que no somos"). Idea
-             de Adri: aunque ya haya una marca del sector, sigue habiendo sitio. -->
+             agrupados por categoría. Cada grupo es una tarjeta del sistema
+             (.card-base sobre crema, rótulo mono con el filete violeta de
+             identidad), y cada encaje vuelve a ser un tag con el mismo lenguaje
+             que los badges genómicos de la home (mono, miriam-soft, píldora que
+             "respira" al pasar). Con cuerpo y personalidad, pero de esta web —ni
+             lista plana (round-4) ni chips genéricos con borde (round-2). Idea de
+             Adri: aunque ya haya una marca del sector, sigue habiendo sitio. -->
         <div class="encajes mb-12">
           <h3 class="heading-display text-xl text-berenjena mb-2">{{ t('marcas.encajes_title') }}</h3>
           <p class="text-sm text-tinta leading-relaxed mb-7 max-w-3xl">{{ t('marcas.encajes_intro') }}</p>
           <div class="encajes-grid">
-            <div v-for="(g, gi) in encajesGroups" :key="gi" class="encajes-group">
+            <div v-for="(g, gi) in encajesGroups" :key="gi" class="encajes-group card-base" style="background: #faf6f0">
               <p class="encajes-group__label">{{ rt(g.label) }}</p>
-              <ul class="encajes-list">
-                <li v-for="(tag, ti) in (g.tags as unknown[])" :key="ti" class="encaje-item">
-                  <span class="encaje-dash" aria-hidden="true"></span>
-                  <span>{{ rt(tag) }}</span>
+              <ul class="encajes-tags">
+                <li v-for="(tag, ti) in (g.tags as unknown[])" :key="ti">
+                  <span class="encaje-tag">{{ rt(tag) }}</span>
                 </li>
               </ul>
             </div>
@@ -411,43 +416,30 @@ export default { name: 'MarcasPage' }
   text-underline-offset: 4px;
 }
 
-/* 4 pilares — formato editorial, sin caja. Cada pilar es una columna de texto
-   separada de la anterior por un filete fino (no un recuadro). El número violeta
-   precede al titular como índice de lectura; el "qué te llevas" (.pilar-gain) se
-   separa con la misma regla fina, manteniendo la jerarquía por peso, no por borde. */
+/* 4 pilares — tarjeta del sistema (.card-base sobre crema), mismo patrón que la
+   "escalera de CTAs" de la home: número mono de índice arriba, titular Fraunces,
+   cuerpo en tinta, y un cierre con el beneficio. flex-col + flex-1 en el cuerpo
+   para que las cuatro tarjetas se alineen aunque el texto varíe de alto.
+   El acento es el número y la flecha violeta — sin el borde grueso del round-2. */
 .pilar {
-  padding-top: 1.6rem;
-  margin-top: 1.6rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.1);
-}
-/* Las dos primeras filas (1 col móvil → la 1.ª; 2 cols ≥sm → las dos de arriba)
-   no llevan filete ni espacio superior: el bloque arranca limpio. */
-.pilares > .pilar:first-child {
-  padding-top: 0;
-  margin-top: 0;
-  border-top: 0;
-}
-@media (min-width: 640px) {
-  .pilares > .pilar:nth-child(2) {
-    padding-top: 0;
-    margin-top: 0;
-    border-top: 0;
-  }
-}
-.pilar-head {
-  display: flex;
-  align-items: baseline;
-  gap: 0.6rem;
-  margin-bottom: 0.5rem;
+  /* hereda .card-base (padding, radio, hairline, bg crema). */
 }
 .pilar-num {
-  letter-spacing: 0.08em;
   flex-shrink: 0;
 }
+/* "Qué te llevas" — cierre de la tarjeta tras un filete fino, con flecha violeta
+   de acento (la misma señal de avance que usan las pathway-cards de la home).
+   Se lee como el beneficio, no como otro párrafo. */
 .pilar-gain {
-  margin-top: 0.6rem;
-  padding-top: 0.55rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  margin-top: 0.2rem;
+  padding-top: 0.85rem;
   border-top: 1px solid rgba(45, 27, 61, 0.08);
+}
+.pilar-gain__icon {
+  transform: translateY(0.18em);
 }
 
 /* Pills de marcas partner — misma base que el badge genómico del DS
@@ -480,19 +472,24 @@ export default { name: 'MarcasPage' }
 }
 
 /* ── Encajes naturales ───────────────────────────────────────────────────────
-   Listas editoriales agrupadas por categoría — sin chips ni recuadros. El rótulo
-   de grupo lleva el filete violeta de identidad; cada encaje es una línea con un
-   guion-acento fino (mismo lenguaje que "Lo que no somos" del equipo). El aire y
-   la tipografía hacen el trabajo: limpio, no "cajón". */
+   Tarjetas del sistema (.card-base sobre crema) agrupadas por categoría: el
+   rótulo de grupo conserva el filete violeta de identidad y dentro vuelven los
+   tags. Cada tag (.encaje-tag) es el MISMO badge que el perfil genómico de la
+   home (mono, fondo miriam-soft, sin borde) y "respira" igual al pasar/enfocar
+   (halo violeta, como .badge-genomic) — píldoras estáticas, no enlaces, pero con
+   el lenguaje real del sitio: ni lista plana (round-4) ni chip con borde (round-2). */
 .encajes-grid {
   display: grid;
-  gap: 2rem 2.5rem;
+  gap: 1rem;
 }
 @media (min-width: 640px) {
   .encajes-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2.25rem 3rem;
+    gap: 1.25rem;
   }
+}
+.encajes-group {
+  /* hereda .card-base (padding, radio, hairline, bg crema). */
 }
 .encajes-group__label {
   @apply text-berenjena border-l-[3px] border-miriam;
@@ -502,31 +499,32 @@ export default { name: 'MarcasPage' }
   letter-spacing: 0.06em;
   text-transform: uppercase;
   padding-left: 0.6rem;
-  margin-bottom: 0.85rem;
+  margin-bottom: 1rem;
 }
-.encajes-list {
+.encajes-tags {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
-.encaje-item {
-  @apply text-tinta;
-  display: flex;
-  align-items: baseline;
-  gap: 0.65rem;
-  font-size: 14.5px;
-  line-height: 1.5;
+/* Tag = badge genómico del DS (bg-miriam-soft + text-berenjena, vía @apply, sin
+   hex a mano). Mismo halo sutil al pasar/enfocar que .badge-genomic — "hasta los
+   detalles respiran" — pero sin pasar a violeta sólido: no es un enlace. */
+.encaje-tag {
+  @apply inline-block bg-miriam-soft text-berenjena rounded-full;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+  padding: 0.3rem 0.7rem;
+  transition: box-shadow 0.2s ease;
 }
-.encaje-dash {
-  flex-shrink: 0;
-  width: 0.85rem;
-  height: 2px;
-  border-radius: 999px;
-  background: rgba(157, 68, 171, 0.6);
-  transform: translateY(-0.32em);
+@media (hover: hover) {
+  .encaje-tag:hover {
+    box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.18);
+  }
 }
 
 /* Fila del dossier — cierre del bloque con filete fino superior (sin caja). */

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -187,17 +187,16 @@
           </div>
         </div>
 
-        <!-- Dossier en primer plano + CTA de contacto. Filete fino superior en vez
-             de caja rellena: separa el cierre del bloque sin añadir otro recuadro
-             (mismo divisor editorial que la tira de prensa de la home). -->
-        <div class="dossier-row flex flex-col sm:flex-row sm:items-center gap-5 sm:gap-8">
-          <p class="text-base text-berenjena leading-relaxed flex-1 m-0">
+        <!-- Dossier en primer plano. Filete fino superior en vez de caja rellena:
+             separa el cierre del bloque sin añadir otro recuadro (mismo divisor
+             editorial que la tira de prensa de la home). Aquí solo el ENLACE al PDF:
+             el CTA de contacto duplicado se retiró para no apilar acciones (la
+             llamada a contactar vive en hero, audiencia y cierre). -->
+        <div class="dossier-row">
+          <p class="text-base text-berenjena leading-relaxed m-0">
             {{ t('marcas.pilares_dossier_line') }}
             <a href="/dossier-marcas-deck.pdf" download class="link-inline font-medium">{{ t('marcas.pilares_dossier_cta') }}</a>
           </p>
-          <NuxtLink :to="localePath('contacto')" class="btn-cta shrink-0" style="text-decoration: none">
-            {{ t('marcas.pilares_cta') }}
-          </NuxtLink>
         </div>
       </div>
     </section>
@@ -305,14 +304,13 @@
             <template #em><em class="italic text-coral">{{ t('marcas.cta_title_em') }}</em></template>
           </i18n-t>
           <p class="text-lg text-cream/85 leading-relaxed mb-8 max-w-xl mx-auto">{{ t('marcas.cta_p') }}</p>
-          <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-6">
+          <!-- Cierre con UN solo CTA: contactar. El enlace de dossier se retiró
+               aquí (redundante con el del hero, el de la dossier-row y el botón
+               flotante) para que el cierre empuje una única acción. -->
+          <div class="flex justify-center mb-6">
             <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
               {{ t('marcas.cta_button') }}
             </NuxtLink>
-            <a href="/dossier-marcas-deck.pdf" download class="link-action group font-mono text-sm text-cream">
-              {{ t('marcas.cta_dossier') }}
-              <Icon name="ph:download-simple" class="w-4 h-4 transition-transform group-hover:translate-y-0.5" aria-hidden="true" />
-            </a>
           </div>
           <p class="text-sm text-cream/85 leading-relaxed mb-6 max-w-xl mx-auto">{{ t('marcas.cta_podcast') }}</p>
           <p class="font-mono text-xs text-cream/65 max-w-md mx-auto leading-relaxed">{{ t('marcas.cta_microcopy') }}</p>

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -13,7 +13,13 @@
         · Dos bandas oscuras (hero · cierre) = berenjena plano (bg-berenjena) +
           la MISMA retícula de puntos crema al 4 % que las bandas oscuras del
           resto del sitio (index.vue / equipo.vue). Sin tinte violeta: el fondo
-          es exactamente el del resto de la web (.band-fx).
+          es exactamente el del resto de la web (.band-fx). En el hero, además,
+          una constelación CELULAR (.cluster) ANCLADA junto al avatar —el racimo de
+          células del dibujo, hecho con el GLYPH CANÓNICO de estrella de 4 puntas de
+          la marca (BrandMark/Constellation, STAR_D), no bolitas de química—: 3-4
+          estrellas «núcleo» (una en miriam-claro, el resto crema) + satélites,
+          unidos por líneas finas curvas; VISIBLE sobre la berenjena, sin color
+          fuera de marca.
         · ?marca=Nombre personaliza el hero (cliente, sin romper SSR).
         · Botón flotante → descarga el dossier (public/dossier-marcas-deck.pdf).
         · Pop-up de contacto propio (MarcasContactPrompt): SOLO aquí, apunta a
@@ -62,11 +68,6 @@
       :aria-labelledby="'m-hero'"
     >
       <div class="band-fx" aria-hidden="true"></div>
-      <!-- Vida sutil SOLO en el hero: constelación crema + motivo molecular muy
-           tenue (la identidad científica del sitio). Capa encima de la retícula
-           compartida, mismo crema (#faf6f0), baja opacidad, estática. Sin glow
-           lila ni color custom. -->
-      <div class="band-life" aria-hidden="true"></div>
       <div class="section-wide relative z-10">
         <div class="grid lg:grid-cols-[1fr_auto] gap-10 lg:gap-16 items-center">
           <div>
@@ -113,7 +114,78 @@
             </ClientOnly>
           </div>
 
-          <figure class="justify-self-center lg:justify-self-end m-0">
+          <figure class="avatar-stage justify-self-center lg:justify-self-end m-0">
+            <!-- Constelación celular del hero (opción A, aprobada por Miriam) —
+                 la identidad científica del avatar (racimo de células neuroendo-
+                 crinas) dibujada con el GLYPH CANÓNICO de estrella de 4 puntas de
+                 la marca (el de BrandMark/Constellation, STAR_D), NO con bolitas de
+                 química. Racimo = 3-4 estrellas «núcleo» grandes/brillantes +
+                 satélites pequeños alrededor, unidos por líneas finas CURVAS (estilo
+                 penLine de Constellation.vue). Anclado junto al lado del avatar.
+                 VISIBILIDAD (lo que antes fallaba): estrellas op. 0.5–0.85 (núcleos
+                 casi opacos), enlaces op. 0.22–0.30; UN núcleo en miriam-claro
+                 (#c77dd2), el resto crema (#faf6f0) → se ve claro sobre la berenjena.
+                 Estático salvo un único parpadeo sutil al entrar (off con reduced-
+                 motion). aria-hidden: pura decoración. -->
+            <svg
+              class="cluster"
+              viewBox="0 0 360 360"
+              fill="none"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <defs>
+                <!-- Glyph canónico de estrella de 4 puntas (= STAR_D de
+                     Constellation.vue / BrandMark.vue), en su caja 20×20. -->
+                <path
+                  id="m-star"
+                  d="M10 1.6 C10.8 5,11.4 6.2,12.6 7.4 C14 8.8,16.4 9.4,18.4 10 C16.2 10.8,14.2 11.4,12.8 12.7 C11.5 13.9,10.9 15.7,10 18.4 C9.3 15.9,8.5 14.2,7.2 12.9 C5.8 11.6,3.4 10.7,1.6 10 C3.8 9.1,5.8 8.4,7.2 7.1 C8.4 6,9.2 4.2,10 1.6 Z"
+                />
+              </defs>
+
+              <!-- Enlaces del racimo: líneas finas CURVAS (Q) entre núcleos y
+                   satélites, estilo penLine. Crema, op. 0.22–0.30 → visibles. -->
+              <g stroke="#faf6f0" stroke-width="1.1" stroke-linecap="round" fill="none" class="cluster-links">
+                <!-- lóbulo derecho (junto al avatar) -->
+                <path d="M300 84 Q322 108 318 150" opacity="0.30" />
+                <path d="M318 150 Q300 176 262 178" opacity="0.26" />
+                <path d="M300 84 Q282 60 248 70" opacity="0.24" />
+                <path d="M318 150 Q344 130 340 100" opacity="0.22" />
+                <path d="M262 178 Q258 218 286 250" opacity="0.26" />
+                <path d="M300 84 Q272 120 262 178" opacity="0.24" />
+                <!-- lóbulo izquierdo -->
+                <path d="M70 132 Q44 156 52 196" opacity="0.30" />
+                <path d="M70 132 Q104 120 122 92" opacity="0.26" />
+                <path d="M52 196 Q86 214 118 200" opacity="0.24" />
+                <path d="M70 132 Q98 168 118 200" opacity="0.22" />
+                <!-- puente sutil entre lóbulos -->
+                <path d="M262 178 Q190 158 118 200" opacity="0.22" />
+              </g>
+
+              <!-- Satélites: estrellas pequeñas alrededor de los núcleos
+                   (op. 0.5–0.65). Crema. scale ~0.18–0.26 sobre la caja de 20. -->
+              <g fill="#faf6f0" class="cluster-sats">
+                <use href="#m-star" opacity="0.58" transform="translate(340 100) scale(0.24) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.5"  transform="translate(248 70)  scale(0.20) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.6"  transform="translate(286 250) scale(0.24) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.5"  transform="translate(332 196) scale(0.18) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.55" transform="translate(122 92)  scale(0.22) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.5"  transform="translate(36 168)  scale(0.18) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.6"  transform="translate(118 200) scale(0.24) translate(-10 -10)" />
+                <use href="#m-star" opacity="0.5"  transform="translate(96 250)  scale(0.18) translate(-10 -10)" />
+              </g>
+
+              <!-- Núcleos: 3-4 estrellas grandes y casi opacas (op. 0.78–0.85),
+                   el racimo del avatar. UNO en miriam-claro (#c77dd2), el resto
+                   crema. El violeta es el núcleo guía (lóbulo derecho, junto al
+                   avatar). scale ~0.42–0.5. -->
+              <g class="cluster-cores">
+                <use href="#m-star" fill="#c77dd2" opacity="0.85" transform="translate(300 84)  scale(0.50) translate(-10 -10)" />
+                <use href="#m-star" fill="#faf6f0" opacity="0.82" transform="translate(318 150) scale(0.44) translate(-10 -10)" />
+                <use href="#m-star" fill="#faf6f0" opacity="0.8"  transform="translate(262 178) scale(0.42) translate(-10 -10)" />
+                <use href="#m-star" fill="#faf6f0" opacity="0.8"  transform="translate(70 132)  scale(0.44) translate(-10 -10)" />
+              </g>
+            </svg>
             <!-- El marco (no la imagen) posee la geometría: aspect-ratio 1 +
                  overflow hidden → círculo perfecto e inmune al estiramiento del
                  grid, igual que TeamPortrait y el retrato del hero de la home.
@@ -283,9 +355,17 @@
           <a :href="pressLa7" target="_blank" rel="noopener" class="link-logo text-2xl sm:text-3xl">La 7<span class="sr-only"> {{ t('a11y.new_tab') }}</span></a>
         </div>
 
-        <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
-          {{ t('marcas.audiencia_cta') }}
-        </NuxtLink>
+        <!-- Cierre de la sección de audiencia: el CTA dejaba de flotar suelto tras
+             la tira de prensa. Ahora va ANCLADO en una fila con filete fino superior
+             (mismo patrón editorial que .dossier-row del bloque de pilares): una
+             línea de remate a la izquierda + el botón a la derecha, leídos como el
+             cierre natural de la sección, no como un CTA perdido. -->
+        <div class="audiencia-cta-row">
+          <p class="text-base text-berenjena leading-relaxed m-0 max-w-md">{{ t('marcas.audiencia_cta_line') }}</p>
+          <NuxtLink :to="localePath('contacto')" class="btn-cta shrink-0" style="text-decoration: none">
+            {{ t('marcas.audiencia_cta') }}
+          </NuxtLink>
+        </div>
       </div>
     </section>
 
@@ -572,6 +652,27 @@ export default { name: 'MarcasPage' }
   border-top: 1px solid rgba(45, 27, 61, 0.1);
 }
 
+/* Fila de cierre de la sección de audiencia — MISMO filete fino superior que
+   .dossier-row, para que el CTA "¿Encajamos?" quede anclado al bloque (no suelto):
+   línea de remate + botón en una fila. Apilado en móvil; en fila, con el botón a la
+   derecha, desde sm. */
+.audiencia-cta-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.1rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid rgba(45, 27, 61, 0.1);
+}
+@media (min-width: 640px) {
+  .audiencia-cta-row {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+}
+
 /* ── Textura de las bandas oscuras ───────────────────────────────────────────
    MISMA que el resto del sitio: las bandas berenjena de la home (index.vue, banda
    "la historia") y del equipo (equipo.vue, panel "lo que NO somos") llevan una
@@ -591,58 +692,68 @@ export default { name: 'MarcasPage' }
   background-size: 32px 32px;
 }
 
-/* ── Vida del hero (capa .band-life, SOLO en la banda superior) ───────────────
-   Da aire y vida ON-BRAND a la banda oscura sin reintroducir el resplandor lila
-   que Miriam pidió quitar: TODO en crema (#faf6f0), baja opacidad, estático.
-     · Constelación: puntos crema dispersos de tamaños distintos (estrellas),
-       irregulares —no la retícula regular de .band-fx— para que «respire».
-     · Motivo molecular/neuro: hexágono de nodos+enlaces (la identidad
-       científica del sitio y del avatar) en SVG inline crema, muy tenue,
-       desplazado a la derecha para no competir con el titular.
-   Capa por encima de .band-fx; ambas suman a la misma retícula del resto del
-   sitio. Sin glow lila, sin color custom, sin animación → sin coste de contraste. */
-.band-life {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  overflow: hidden;
-  /* Constelación crema: cada radial-gradient es una «estrella». Posiciones y
-     tamaños variados → cielo disperso, no malla. Opacidad por capa muy baja. */
-  background-image:
-    radial-gradient(1.5px 1.5px at 12% 22%, rgba(250, 246, 240, 0.5), transparent 60%),
-    radial-gradient(1px 1px at 26% 64%, rgba(250, 246, 240, 0.38), transparent 60%),
-    radial-gradient(1.5px 1.5px at 38% 14%, rgba(250, 246, 240, 0.45), transparent 60%),
-    radial-gradient(1px 1px at 54% 78%, rgba(250, 246, 240, 0.34), transparent 60%),
-    radial-gradient(2px 2px at 68% 30%, rgba(250, 246, 240, 0.42), transparent 60%),
-    radial-gradient(1px 1px at 82% 58%, rgba(250, 246, 240, 0.36), transparent 60%),
-    radial-gradient(1.5px 1.5px at 90% 18%, rgba(250, 246, 240, 0.4), transparent 60%),
-    radial-gradient(1px 1px at 46% 44%, rgba(250, 246, 240, 0.3), transparent 60%);
-  background-repeat: no-repeat;
+/* ── Constelación celular del hero (.avatar-stage > .cluster) ─────────────────
+   Opción A, aprobada por Miriam. El racimo de células del avatar dibujado con el
+   GLYPH CANÓNICO de estrella de 4 puntas de la marca (#m-star = STAR_D de
+   Constellation.vue / BrandMark.vue), NO con bolitas de química. Anclada junto al
+   avatar (no detrás del H1) para no competir con el titular. Sustituye a la
+   antigua .band-life/.molecule (puntos invisibles + nodos químicos, feedback de
+   Miriam: «no se ve» / «no es química»).
+   Decisiones de marca + VISIBILIDAD (lo que antes fallaba):
+     · Estrellas VISIBLES: núcleos op. 0.78–0.85 (casi opacos), satélites
+       0.5–0.65; enlaces op. 0.22–0.30 (NO 0.16). Se ve claro sobre berenjena.
+     · UN núcleo en miriam-claro (#c77dd2, énfasis sobre oscuro, único color
+       fuera del crema y dentro de marca); el resto crema (#faf6f0).
+     · Líneas CURVAS finas (Q de Bézier, estilo penLine) → racimo, no malla rígida.
+     · Estático salvo un único parpadeo sutil al entrar (off con reduced-motion).
+   El <figure> es el lienzo: posición relativa para que el SVG se ancle al avatar. */
+.avatar-stage {
+  position: relative;
 }
-/* Motivo molecular/neuro: hexágono de nodos+enlaces en crema, muy tenue. SVG
-   inline (sin pedir asset). A la derecha y recortado por el borde → sugiere, no
-   ilustra. Oculto en pantallas muy estrechas para no recargar el móvil. */
-.band-life::after {
-  content: '';
+/* El SVG envuelve el avatar (más grande que el marco de 168px) y se centra en él.
+   Detrás del avatar (z-index 0) y sin capturar el ratón. */
+.cluster {
   position: absolute;
   top: 50%;
-  right: -3rem;
+  left: 50%;
   width: 360px;
   height: 360px;
-  transform: translateY(-50%);
-  opacity: 0.07;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200' fill='none' stroke='%23faf6f0' stroke-width='1.4'%3E%3Cpolygon points='100,40 152,70 152,130 100,160 48,130 48,70'/%3E%3Cline x1='100' y1='40' x2='100' y2='100'/%3E%3Cline x1='152' y1='70' x2='100' y2='100'/%3E%3Cline x1='152' y1='130' x2='100' y2='100'/%3E%3Cline x1='100' y1='160' x2='100' y2='100'/%3E%3Cline x1='48' y1='130' x2='100' y2='100'/%3E%3Cline x1='48' y1='70' x2='100' y2='100'/%3E%3Cline x1='100' y1='40' x2='30' y2='18'/%3E%3Cline x1='152' y1='130' x2='190' y2='168'/%3E%3Cline x1='48' y1='130' x2='14' y2='150'/%3E%3Ccircle cx='100' cy='100' r='4.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='100' cy='40' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='152' cy='70' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='152' cy='130' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='100' cy='160' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='48' cy='130' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='48' cy='70' r='3.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='30' cy='18' r='2.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='190' cy='168' r='2.5' fill='%23faf6f0' stroke='none'/%3E%3Ccircle cx='14' cy='150' r='2.5' fill='%23faf6f0' stroke='none'/%3E%3C/svg%3E");
+  transform: translate(-50%, -50%);
+  z-index: 0;
+  pointer-events: none;
+  overflow: visible;
 }
+/* El avatar va por encima del racimo. */
+.avatar-stage .avatar-frame {
+  position: relative;
+  z-index: 1;
+}
+/* Bienvenida: un único parpadeo sutil de las estrellas al entrar (como
+   BrandMark/Constellation), luego quietas. OFF con prefers-reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+  .cluster-cores use,
+  .cluster-sats use {
+    animation: m-cluster-in 1.6s ease-out 1 both;
+  }
+  .cluster-sats use {
+    animation-delay: 0.25s;
+  }
+  @keyframes m-cluster-in {
+    0% {
+      opacity: 0;
+    }
+    60% {
+      opacity: 1;
+    }
+  }
+}
+/* Móvil: el racimo se atenúa (no compite con el contenido en pantalla estrecha)
+   y encoge un poco para no desbordar de más. */
 @media (max-width: 640px) {
-  .band-life::after {
-    width: 220px;
-    height: 220px;
-    right: -4rem;
-    opacity: 0.05;
+  .cluster {
+    width: 300px;
+    height: 300px;
+    opacity: 0.85;
   }
 }
 
@@ -683,14 +794,14 @@ export default { name: 'MarcasPage' }
   }
 }
 
-/* Impresión: fuera el cielo decorativo y el botón; secciones sin cortarse.
-   (El cromo global —nav/footer/barra— ya lo oculta app/assets/css/main.css.) */
+/* Impresión: fuera la textura y la constelación decorativa y el botón; secciones
+   sin cortarse. (El cromo global —nav/footer/barra— ya lo oculta main.css.) */
 @media print {
   .no-print {
     display: none !important;
   }
   .band-fx,
-  .band-life {
+  .cluster {
     display: none !important;
   }
   section {

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -102,15 +102,23 @@
           </div>
 
           <figure class="justify-self-center lg:justify-self-end m-0">
-            <NuxtImg
-              src="/img/miriam-avatar.webp"
-              alt=""
-              width="336"
-              height="336"
-              format="webp"
-              decoding="async"
-              class="w-[168px] h-[168px] rounded-full object-cover avatar-ring"
-            />
+            <!-- El marco (no la imagen) posee la geometría: aspect-ratio 1 +
+                 overflow hidden → círculo perfecto e inmune al estiramiento del
+                 grid, igual que TeamPortrait y el retrato del hero de la home.
+                 sizes da a @nuxt/image un srcset con candidato 2x para que se
+                 vea nítido en pantallas Retina (MacBook Air), no pixelado. -->
+            <div class="avatar-frame avatar-ring">
+              <NuxtImg
+                src="/img/miriam-avatar.webp"
+                alt=""
+                width="512"
+                height="512"
+                sizes="168px"
+                format="webp"
+                decoding="async"
+                class="avatar-img"
+              />
+            </div>
           </figure>
         </div>
       </div>
@@ -400,6 +408,25 @@ export default { name: 'MarcasPage' }
     padding-top: 7rem;    /* 112px, = section-spacing sm */
     padding-bottom: calc(5.5rem + 2px); /* 88px + 2px de sangrado (ver .cta-band) */
   }
+}
+
+/* Avatar del hero — mismo patrón que TeamPortrait y el retrato del hero de la
+   home: el MARCO posee la geometría (tamaño + círculo + recorte) y la imagen
+   solo lo rellena. Así el círculo es perfecto e inmune a que el grid estire el
+   elemento reemplazado, y object-fit encuadra el 1024² original sin deformarlo. */
+.avatar-frame {
+  width: 168px;
+  height: 168px;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 9999px;
+}
+.avatar-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
 }
 
 /* Anillo decorativo del avatar (violeta-soft translúcido). */

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -141,6 +141,22 @@
           </article>
         </div>
 
+        <!-- Encajes naturales — dónde el producto se cruza con la vida real,
+             en tags agrupados por categoría. Idea de Adri: aunque ya haya una
+             marca del sector, sigue habiendo sitio (menciones). -->
+        <div class="encajes mb-10">
+          <h3 class="heading-display text-xl text-berenjena mb-2">{{ t('marcas.encajes_title') }}</h3>
+          <p class="text-sm text-tinta leading-relaxed mb-6 max-w-3xl">{{ t('marcas.encajes_intro') }}</p>
+          <div class="encajes-grid">
+            <div v-for="(g, gi) in encajesGroups" :key="gi" class="encajes-group">
+              <p class="encajes-group__label">{{ rt(g.label) }}</p>
+              <ul class="encajes-tags">
+                <li v-for="(tag, ti) in (g.tags as string[])" :key="ti" class="encaje-tag">{{ tag }}</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
         <!-- Dossier en primer plano + CTA de contacto -->
         <div class="rounded-2xl p-6 sm:p-7 bg-cream-card flex flex-col sm:flex-row sm:items-center gap-5 sm:gap-8">
           <p class="text-base text-berenjena leading-relaxed flex-1 m-0">
@@ -183,14 +199,30 @@
           </div>
         </div>
 
-        <p class="text-tinta leading-relaxed mb-5 max-w-3xl">{{ t('marcas.audiencia_frame') }}</p>
+        <p class="text-tinta leading-relaxed mb-9 max-w-3xl">{{ t('marcas.audiencia_frame') }}</p>
 
-        <i18n-t keypath="marcas.audiencia_carlos" tag="p" class="text-tinta leading-relaxed mb-9 max-w-3xl">
-          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.audiencia_carlos_b1') }}</strong></template>
-          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.audiencia_carlos_b2') }}</strong></template>
-        </i18n-t>
+        <!-- Se movilizan a la orden — la comunidad empuja un objetivo concreto cuando
+             se lo pido. Prueba = magnitud de movilización (~335K acciones) de una
+             campaña reciente. NO se detalla el resultado del concurso (confidencial). -->
+        <div class="movilizan card-base bg-cream mb-9">
+          <h3 class="heading-display text-xl text-berenjena mb-3">{{ t('marcas.movilizan_title') }}</h3>
+          <p class="text-base text-tinta leading-relaxed mb-4 max-w-3xl">
+            <i18n-t keypath="marcas.movilizan_p" tag="span">
+              <template #b><strong class="font-semibold text-berenjena">{{ t('marcas.movilizan_proof') }}</strong></template>
+            </i18n-t>
+          </p>
+          <p
+            class="font-display font-semibold tracking-tight nums text-miriam"
+            style="font-size: clamp(2rem, 5.5vw, 3rem); line-height: 0.95"
+          >
+            {{ t('marcas.movilizan_proof') }}
+          </p>
+          <p class="mt-2 font-mono uppercase text-[11px] tracking-[0.06em] text-tinta leading-snug">
+            {{ t('marcas.movilizan_caption') }}
+          </p>
+        </div>
 
-        <!-- Prueba social ligera: marcas que ya se atrevieron + prensa -->
+        <!-- Prueba social ligera: marcas que ya se atrevieron (+ teaser) + prensa -->
         <div class="flex flex-wrap items-center gap-x-3 gap-y-3 mb-7">
           <span class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta self-center mr-1">
             {{ t('marcas.audiencia_partners_label') }}
@@ -203,6 +235,7 @@
             rel="noopener"
             class="partner-pill"
           >{{ rt(p.label) }} →</a>
+          <span class="partners-more font-mono text-[13px] text-tinta self-center">{{ t('marcas.partners_more') }}</span>
         </div>
 
         <div class="flex flex-wrap items-baseline gap-x-7 gap-y-3 mb-9">
@@ -251,6 +284,7 @@
               {{ t('marcas.cta_dossier') }}
             </a>
           </div>
+          <p class="text-sm text-cream/85 leading-relaxed mb-6 max-w-xl mx-auto">{{ t('marcas.cta_podcast') }}</p>
           <p class="font-mono text-xs text-cream/65 max-w-md mx-auto leading-relaxed">{{ t('marcas.cta_microcopy') }}</p>
         </div>
       </div>
@@ -282,6 +316,7 @@ const marca = computed(() => {
 
 // Listas i18n (arrays en el JSON) — se resuelven hoja a hoja con rt() en el template.
 const pilaresCards = computed(() => tm('marcas.pilares_cards') as Record<string, unknown>[])
+const encajesGroups = computed(() => tm('marcas.encajes_groups') as Record<string, unknown>[])
 const audienciaStats = computed(() => tm('marcas.audiencia_stats') as Record<string, unknown>[])
 const partners = computed(() => tm('marcas.partners') as Record<string, unknown>[])
 
@@ -401,6 +436,59 @@ export default { name: 'MarcasPage' }
   background: #9d44ab;
   color: #faf6f0;
   transform: translateY(-1px);
+}
+
+/* Teaser tras la tira de partners — "…y más por venir". Atenuado y en cursiva:
+   sugiere, no compite con las pills. */
+.partners-more {
+  font-style: italic;
+  opacity: 0.85;
+}
+
+/* ── Encajes naturales ───────────────────────────────────────────────────────
+   Tags estáticos (no enlaces) agrupados por categoría. Mismos tokens que las
+   pills de partner pero en versión "neutra" (sin acción): no se encienden a
+   violeta sólido para no leerse como enlace. El borde violeta del título de
+   grupo ata el bloque a la identidad de la página. */
+.encajes-grid {
+  display: grid;
+  gap: 1.5rem 2rem;
+}
+@media (min-width: 640px) {
+  .encajes-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+.encajes-group__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #2d1b3d;
+  padding-left: 0.6rem;
+  border-left: 3px solid #9d44ab;
+  margin-bottom: 0.75rem;
+}
+.encajes-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.encaje-tag {
+  display: inline-flex;
+  align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(232, 212, 237, 0.55);
+  color: #2d1b3d;
+  border: 1px solid rgba(157, 68, 171, 0.18);
 }
 
 /* ── Cielo decorativo de las bandas oscuras ──────────────────────────────────

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -30,15 +30,22 @@
 
     <!-- ░░ 1 · POR QUÉ COLABORAR / LA ATENCIÓN ░░ banda oscura -->
     <!--
-      Header — opción A elegida (plan §3.1, "todas las miradas"). Lidera con
-      atención/escaparate + dignidad. Alternativas conservadas para que Miriam
+      Header — opción B ELEGIDA (decisión con Adri, 18-jun): lidera con la
+      atención/escaparate ya existente y la marca DENTRO de la historia; encuadre
+      partnership (no donativo) debajo. Alternativas conservadas para que Miriam
       pueda cambiarlas sin volver al plan:
 
-      · Alternativa B — "escaparate que va a volar" (idea directa de Adri):
+      · Alternativa A — "todas las miradas" (plan §3.1, atención + dignidad):
+          H1:  En los próximos meses, mucha gente va a seguir esta historia.
+          Sub: Perfil único (ingeniera + tumor ultra-raro), contado con rigor y
+               sin postureo. Te propongo acompañar tu marca dentro de esa historia.
+          CTA: Hablemos de colaborar →
+
+      · Alternativa B2 — "escaparate que va a volar" (idea directa de Adri):
           H1:  Un escaparate que va a volar. ¿Subes tu marca?
-          Sub: Relanzo mi podcast con Carlos Roca y mi historia va a tener mucha
-               atención. Convierte esa atención en ojos para tu marca —y ayúdame
-               a sostener mi tratamiento— con una colaboración que se nota.
+          Sub: Relanzo mi podcast y mi historia va a tener mucha atención.
+               Convierte esa atención en ojos para tu marca —y ayúdame a sostener
+               mi tratamiento— con una colaboración que se nota.
           CTA: Quiero colaborar →
 
       · Alternativa C — "trato honesto" (partnership-forward):

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -2,23 +2,52 @@
   <div>
     <!--
       ════════════════════════════════════════════════════════════
-        Página /marcas (· /en/brands) — «dossier para marcas» B2B.
+        Página /marcas (· /en/brands) — landing B2B para marcas.
         UNLISTED: no vive en SiteNav, se reparte por enlace directo.
         · Compuesta solo con tokens del design-system (cream/berenjena/
           tinta/miriam/coral) + dos extensiones de marca (miriam-claro
           y berenjena-2) para el énfasis e/o las tarjetas SOBRE oscuro.
         · UN ACENTO POR BLOQUE: violeta = identidad (miriam / miriam-claro
-          en oscuro), coral = SOLO acción (botón «Hablemos» y la cifra
-          «38.897 €»). Crema, nunca blanco; texto berenjena, nunca negro.
-        · Tres bandas oscuras (hero · la prueba · cierre) llevan un cielo
-          decorativo (.band-fx): resplandor violeta centrado + estrellas
-          tenues hacia los bordes → no pisan el texto (zona tranquila).
+          en oscuro), coral = SOLO acción (botones CTA). Crema, nunca
+          blanco; texto berenjena, nunca negro.
+        · Dos bandas oscuras (hero · cierre) llevan un cielo decorativo
+          (.band-fx): resplandor violeta centrado + estrellas tenues hacia
+          los bordes → no pisan el texto (zona tranquila).
         · ?marca=Nombre personaliza el hero (cliente, sin romper SSR).
-        · Botón flotante → descarga el deck (public/dossier-marcas-deck.pdf); estilos @media print mínimos.
+        · Botón flotante → descarga el dossier (public/dossier-marcas-deck.pdf).
+        · Pop-up de contacto propio (MarcasContactPrompt): SOLO aquí, apunta a
+          /contacto, NO a donación (el aviso global de donación se mantiene en
+          el resto del sitio).
+
+        ── ESTRUCTURA (4 bloques, plan de marketing 18-jun-2026) ──
+          1 · Por qué colaborar / la atención que voy a tener  (hero, banda oscura)
+          2 · Formas de colaborar — 4 pilares (lo más rápido de pillar → ARRIBA)
+          3 · Mi tipo de audiencia (ligero: tira macro + prueba social + prensa)
+          4 · Ponte en contacto  (cierre, banda oscura)
       ════════════════════════════════════════════════════════════
     -->
 
-    <!-- ░░ 1 · HERO ░░ banda oscura -->
+    <!-- ░░ 1 · POR QUÉ COLABORAR / LA ATENCIÓN ░░ banda oscura -->
+    <!--
+      Header — opción A elegida (plan §3.1, "todas las miradas"). Lidera con
+      atención/escaparate + dignidad. Alternativas conservadas para que Miriam
+      pueda cambiarlas sin volver al plan:
+
+      · Alternativa B — "escaparate que va a volar" (idea directa de Adri):
+          H1:  Un escaparate que va a volar. ¿Subes tu marca?
+          Sub: Relanzo mi podcast con Carlos Roca y mi historia va a tener mucha
+               atención. Convierte esa atención en ojos para tu marca —y ayúdame
+               a sostener mi tratamiento— con una colaboración que se nota.
+          CTA: Quiero colaborar →
+
+      · Alternativa C — "trato honesto" (partnership-forward):
+          H1:  Te propongo un trato honesto: tú me acompañas, yo te doy una
+               plataforma que va a volar.
+          Sub: Perfil único (ingeniera + tumor ultra-raro), una narrativa que ya
+               está cogiendo altura y una comunidad que actúa. Busco partners a
+               largo plazo, no patrocinios de usar y tirar.
+          CTA: Contáctame →
+    -->
     <section
       v-reveal
       class="relative overflow-hidden section-spacing bg-berenjena"
@@ -39,7 +68,6 @@
               class="heading-display text-cream text-4xl sm:text-5xl"
               style="letter-spacing: -0.03em; line-height: 1.08"
             >
-              <template #br><br /></template>
               <template #em>
                 <em class="italic text-miriam-claro">{{ t('marcas.hero_title_em') }}</em>
               </template>
@@ -47,13 +75,26 @@
             <p class="mt-6 text-lg text-cream/85 leading-relaxed max-w-2xl">
               {{ t('marcas.hero_subtitle') }}
             </p>
-            <p class="mt-6 font-mono text-xs uppercase tracking-[0.16em] text-miriam-claro">
+            <p class="mt-5 text-sm text-cream/70 leading-relaxed max-w-2xl">
+              {{ t('marcas.hero_context') }}
+            </p>
+
+            <div class="mt-8 flex flex-col sm:flex-row sm:items-center gap-4">
+              <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
+                {{ t('marcas.hero_cta') }}
+              </NuxtLink>
+              <a href="/dossier-marcas-deck.pdf" download class="link-inline link-inline--invert font-mono text-sm">
+                {{ t('marcas.hero_cta_dossier') }}
+              </a>
+            </div>
+
+            <p class="mt-7 font-mono text-xs uppercase tracking-[0.16em] text-miriam-claro">
               {{ t('marcas.hero_tagline') }}
             </p>
             <ClientOnly>
               <p
                 v-if="marca"
-                class="mt-6 font-mono text-xs uppercase tracking-[0.12em] text-cream/70"
+                class="mt-5 font-mono text-xs uppercase tracking-[0.12em] text-cream/70"
               >
                 {{ t('marcas.hero_edition_label') }}
                 <b class="ml-1 font-semibold text-cream marca-name">{{ marca }}</b>
@@ -76,80 +117,63 @@
       </div>
     </section>
 
-    <!-- ░░ 2 · LA HISTORIA ░░ crema -->
-    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-historia'">
+    <!-- ░░ 2 · FORMAS DE COLABORAR — 4 PILARES ░░ crema · el bloque clave, arriba -->
+    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-pilares'">
       <div class="section-wide">
-        <p class="eyebrow mb-3 block">{{ t('marcas.historia_eyebrow') }}</p>
+        <p class="eyebrow mb-3 block">{{ t('marcas.pilares_eyebrow') }}</p>
         <i18n-t
-          keypath="marcas.historia_title"
+          keypath="marcas.pilares_title"
           tag="h2"
-          id="m-historia"
-          class="heading-display text-3xl sm:text-4xl text-berenjena mb-6 max-w-3xl"
+          id="m-pilares"
+          class="heading-display text-3xl sm:text-4xl text-berenjena mb-4 max-w-3xl"
           style="letter-spacing: -0.02em"
         >
-          <template #em><em class="italic text-miriam">{{ t('marcas.historia_title_em') }}</em></template>
+          <template #em><em class="italic text-miriam">{{ t('marcas.pilares_title_em') }}</em></template>
         </i18n-t>
+        <p class="text-lg text-tinta leading-relaxed mb-9 max-w-3xl">{{ t('marcas.pilares_intro') }}</p>
 
-        <i18n-t keypath="marcas.historia_p1" tag="p" class="text-lg text-tinta leading-relaxed mb-4 max-w-3xl">
-          <template #age>{{ caseData.currentAge }}</template>
-          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p1_b1') }}</strong></template>
-          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p1_b2') }}</strong></template>
-        </i18n-t>
-
-        <i18n-t keypath="marcas.historia_p2" tag="p" class="text-tinta leading-relaxed mb-6 max-w-3xl">
-          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p2_b1') }}</strong></template>
-          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p2_b2') }}</strong></template>
-          <template #b3><strong class="font-semibold text-berenjena">{{ t('marcas.historia_p2_b3') }}</strong></template>
-        </i18n-t>
-
-        <div class="flex flex-wrap gap-2 mb-6">
-          <span v-for="(b, i) in badges" :key="i" class="badge-genomic">{{ rt(b) }}</span>
+        <div class="grid sm:grid-cols-2 gap-4 mb-10">
+          <article v-for="(card, ci) in pilaresCards" :key="ci" class="card-base bg-cream-card pillar-card">
+            <span class="pillar-num font-mono text-xs text-miriam" aria-hidden="true">0{{ ci + 1 }}</span>
+            <h3 class="heading-display text-xl text-berenjena mb-2">{{ rt(card.title) }}</h3>
+            <p class="text-sm text-tinta leading-relaxed mb-3">{{ rt(card.what) }}</p>
+            <p class="text-sm text-berenjena leading-relaxed font-medium pillar-gain">{{ rt(card.gain) }}</p>
+          </article>
         </div>
 
-        <i18n-t keypath="marcas.historia_foot" tag="p" class="text-sm text-tinta">
-          <template #link>
-            <NuxtLink :to="localePath({ name: 'ciencia' })" class="link-inline">{{ t('marcas.historia_foot_link') }}</NuxtLink>
-          </template>
-        </i18n-t>
-      </div>
-    </section>
-
-    <StarDivider class="bg-cream" />
-
-    <!-- ░░ 2b · EL MODELO ░░ lo que más importa a las marcas · crema -->
-    <section v-reveal class="pt-6 pb-14 sm:pt-8 sm:pb-16 bg-cream" aria-labelledby="m-modelo">
-      <div class="section-wide">
-        <p id="m-modelo" class="eyebrow mb-4 block">{{ t('marcas.modelo_eyebrow') }}</p>
-        <div class="rounded-2xl p-6 sm:p-8 bg-berenjena">
-          <i18n-t keypath="marcas.ganas_model" tag="p" class="text-cream/90 leading-relaxed max-w-3xl">
-            <template #b1><strong class="font-semibold text-miriam-claro">{{ t('marcas.ganas_model_b1') }}</strong></template>
-            <template #b2><strong class="font-semibold text-cream">{{ t('marcas.ganas_model_b2') }}</strong></template>
-            <template #em><em class="italic text-cream">{{ t('marcas.ganas_model_em') }}</em></template>
-          </i18n-t>
+        <!-- Dossier en primer plano + CTA de contacto -->
+        <div class="rounded-2xl p-6 sm:p-7 bg-cream-card flex flex-col sm:flex-row sm:items-center gap-5 sm:gap-8">
+          <p class="text-base text-berenjena leading-relaxed flex-1 m-0">
+            {{ t('marcas.pilares_dossier_line') }}
+            <a href="/dossier-marcas-deck.pdf" download class="link-inline font-medium">{{ t('marcas.pilares_dossier_cta') }}</a>
+          </p>
+          <NuxtLink :to="localePath('contacto')" class="btn-cta shrink-0" style="text-decoration: none">
+            {{ t('marcas.pilares_cta') }}
+          </NuxtLink>
         </div>
       </div>
     </section>
 
-    <!-- ░░ 3 · LOS NÚMEROS ░░ crema-card -->
-    <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'m-numeros'">
+    <!-- ░░ 3 · MI TIPO DE AUDIENCIA (ligero) ░░ crema-card · tira macro + prueba + prensa -->
+    <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'m-audiencia'">
       <div class="section-wide">
-        <p class="eyebrow mb-3 block">{{ t('marcas.numeros_eyebrow') }}</p>
+        <p class="eyebrow mb-3 block">{{ t('marcas.audiencia_eyebrow') }}</p>
         <i18n-t
-          keypath="marcas.numeros_title"
+          keypath="marcas.audiencia_title"
           tag="h2"
-          id="m-numeros"
+          id="m-audiencia"
           class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
           style="letter-spacing: -0.02em"
         >
-          <template #em><em class="italic text-miriam">{{ t('marcas.numeros_title_em') }}</em></template>
+          <template #em><em class="italic text-miriam">{{ t('marcas.audiencia_title_em') }}</em></template>
         </i18n-t>
 
-        <div class="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-9 mb-10">
-          <div v-for="(s, i) in numerosStats" :key="i">
+        <!-- Tira macro: 3 cifras, sin tablas (el desglose fino vive en el dossier) -->
+        <div class="grid grid-cols-3 gap-x-6 gap-y-8 mb-8">
+          <div v-for="(s, i) in audienciaStats" :key="i">
             <p
-              class="font-display font-semibold tracking-tight nums"
-              :class="i === 1 ? 'text-miriam' : 'text-berenjena'"
-              style="font-size: clamp(2.5rem, 6vw, 3.75rem); line-height: 0.95"
+              class="font-display font-semibold tracking-tight nums text-berenjena"
+              style="font-size: clamp(2rem, 5.5vw, 3.25rem); line-height: 0.95"
             >
               {{ rt(s.value) }}
             </p>
@@ -159,193 +183,18 @@
           </div>
         </div>
 
-        <i18n-t keypath="marcas.numeros_growth" tag="p" class="text-tinta leading-relaxed mb-9 max-w-3xl">
-          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.numeros_growth_b1') }}</strong></template>
-          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.numeros_growth_b2') }}</strong></template>
+        <p class="text-tinta leading-relaxed mb-5 max-w-3xl">{{ t('marcas.audiencia_frame') }}</p>
+
+        <i18n-t keypath="marcas.audiencia_carlos" tag="p" class="text-tinta leading-relaxed mb-9 max-w-3xl">
+          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.audiencia_carlos_b1') }}</strong></template>
+          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.audiencia_carlos_b2') }}</strong></template>
         </i18n-t>
 
-        <div class="data-card">
-          <table class="data-table data-table--cards">
-            <thead>
-              <tr>
-                <th scope="col">{{ t('marcas.numeros_th_canal') }}</th>
-                <th scope="col">{{ t('marcas.numeros_th_audiencia') }}</th>
-                <th scope="col">{{ t('marcas.numeros_th_senal') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="(c, i) in channels" :key="i">
-                <td class="cell-head col-marker" :data-label="t('marcas.numeros_th_canal')">{{ rt(c.canal) }}</td>
-                <td class="nums" :data-label="t('marcas.numeros_th_audiencia')">{{ rt(c.audiencia) }}</td>
-                <td class="col-note cell-block" :data-label="t('marcas.numeros_th_senal')">{{ rt(c.senal) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <p class="mt-4 text-xs text-tinta leading-relaxed">{{ t('marcas.numeros_foot') }}</p>
-      </div>
-    </section>
-
-    <!-- ░░ 4 · QUIÉN TE ESCUCHA ░░ crema -->
-    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-demo'">
-      <div class="section-wide">
-        <p class="eyebrow mb-3 block">{{ t('marcas.demo_eyebrow') }}</p>
-        <i18n-t
-          keypath="marcas.demo_title"
-          tag="h2"
-          id="m-demo"
-          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
-          style="letter-spacing: -0.02em"
-        >
-          <template #em><em class="italic text-miriam">{{ t('marcas.demo_title_em') }}</em></template>
-        </i18n-t>
-
-        <div class="grid md:grid-cols-3 gap-4 mb-8">
-          <article v-for="(card, ci) in demoCards" :key="ci" class="card-base bg-cream-card">
-            <h3 class="heading-display text-xl text-berenjena mb-4">{{ rt(card.title) }}</h3>
-            <ul class="space-y-2.5">
-              <li
-                v-for="(line, li) in card.lines"
-                :key="li"
-                class="flex gap-2.5 text-sm text-tinta leading-relaxed"
-              >
-                <span class="font-mono text-miriam text-xs mt-0.5 shrink-0" aria-hidden="true">·</span>
-                <span>{{ rt(line) }}</span>
-              </li>
-            </ul>
-          </article>
-        </div>
-
-        <i18n-t keypath="marcas.demo_eco" tag="p" class="text-tinta leading-relaxed max-w-3xl">
-          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.demo_eco_b1') }}</strong></template>
-        </i18n-t>
-      </div>
-    </section>
-
-    <!-- ░░ 5 · LA PRUEBA DE QUE MI GENTE ACTÚA ░░ banda oscura -->
-    <section
-      v-reveal
-      class="relative overflow-hidden section-spacing bg-berenjena"
-      :aria-labelledby="'m-prueba'"
-    >
-      <div class="band-fx" aria-hidden="true">
-        <div class="band-fx__stars"></div>
-        <div class="band-fx__glow"></div>
-      </div>
-      <div class="section-wide relative z-10">
-        <p class="dark-eyebrow mb-3">{{ t('marcas.prueba_eyebrow') }}</p>
-        <i18n-t
-          keypath="marcas.prueba_title"
-          tag="h2"
-          id="m-prueba"
-          class="heading-display text-3xl sm:text-4xl text-cream mb-8 max-w-3xl"
-          style="letter-spacing: -0.02em"
-        >
-          <template #em><em class="italic text-coral">{{ t('marcas.prueba_title_em') }}</em></template>
-        </i18n-t>
-
-        <div class="grid sm:grid-cols-3 gap-7 mb-10">
-          <div v-for="(s, i) in pruebaStats" :key="i">
-            <p
-              class="font-display font-semibold tracking-tight nums"
-              :class="i === 0 ? 'text-coral' : 'text-cream'"
-              style="font-size: clamp(2.25rem, 5.5vw, 3.25rem); line-height: 0.95"
-            >
-              {{ rt(s.value) }}
-            </p>
-            <p class="mt-2 font-mono uppercase text-[11px] tracking-[0.06em] text-cream/70 leading-snug">
-              {{ rt(s.caption) }}
-            </p>
-          </div>
-        </div>
-
-        <div class="rounded-2xl p-6 sm:p-7 mb-8 bg-berenjena-2 dark-card">
-          <h3 class="font-display font-semibold text-cream text-lg mb-3">{{ t('marcas.prueba_carlos_title') }}</h3>
-          <i18n-t keypath="marcas.prueba_carlos_p" tag="p" class="text-cream/85 leading-relaxed">
-            <template #b1><strong class="font-semibold text-cream">{{ t('marcas.prueba_carlos_p_b1') }}</strong></template>
-            <template #b2><strong class="font-semibold text-cream">{{ t('marcas.prueba_carlos_p_b2') }}</strong></template>
-          </i18n-t>
-        </div>
-
-        <h3 class="font-display font-semibold text-cream text-lg mb-4">{{ t('marcas.prueba_virals_title') }}</h3>
-        <div class="data-card mb-8">
-          <table class="data-table data-table--cards">
-            <thead>
-              <tr>
-                <th scope="col">{{ t('marcas.prueba_th_post') }}</th>
-                <th scope="col" class="th-right">{{ t('marcas.prueba_th_plays') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="(v, i) in virals" :key="i">
-                <td class="cell-head col-note" :data-label="t('marcas.prueba_th_post')">
-                  {{ rt(v.post) }}
-                  <span
-                    v-if="i === 0"
-                    class="ml-2 inline-block align-middle font-mono uppercase text-[9px] tracking-[0.06em] px-1.5 py-0.5 rounded bg-miriam-soft text-berenjena"
-                  >{{ t('marcas.prueba_origen_tag') }}</span>
-                </td>
-                <td class="nums td-right" :data-label="t('marcas.prueba_th_plays')">{{ rt(v.plays) }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div class="rounded-2xl p-6 sm:p-7 bg-berenjena-2 dark-card">
-          <h3 class="font-display font-semibold text-cream text-lg mb-3">{{ t('marcas.prueba_linkedin_title') }}</h3>
-          <blockquote class="font-display italic text-cream/90 text-lg leading-relaxed mb-3">
-            {{ t('marcas.prueba_linkedin_quote') }}
-          </blockquote>
-          <p class="font-mono text-xs text-cream/70 tracking-wide nums">{{ t('marcas.prueba_linkedin_stats') }}</p>
-        </div>
-      </div>
-    </section>
-
-    <!-- ░░ 6 · QUÉ GANAS TÚ ░░ crema-card -->
-    <section v-reveal class="section-spacing bg-cream-card" :aria-labelledby="'m-ganas'">
-      <div class="section-wide">
-        <p class="eyebrow mb-3 block">{{ t('marcas.ganas_eyebrow') }}</p>
-        <i18n-t
-          keypath="marcas.ganas_title"
-          tag="h2"
-          id="m-ganas"
-          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
-          style="letter-spacing: -0.02em"
-        >
-          <template #em><em class="italic text-miriam">{{ t('marcas.ganas_title_em') }}</em></template>
-        </i18n-t>
-
-        <div class="grid sm:grid-cols-2 gap-4 mb-8">
-          <article v-for="(card, ci) in ganasCards" :key="ci" class="card-base bg-cream">
-            <h3 class="heading-display text-xl text-berenjena mb-2">{{ rt(card.title) }}</h3>
-            <p class="text-sm text-tinta leading-relaxed">{{ rt(card.desc) }}</p>
-          </article>
-        </div>
-
-        <i18n-t keypath="marcas.ganas_fit" tag="p" class="text-tinta leading-relaxed mb-8 max-w-3xl">
-          <template #b1><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b1') }}</strong></template>
-          <template #b2><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b2') }}</strong></template>
-          <template #b3><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b3') }}</strong></template>
-          <template #b4><strong class="font-semibold text-berenjena">{{ t('marcas.ganas_fit_b4') }}</strong></template>
-        </i18n-t>
-      </div>
-    </section>
-
-    <!-- ░░ 7 · MARCAS QUE YA SE ATREVIERON ░░ crema -->
-    <section v-reveal class="section-spacing bg-cream" :aria-labelledby="'m-partners'">
-      <div class="section-wide">
-        <p class="eyebrow mb-3 block">{{ t('marcas.partners_eyebrow') }}</p>
-        <i18n-t
-          keypath="marcas.partners_title"
-          tag="h2"
-          id="m-partners"
-          class="heading-display text-3xl sm:text-4xl text-berenjena mb-8 max-w-3xl"
-          style="letter-spacing: -0.02em"
-        >
-          <template #em><em class="italic text-miriam">{{ t('marcas.partners_title_em') }}</em></template>
-        </i18n-t>
-
-        <div class="flex flex-wrap gap-3 mb-8">
+        <!-- Prueba social ligera: marcas que ya se atrevieron + prensa -->
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-3 mb-7">
+          <span class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta self-center mr-1">
+            {{ t('marcas.audiencia_partners_label') }}
+          </span>
           <a
             v-for="(p, i) in partners"
             :key="i"
@@ -356,19 +205,7 @@
           >{{ rt(p.label) }} →</a>
         </div>
 
-        <div class="grid sm:grid-cols-2 gap-4 mb-8">
-          <figure
-            v-for="(q, i) in quotes"
-            :key="i"
-            class="card-base bg-cream-card m-0 quote-card"
-          >
-            <blockquote class="font-display italic text-berenjena text-lg leading-relaxed mb-3">{{ rt(q.quote) }}</blockquote>
-            <figcaption class="font-mono text-xs text-tinta tracking-wide">{{ rt(q.author) }}</figcaption>
-          </figure>
-        </div>
-
-        <!-- Caso en prensa · tira de medios (mismo componente y enlaces que la home) -->
-        <div class="flex flex-wrap items-baseline gap-x-7 gap-y-3">
+        <div class="flex flex-wrap items-baseline gap-x-7 gap-y-3 mb-9">
           <span class="font-mono uppercase text-[11px] tracking-[0.12em] text-tinta self-center">
             {{ t('home.s9_strip_label') }}
           </span>
@@ -376,10 +213,14 @@
           <a :href="pressMurcia" target="_blank" rel="noopener" class="link-logo text-2xl sm:text-3xl">La Opinión de Murcia<span class="sr-only"> {{ t('a11y.new_tab') }}</span></a>
           <a :href="pressLa7" target="_blank" rel="noopener" class="link-logo text-2xl sm:text-3xl">La 7<span class="sr-only"> {{ t('a11y.new_tab') }}</span></a>
         </div>
+
+        <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
+          {{ t('marcas.audiencia_cta') }}
+        </NuxtLink>
       </div>
     </section>
 
-    <!-- ░░ 8 · CIERRE / CTA ░░ banda oscura, centrada -->
+    <!-- ░░ 4 · PONTE EN CONTACTO ░░ banda oscura, centrada -->
     <section
       v-reveal
       class="cta-band relative overflow-hidden bg-berenjena"
@@ -402,27 +243,26 @@
             <template #em><em class="italic text-coral">{{ t('marcas.cta_title_em') }}</em></template>
           </i18n-t>
           <p class="text-lg text-cream/85 leading-relaxed mb-8 max-w-xl mx-auto">{{ t('marcas.cta_p') }}</p>
-          <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-7">
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-6">
             <NuxtLink :to="localePath('contacto')" class="btn-cta" style="text-decoration: none">
               {{ t('marcas.cta_button') }}
             </NuxtLink>
-            <a
-              href="https://instagram.com/miriamgonp"
-              target="_blank"
-              rel="noopener"
-              translate="no"
-              class="font-mono text-sm text-cream/80 hover:text-cream underline underline-offset-4 decoration-cream/40 hover:decoration-cream transition-colors"
-            >{{ t('marcas.cta_secondary') }}</a>
+            <a href="/dossier-marcas-deck.pdf" download class="link-inline link-inline--invert font-mono text-sm">
+              {{ t('marcas.cta_dossier') }}
+            </a>
           </div>
-          <p class="font-display italic text-cream/80 text-lg">{{ t('marcas.cta_tagline') }}</p>
+          <p class="font-mono text-xs text-cream/65 max-w-md mx-auto leading-relaxed">{{ t('marcas.cta_microcopy') }}</p>
         </div>
       </div>
     </section>
 
-    <!-- Botón flotante · descarga el deck en PDF (oculto en impresión) -->
+    <!-- Botón flotante · descarga el dossier en PDF (oculto en impresión) -->
     <a href="/dossier-marcas-deck.pdf" download class="m-print-btn no-print" style="text-decoration: none" :aria-label="t('marcas.print_aria')">
       {{ t('marcas.print') }}
     </a>
+
+    <!-- Pop-up de contacto SOLO en /marcas (sustituye aquí al aviso de donación) -->
+    <MarcasContactPrompt />
   </div>
 </template>
 
@@ -441,15 +281,9 @@ const marca = computed(() => {
 })
 
 // Listas i18n (arrays en el JSON) — se resuelven hoja a hoja con rt() en el template.
-const badges = computed(() => tm('marcas.historia_badges') as unknown[])
-const numerosStats = computed(() => tm('marcas.numeros_stats') as Record<string, unknown>[])
-const channels = computed(() => tm('marcas.numeros_channels') as Record<string, unknown>[])
-const demoCards = computed(() => tm('marcas.demo_cards') as Record<string, unknown>[])
-const pruebaStats = computed(() => tm('marcas.prueba_stats') as Record<string, unknown>[])
-const virals = computed(() => tm('marcas.prueba_virals') as Record<string, unknown>[])
-const ganasCards = computed(() => tm('marcas.ganas_cards') as Record<string, unknown>[])
+const pilaresCards = computed(() => tm('marcas.pilares_cards') as Record<string, unknown>[])
+const audienciaStats = computed(() => tm('marcas.audiencia_stats') as Record<string, unknown>[])
 const partners = computed(() => tm('marcas.partners') as Record<string, unknown>[])
-const quotes = computed(() => tm('marcas.partners_quotes') as Record<string, unknown>[])
 
 // Cobertura de prensa real — mismos enlaces que la tira de medios de la home (index.vue)
 const pressElPais = 'https://elpais.com/tecnologia/2026-04-23/asi-usa-una-paciente-con-cancer-metastasico-la-ia-para-entender-su-enfermedad-cual-es-el-mejor-metodo-para-hablar-de-salud-con-chatbots.html'
@@ -471,8 +305,8 @@ defineOgImage('Default.takumi', {
   title: () => t('marcas.meta_title'),
   description: () =>
     locale.value === 'es'
-      ? 'Co-creación real para marcas. Una comunidad de ~248K que actúa.'
-      : 'Real co-creation for brands. A ~248K community that acts.',
+      ? 'Un escaparate único para tu marca, con dignidad. Cuatro formas reales de colaborar.'
+      : 'A unique showcase for your brand, with dignity. Four real ways to collaborate.',
 })
 </script>
 
@@ -494,18 +328,16 @@ export default { name: 'MarcasPage' }
 }
 
 /* Banda de cierre/CTA: ritmo equilibrado. El contenido es corto (eyebrow → h2 →
-   subtítulo → botones → tagline), así que en vez del py-28 simétrico del DS, que
-   dejaba un hueco muerto bajo la tagline, usamos un padding inferior algo menor
-   que el superior: la composición queda centrada y la banda "abraza" el muro de
-   logos del footer sin aire vacío.
+   subtítulo → botones → microcopy), así que en vez del py-28 simétrico del DS, que
+   dejaba un hueco muerto, usamos un padding inferior algo menor que el superior:
+   la composición queda centrada y la banda "abraza" el muro de logos del footer.
 
    Flush con el footer: la banda CTA y el muro de logos del footer son ambos
    berenjena y deben tocarse sin costura. El borde compartido cae en un píxel
    fraccionario (la altura de la página no es entera) y dejaba asomar 1px del
    fondo crema del <footer> → fina línea clara antiestética. Sangramos la banda
    2px hacia el footer (margin-bottom negativo) y extendemos su fondo berenjena
-   esos 2px (padding-bottom) para que la costura quede siempre cubierta, sin
-   alterar la composición ni el ritmo visible. */
+   esos 2px (padding-bottom) para que la costura quede siempre cubierta. */
 .cta-band {
   padding-top: 5rem;    /* 80px */
   padding-bottom: calc(4.25rem + 2px); /* 68px + 2px de sangrado */
@@ -532,9 +364,21 @@ export default { name: 'MarcasPage' }
   text-underline-offset: 4px;
 }
 
-/* Tarjetas elevadas sobre las bandas oscuras (cajas Carlos Roca / LinkedIn). */
-.dark-card {
-  border: 1px solid rgba(232, 212, 237, 0.14);
+/* Tarjetas de los 4 pilares — numeradas y con borde violeta de identidad a la
+   izquierda; el "qué te llevas" (.pillar-gain) se separa con una fina regla. */
+.pillar-card {
+  position: relative;
+  border-left: 4px solid #9d44ab;
+}
+.pillar-num {
+  position: absolute;
+  top: 1rem;
+  right: 1.1rem;
+  letter-spacing: 0.08em;
+}
+.pillar-gain {
+  padding-top: 0.65rem;
+  border-top: 1px solid rgba(45, 27, 61, 0.1);
 }
 
 /* Pills de marcas partner — identidad violeta; se «encienden» a violeta sólido
@@ -557,19 +401,6 @@ export default { name: 'MarcasPage' }
   background: #9d44ab;
   color: #faf6f0;
   transform: translateY(-1px);
-}
-
-.quote-card {
-  border-left: 4px solid #9d44ab;
-}
-
-/* Alineación a la derecha de la columna de reproducciones (solo ≥sm; en móvil
-   la tabla colapsa a tarjetas etiqueta/valor y manda el layout de cards). */
-@media (min-width: 640px) {
-  .th-right,
-  .td-right {
-    text-align: right;
-  }
 }
 
 /* ── Cielo decorativo de las bandas oscuras ──────────────────────────────────
@@ -607,7 +438,7 @@ export default { name: 'MarcasPage' }
     radial-gradient(1.1px 1.1px at 90% 12%, rgba(250, 246, 240, 0.4), transparent 60%);
 }
 
-/* Botón flotante de impresión — sobre la barra de apoyo móvil (<lg). */
+/* Botón flotante de descarga del dossier — sobre la barra de apoyo móvil (<lg). */
 .m-print-btn {
   position: fixed;
   right: 1rem;

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -930,12 +930,13 @@
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
     "partners_more": "…and more to come",
+    "audiencia_cta_line": "Can you see your brand in here? Write to me and we'll look at it together.",
     "audiencia_cta": "A good fit?",
 
     "cta_eyebrow": "// get in touch",
     "cta_title": "A real partnership, {em}.",
     "cta_title_em": "not a one-day logo",
-    "cta_p": "Tell me what you do and we'll build it together, made for you. This isn't a form that gets lost: there are people behind it and we reply for real.",
+    "cta_p": "Tell me what you do and, if it makes sense for both of us, we'll build it together: a collaboration works when it adds up for your brand and for this project at once. This isn't a form that gets lost: there are people behind it and we reply for real.",
     "cta_button": "Let's talk about your brand",
     "cta_podcast": "And big initiatives are on the way to show everything behind this — the details are in the dossier.",
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -844,27 +844,27 @@
     "links_signature": "— Miriam González's team · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Partner with a story all eyes are about to be on — helpmiriam.com",
-    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I offer your brand that showcase —with rigor and no posturing—. A charitable project, yes, but this is a professional collaboration and we negotiate it as such.",
-    "og_description": "A unique showcase, with dignity: your brand inside the story of a tech creator researching her own ultra-rare cancer. A professional, long-term collaboration, not a logo on a banner.",
+    "meta_title": "Partner with a story a lot of people are going to follow — helpmiriam.com",
+    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I'd like to bring your brand alongside this story, with rigor and no posturing. It's a charitable project, yes, but also a professional collaboration, and we treat it as such.",
+    "og_description": "Your brand inside the story of a tech creator researching her own ultra-rare cancer, told with care and transparency. A professional, long-term collaboration, not a logo on a banner.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Download the brand dossier as PDF",
 
     "_comment_hero": "Header — option A (recommended by the plan). Alternatives B and C as comments in marcas.vue.",
     "hero_eyebrow": "// for brands",
-    "hero_title": "In the coming months, {em} are going to be right here.",
-    "hero_title_em": "all eyes",
-    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer —Murcia, software engineer, a case described only a handful of times in the literature, and one people are going to talk about—. I offer your brand that showcase, with rigor and no posturing, and I'm proposing a real collaboration, not a one-day ad. We do it together.",
-    "hero_context": "Let me be clear from the start: it's a charitable project, yes, but this is a professional collaboration and we negotiate it as such. I'm not asking you for a donation; I'm proposing a partnership. I document the whole process with full transparency.",
+    "hero_title": "Over the coming months, a lot of people {em}.",
+    "hero_title_em": "are going to follow this story",
+    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer —Murcia, software engineer, a case described only a handful of times in the literature—. I tell it with rigor and no posturing, and I'd like to bring your brand alongside that story: a real collaboration, not a one-day ad. We do it together.",
+    "hero_context": "Let me be clear from the start: it's a charitable project, yes, but it's also a professional collaboration and we treat it as such. I'm not asking you for a donation; I'm proposing a partnership. And I document the whole process with full transparency.",
     "hero_cta": "Let's talk about partnering",
     "hero_cta_dossier": "See the dossier (PDF)",
-    "hero_tagline": "// I'm looking for few brands, but real ones",
+    "hero_tagline": "// I'm looking for few brands, but the right ones",
     "hero_edition_label": "Edition prepared for:",
 
     "pilares_eyebrow": "// how your brand fits",
     "pilares_title": "Ways to collaborate {em}.",
-    "pilares_title_em": "that get noticed",
-    "pilares_intro": "Four ways to put your brand on this platform with me. I designed them so you can show them to your team as they are and pick the one that fits you best.",
+    "pilares_title_em": "that make sense",
+    "pilares_intro": "Four ways to bring your brand into this project with me. I designed them so you can show them to your team as they are and pick the one that fits you best.",
     "pilares_cards": [
       {
         "title": "Content co-creation",
@@ -918,12 +918,12 @@
     ],
     "audiencia_frame": "The people your brand will reach: a tech + health profile, Spain and Latin America, professional and engaged. If you want the fine breakdown —ages, geography, channel by channel—, I'll send it to you in the dossier.",
 
-    "movilizan_title": "They mobilize on cue",
-    "movilizan_p": "This isn't an audience that just watches: when I ask for something concrete, it pushes. In a recent campaign, the ask turned into {b}.",
+    "movilizan_title": "And when it counts, they show up",
+    "movilizan_p": "This isn't an audience that just watches: when I ask for something concrete, it responds. In a recent campaign, that «give me a hand» turned into {b}.",
     "movilizan_proof": "≈335,000 actions mobilized",
-    "movilizan_caption": "A community that goes from scrolling to acting when it matters.",
+    "movilizan_caption": "A community that goes from scrolling to acting when it truly matters.",
 
-    "audiencia_partners_label": "Already took the leap",
+    "audiencia_partners_label": "Already on board",
     "partners": [
       { "label": "Tahe Cosmetics", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
@@ -934,13 +934,13 @@
     "audiencia_cta": "A good fit? Write to me",
 
     "cta_eyebrow": "// get in touch",
-    "cta_title": "I'm looking for few brands, {em}. Are you one?",
-    "cta_title_em": "but real ones",
+    "cta_title": "I'm looking for few brands, {em}.",
+    "cta_title_em": "but the right ones",
     "cta_p": "Tell me what you do and we'll build it together, made for you. I answer you personally.",
     "cta_button": "Write to me",
     "cta_dossier": "Download dossier (PDF)",
     "cta_podcast": "And what's coming: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. A good moment to come aboard. 🎙️",
-    "cta_microcopy": "Saying it again because it matters: a charitable project, yes, but this is a professional collaboration between you and me, and we negotiate it as such.",
+    "cta_microcopy": "One last thing, because it matters: it's a charitable project, yes, but also a professional collaboration between you and me, and we treat it as such.",
 
     "popup_title": "Your brand and me, together?",
     "popup_text": "I read every message personally. Tell me who you are and we'll see how we fit.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -847,7 +847,7 @@
     "meta_title": "A showcase about to take off. Bring your brand on. — helpmiriam.com",
     "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a profile that doesn't come twice and a story with a lot of attention ahead. I'm not asking you for a donation; I'm proposing a partnership to turn that attention into eyes on your brand. Charitable, yes, but also professional, and we treat it as such.",
     "og_description": "A showcase about to take off. I'd like to bring your brand onto this story —not a one-day logo— with a tech creator researching her own ultra-rare cancer. A professional, long-term partnership, with full transparency.",
-    "print": "↓ Dossier (PDF)",
+    "print": "Dossier (PDF)",
     "print_aria": "Download the brand dossier as PDF",
 
     "_comment_hero": "Header — Adri's copy pass (Jun 18, AUTHORITATIVE): H1 leads with her «showcase about to take off» image + a direct call to the brand («Bring your brand on»). The partnership-not-donation framing moves down to hero_context. DOSSIER register (sober, peer-to-peer). Alternatives A and C live in the marcas.vue comment.",
@@ -915,7 +915,7 @@
       { "value": "+1M", "caption": "views / month (IG)" },
       { "value": "72.5%", "caption": "verified real audience (Modash)" }
     ],
-    "audiencia_frame": "A tech and health profile, in Spain and Latin America, professional and engaged. I won't bury you in charts: the brands that reach out do it for the media angle and to join something real, not for the exact size of the audience. If you want the fine breakdown —ages, geography, channel by channel—, it's in the dossier.",
+    "audiencia_frame": "I won't bury you in charts: the brands that reach out do it for the media angle and to join something real, not for the exact size of the audience. If you want the fine breakdown, it's in the dossier.",
 
     "movilizan_title": "And when it counts, they show up",
     "movilizan_p": "This isn't an audience that just watches: when I ask for something concrete, it responds. In a recent campaign, that «give me a hand» turned into {b}.",
@@ -937,8 +937,7 @@
     "cta_title_em": "not a one-day logo",
     "cta_p": "Tell me what you do and we'll build it together, made for you. This isn't a form that gets lost: there are people behind it and we reply for real.",
     "cta_button": "Let's talk about your brand",
-    "cta_podcast": "And the timing helps: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. Over the coming months this is going to draw a lot of attention: a good moment to come aboard.",
-    "cta_microcopy": "One last thing, because it matters: it's a charitable project, yes, but also a professional collaboration between you and me, and we treat it as such.",
+    "cta_podcast": "And big initiatives are on the way to show everything behind this — the details are in the dossier.",
 
     "popup_title": "Bring your brand onto this showcase?",
     "popup_text": "This isn't an inbox that gets ignored: there are people behind it and we reply for real. Tell me who you are and we'll see how we fit.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -845,8 +845,8 @@
   },
   "marcas": {
     "meta_title": "Partner with a story all eyes are about to be on — helpmiriam.com",
-    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I offer your brand that showcase —with rigor and no posturing— and a real collaboration, not a one-day ad.",
-    "og_description": "A unique showcase, with dignity: your brand inside the story of a tech creator researching her own ultra-rare cancer. A long-term collaboration, not a logo on a banner.",
+    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I offer your brand that showcase —with rigor and no posturing—. A charitable project, yes, but this is a professional collaboration and we negotiate it as such.",
+    "og_description": "A unique showcase, with dignity: your brand inside the story of a tech creator researching her own ultra-rare cancer. A professional, long-term collaboration, not a logo on a banner.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Download the brand dossier as PDF",
 
@@ -854,8 +854,8 @@
     "hero_eyebrow": "// for brands",
     "hero_title": "In the coming months, {em} are going to be right here.",
     "hero_title_em": "all eyes",
-    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I offer your brand that showcase —with rigor and no posturing— and a real collaboration, not a one-day ad.",
-    "hero_context": "Murcia · software engineer · a case described only a handful of times in the literature · I document the process with full transparency.",
+    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer —Murcia, software engineer, a case described only a handful of times in the literature, and one people are going to talk about—. I offer your brand that showcase, with rigor and no posturing, and I'm proposing a real collaboration, not a one-day ad. We do it together.",
+    "hero_context": "Let me be clear from the start: it's a charitable project, yes, but this is a professional collaboration and we negotiate it as such. I'm not asking you for a donation; I'm proposing a partnership. I document the whole process with full transparency.",
     "hero_cta": "Let's talk about partnering",
     "hero_cta_dossier": "See the dossier (PDF)",
     "hero_tagline": "// I'm looking for few brands, but real ones",
@@ -864,7 +864,7 @@
     "pilares_eyebrow": "// how your brand fits",
     "pilares_title": "Ways to collaborate {em}.",
     "pilares_title_em": "that get noticed",
-    "pilares_intro": "Four ways to put your brand on this platform. Written so you can show them to your team as they are.",
+    "pilares_intro": "Four ways to put your brand on this platform with me. I designed them so you can show them to your team as they are and pick the one that fits you best.",
     "pilares_cards": [
       {
         "title": "Content co-creation",
@@ -916,14 +916,14 @@
       { "value": "+1M", "caption": "views / month (IG)" },
       { "value": "72.5%", "caption": "verified real audience (Modash)" }
     ],
-    "audiencia_frame": "Tech + health profile, Spain and Latin America, professional and engaged. If you want the fine breakdown —ages, geography, channel by channel—, it's in the dossier.",
+    "audiencia_frame": "The people your brand will reach: a tech + health profile, Spain and Latin America, professional and engaged. If you want the fine breakdown —ages, geography, channel by channel—, I'll send it to you in the dossier.",
 
     "movilizan_title": "They mobilize on cue",
     "movilizan_p": "This isn't an audience that just watches: when I ask for something concrete, it pushes. In a recent campaign, the ask turned into {b}.",
     "movilizan_proof": "≈335,000 actions mobilized",
     "movilizan_caption": "A community that goes from scrolling to acting when it matters.",
 
-    "audiencia_partners_label": "Already dared",
+    "audiencia_partners_label": "Already took the leap",
     "partners": [
       { "label": "Tahe Cosmetics", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
@@ -936,11 +936,11 @@
     "cta_eyebrow": "// get in touch",
     "cta_title": "I'm looking for few brands, {em}. Are you one?",
     "cta_title_em": "but real ones",
-    "cta_p": "Tell me what you do and we'll build something made for you. I answer personally.",
+    "cta_p": "Tell me what you do and we'll build it together, made for you. I answer you personally.",
     "cta_button": "Write to me",
     "cta_dossier": "Download dossier (PDF)",
     "cta_podcast": "And what's coming: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. A good moment to come aboard. 🎙️",
-    "cta_microcopy": "A charitable project, yes —but this is a professional collaboration and it's negotiated as such.",
+    "cta_microcopy": "Saying it again because it matters: a charitable project, yes, but this is a professional collaboration between you and me, and we negotiate it as such.",
 
     "popup_title": "Your brand and me, together?",
     "popup_text": "I read every message personally. Tell me who you are and we'll see how we fit.",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -844,18 +844,18 @@
     "links_signature": "— Miriam González's team · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "A story people already follow. Your brand, inside. — helpmiriam.com",
-    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about, a lot. I'm not asking you for a donation; I'm proposing a partnership: bringing your brand into this story, with rigor and no posturing. Charitable, yes, but also professional, and we treat it as such.",
-    "og_description": "A story that already has eyes on it and is about to have many more. I'd like to bring your brand inside —not a one-day logo— with a tech creator researching her own ultra-rare cancer. A professional, long-term partnership, with full transparency.",
+    "meta_title": "A showcase about to take off. Bring your brand on. — helpmiriam.com",
+    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a profile that doesn't come twice and a story with a lot of attention ahead. I'm not asking you for a donation; I'm proposing a partnership to turn that attention into eyes on your brand. Charitable, yes, but also professional, and we treat it as such.",
+    "og_description": "A showcase about to take off. I'd like to bring your brand onto this story —not a one-day logo— with a tech creator researching her own ultra-rare cancer. A professional, long-term partnership, with full transparency.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Download the brand dossier as PDF",
 
-    "_comment_hero": "Header — option B (decided with Adri, Jun 18): leads with the existing attention/showcase and the brand's position INSIDE the story. Framing below = partnership, not donation. Alternatives A and C live in the marcas.vue comment.",
+    "_comment_hero": "Header — Adri's copy pass (Jun 18, AUTHORITATIVE): H1 leads with her «showcase about to take off» image + a direct call to the brand («Bring your brand on»). The partnership-not-donation framing moves down to hero_context. DOSSIER register (sober, peer-to-peer). Alternatives A and C live in the marcas.vue comment.",
     "hero_eyebrow": "// for brands",
-    "hero_title": "A story people already follow. {em}.",
-    "hero_title_em": "Your brand, inside",
-    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer —a case described only a handful of times in the literature—, and over the coming months it's going to have a lot of eyes on it. I'd like to bring your brand into that story: not a one-day logo, but a collaboration that's felt and that lasts. We build it together.",
-    "hero_context": "Let me be clear from the start: I'm not asking you for a donation; I'm proposing a partnership. It's a charitable project, yes, but also a professional collaboration, and we treat it as such —with full transparency at every step.",
+    "hero_title": "A showcase about to take off. {em}.",
+    "hero_title_em": "Bring your brand on",
+    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer: a profile that doesn't come twice. Over the coming months this story is going to have a lot of eyes on it, and I'd like to bring your brand onto it —not a one-day logo, but a presence that's felt and that lasts— to turn that attention into eyes on your brand. With full transparency, start to finish.",
+    "hero_context": "And let me be clear from the start: I'm not asking you for a donation; I'm proposing a partnership. It's a charitable project, yes, but also a professional collaboration, and we treat it as such.",
     "hero_cta": "Tell me what you do",
     "hero_cta_dossier": "See the dossier (for your team)",
     "hero_tagline": "// I answer you personally · I'm looking for few brands, but the right ones",
@@ -889,7 +889,6 @@
     ],
     "pilares_dossier_line": "Want it in writing to take to your team?",
     "pilares_dossier_cta": "Download the dossier (PDF)",
-    "pilares_cta": "Tell me what you do",
 
     "encajes_title": "Where your product fits",
     "encajes_intro": "Where your product meets my real life, that's where the collaboration feels authentic. And if there's already a brand from your sector, there's still room: that's what mentions are for.",
@@ -930,19 +929,18 @@
       { "label": "Notion", "url": "https://www.notion.com" },
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
-    "partners_more": "…and more to come 🤫",
-    "audiencia_cta": "A good fit? Tell me what you do",
+    "partners_more": "…and more to come",
+    "audiencia_cta": "A good fit?",
 
     "cta_eyebrow": "// get in touch",
     "cta_title": "I'm looking for few brands, {em}.",
     "cta_title_em": "but the right ones",
     "cta_p": "Tell me what you do and we'll build it together, made for you. I answer you personally —not a form, not a team.",
     "cta_button": "Let's talk about your brand",
-    "cta_dossier": "See the dossier (for your team)",
-    "cta_podcast": "And the timing helps: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. Over the coming months this is going to draw a lot of attention —a good moment to come aboard. 🎙️",
+    "cta_podcast": "And the timing helps: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. Over the coming months this is going to draw a lot of attention: a good moment to come aboard.",
     "cta_microcopy": "One last thing, because it matters: it's a charitable project, yes, but also a professional collaboration between you and me, and we treat it as such.",
 
-    "popup_title": "Shall we bring your brand into the story?",
+    "popup_title": "Bring your brand onto this showcase?",
     "popup_text": "I read every message personally. Tell me who you are and we'll see how we fit.",
     "popup_cta": "Tell me what you do",
     "popup_dismiss": "Not now"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -858,7 +858,7 @@
     "hero_context": "And let me be clear from the start: I'm not asking you for a donation; I'm proposing a partnership. It's a charitable project, yes, but also a professional collaboration, and we treat it as such.",
     "hero_cta": "Tell me what you do",
     "hero_cta_dossier": "See the dossier (for your team)",
-    "hero_tagline": "// I answer you personally · I'm looking for few brands, but the right ones",
+    "hero_tagline": "// open to the right brands · there are people behind this, not an inbox",
     "hero_edition_label": "Edition prepared for:",
 
     "pilares_eyebrow": "// ways to collaborate",
@@ -933,15 +933,15 @@
     "audiencia_cta": "A good fit?",
 
     "cta_eyebrow": "// get in touch",
-    "cta_title": "I'm looking for few brands, {em}.",
-    "cta_title_em": "but the right ones",
-    "cta_p": "Tell me what you do and we'll build it together, made for you. I answer you personally —not a form, not a team.",
+    "cta_title": "A real partnership, {em}.",
+    "cta_title_em": "not a one-day logo",
+    "cta_p": "Tell me what you do and we'll build it together, made for you. This isn't a form that gets lost: there are people behind it and we reply for real.",
     "cta_button": "Let's talk about your brand",
     "cta_podcast": "And the timing helps: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. Over the coming months this is going to draw a lot of attention: a good moment to come aboard.",
     "cta_microcopy": "One last thing, because it matters: it's a charitable project, yes, but also a professional collaboration between you and me, and we treat it as such.",
 
     "popup_title": "Bring your brand onto this showcase?",
-    "popup_text": "I read every message personally. Tell me who you are and we'll see how we fit.",
+    "popup_text": "This isn't an inbox that gets ignored: there are people behind it and we reply for real. Tell me who you are and we'll see how we fit.",
     "popup_cta": "Tell me what you do",
     "popup_dismiss": "Not now"
   },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -844,55 +844,55 @@
     "links_signature": "— Miriam González's team · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Partner with a story a lot of people are going to follow — helpmiriam.com",
-    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I'd like to bring your brand alongside this story, with rigor and no posturing. It's a charitable project, yes, but also a professional collaboration, and we treat it as such.",
-    "og_description": "Your brand inside the story of a tech creator researching her own ultra-rare cancer, told with care and transparency. A professional, long-term collaboration, not a logo on a banner.",
+    "meta_title": "A story people already follow. Your brand, inside. — helpmiriam.com",
+    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about, a lot. I'm not asking you for a donation; I'm proposing a partnership: bringing your brand into this story, with rigor and no posturing. Charitable, yes, but also professional, and we treat it as such.",
+    "og_description": "A story that already has eyes on it and is about to have many more. I'd like to bring your brand inside —not a one-day logo— with a tech creator researching her own ultra-rare cancer. A professional, long-term partnership, with full transparency.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Download the brand dossier as PDF",
 
-    "_comment_hero": "Header — option A (recommended by the plan). Alternatives B and C as comments in marcas.vue.",
+    "_comment_hero": "Header — option B (decided with Adri, Jun 18): leads with the existing attention/showcase and the brand's position INSIDE the story. Framing below = partnership, not donation. Alternatives A and C live in the marcas.vue comment.",
     "hero_eyebrow": "// for brands",
-    "hero_title": "Over the coming months, a lot of people {em}.",
-    "hero_title_em": "are going to follow this story",
-    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer —Murcia, software engineer, a case described only a handful of times in the literature—. I tell it with rigor and no posturing, and I'd like to bring your brand alongside that story: a real collaboration, not a one-day ad. We do it together.",
-    "hero_context": "Let me be clear from the start: it's a charitable project, yes, but it's also a professional collaboration and we treat it as such. I'm not asking you for a donation; I'm proposing a partnership. And I document the whole process with full transparency.",
-    "hero_cta": "Let's talk about partnering",
-    "hero_cta_dossier": "See the dossier (PDF)",
-    "hero_tagline": "// I'm looking for few brands, but the right ones",
+    "hero_title": "A story people already follow. {em}.",
+    "hero_title_em": "Your brand, inside",
+    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer —a case described only a handful of times in the literature—, and over the coming months it's going to have a lot of eyes on it. I'd like to bring your brand into that story: not a one-day logo, but a collaboration that's felt and that lasts. We build it together.",
+    "hero_context": "Let me be clear from the start: I'm not asking you for a donation; I'm proposing a partnership. It's a charitable project, yes, but also a professional collaboration, and we treat it as such —with full transparency at every step.",
+    "hero_cta": "Tell me what you do",
+    "hero_cta_dossier": "See the dossier (for your team)",
+    "hero_tagline": "// I answer you personally · I'm looking for few brands, but the right ones",
     "hero_edition_label": "Edition prepared for:",
 
-    "pilares_eyebrow": "// how your brand fits",
-    "pilares_title": "Ways to collaborate {em}.",
-    "pilares_title_em": "that make sense",
-    "pilares_intro": "Four ways to bring your brand into this project with me. I designed them so you can show them to your team as they are and pick the one that fits you best.",
+    "pilares_eyebrow": "// ways to collaborate",
+    "pilares_title": "Four ways to put your brand {em}.",
+    "pilares_title_em": "inside the story",
+    "pilares_intro": "The quickest to grasp, first. Four concrete ways to bring your brand in, designed so you can show them to your team as they are —if you have to pitch it to your boss, this is what you put in front of them— and pick the one that fits you best. They combine.",
     "pilares_cards": [
       {
         "title": "Content co-creation",
         "what": "We create native pieces together —reels, carousels, stories— that weave your product into a story people are already following.",
-        "gain": "Not an inserted ad: content the audience actually wants to see."
+        "gain": "Not an ad people skip: content the audience actually wants to see, with your brand inside."
       },
       {
         "title": "Product placement",
         "what": "Your product, genuinely used and on camera, in my day to day (tech, travel/mobility, wellbeing).",
-        "gain": "Natural, credible presence, with no advertising script."
+        "gain": "Natural, credible presence, with no advertising script —genuinely seen, not read as an ad."
       },
       {
         "title": "Co-funded research",
         "what": "«Research together with your brand»: you fund a concrete piece of the case —a test, a panel, a trip to Zurich— and we tell it with full transparency.",
-        "gain": "Your brand associated with real science and measurable impact."
+        "gain": "Your brand tied to real science and to an impact you can see and tell, not to a slogan."
       },
       {
         "title": "Mentions and branding",
         "what": "Your logo on my profile and on the website (with real traffic) and a «thanks to your brand» at the end of every post, podcast shout-out style.",
-        "gain": "Sustained brand recall, not a one-off impression."
+        "gain": "A constant presence in every post, not a one-off impression forgotten the next day."
       }
     ],
-    "pilares_dossier_line": "Want it in writing to show your team?",
+    "pilares_dossier_line": "Want it in writing to take to your team?",
     "pilares_dossier_cta": "Download the dossier (PDF)",
-    "pilares_cta": "Contact me",
+    "pilares_cta": "Tell me what you do",
 
-    "encajes_title": "Natural fits",
-    "encajes_intro": "Where your product meets my real life — that's where the collaboration feels authentic. And if there's already a brand from your sector, there's still room: that's what mentions are for.",
+    "encajes_title": "Where your product fits",
+    "encajes_intro": "Where your product meets my real life, that's where the collaboration feels authentic. And if there's already a brand from your sector, there's still room: that's what mentions are for.",
     "encajes_groups": [
       {
         "label": "Tech and health",
@@ -908,15 +908,15 @@
       }
     ],
 
-    "audiencia_eyebrow": "// my kind of audience",
-    "audiencia_title": "Who {em} reaches.",
-    "audiencia_title_em": "your brand",
+    "audiencia_eyebrow": "// the eyes you'll have on you",
+    "audiencia_title": "The reach you {em}.",
+    "audiencia_title_em": "step into",
     "audiencia_stats": [
       { "value": "~248K", "caption": "multi-platform community" },
       { "value": "+1M", "caption": "views / month (IG)" },
       { "value": "72.5%", "caption": "verified real audience (Modash)" }
     ],
-    "audiencia_frame": "The people your brand will reach: a tech + health profile, Spain and Latin America, professional and engaged. If you want the fine breakdown —ages, geography, channel by channel—, I'll send it to you in the dossier.",
+    "audiencia_frame": "A tech and health profile, in Spain and Latin America, professional and engaged. I won't bury you in charts: the brands that reach out do it for the media angle and to join something real, not for the exact size of the audience. If you want the fine breakdown —ages, geography, channel by channel—, it's in the dossier.",
 
     "movilizan_title": "And when it counts, they show up",
     "movilizan_p": "This isn't an audience that just watches: when I ask for something concrete, it responds. In a recent campaign, that «give me a hand» turned into {b}.",
@@ -931,20 +931,20 @@
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
     "partners_more": "…and more to come 🤫",
-    "audiencia_cta": "A good fit? Write to me",
+    "audiencia_cta": "A good fit? Tell me what you do",
 
     "cta_eyebrow": "// get in touch",
     "cta_title": "I'm looking for few brands, {em}.",
     "cta_title_em": "but the right ones",
-    "cta_p": "Tell me what you do and we'll build it together, made for you. I answer you personally.",
-    "cta_button": "Write to me",
-    "cta_dossier": "Download dossier (PDF)",
-    "cta_podcast": "And what's coming: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. A good moment to come aboard. 🎙️",
+    "cta_p": "Tell me what you do and we'll build it together, made for you. I answer you personally —not a form, not a team.",
+    "cta_button": "Let's talk about your brand",
+    "cta_dossier": "See the dossier (for your team)",
+    "cta_podcast": "And the timing helps: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. Over the coming months this is going to draw a lot of attention —a good moment to come aboard. 🎙️",
     "cta_microcopy": "One last thing, because it matters: it's a charitable project, yes, but also a professional collaboration between you and me, and we treat it as such.",
 
-    "popup_title": "Your brand and me, together?",
+    "popup_title": "Shall we bring your brand into the story?",
     "popup_text": "I read every message personally. Tell me who you are and we'll see how we fit.",
-    "popup_cta": "Contact me",
+    "popup_cta": "Tell me what you do",
     "popup_dismiss": "Not now"
   },
   "expenses": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -844,158 +844,86 @@
     "links_signature": "— Miriam González's team · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Brands brave enough to co-create — helpmiriam.com",
-    "meta_description": "Real co-creation for brands: your brand inside the story of a tech creator researching her own ultra-rare cancer, before a ~248K community that acts.",
-    "og_description": "Real co-creation: your brand inside the story, not a logo on a banner. A ~248K community that moves money and mobilizes.",
-    "print": "↓ PDF Limited Edition",
-    "print_aria": "Download this dossier (deck) as PDF",
-    "hero_eyebrow": "// brand dossier",
-    "hero_title": "I don't offer you followers.{br}I offer you a {em}.",
-    "hero_title_em": "community that acts",
-    "hero_subtitle": "Real co-creation: your brand inside the story of a tech creator researching her own ultra-rare cancer, out in the open.",
-    "hero_tagline": "// brands brave enough to co-create",
+    "meta_title": "Partner with a story all eyes are about to be on — helpmiriam.com",
+    "meta_description": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I offer your brand that showcase —with rigor and no posturing— and a real collaboration, not a one-day ad.",
+    "og_description": "A unique showcase, with dignity: your brand inside the story of a tech creator researching her own ultra-rare cancer. A long-term collaboration, not a logo on a banner.",
+    "print": "↓ Dossier (PDF)",
+    "print_aria": "Download the brand dossier as PDF",
+
+    "_comment_hero": "Header — option A (recommended by the plan). Alternatives B and C as comments in marcas.vue.",
+    "hero_eyebrow": "// for brands",
+    "hero_title": "In the coming months, {em} are going to be right here.",
+    "hero_title_em": "all eyes",
+    "hero_subtitle": "I'm an engineer and creator with an ultra-rare breast cancer: a case people are going to talk about. I offer your brand that showcase —with rigor and no posturing— and a real collaboration, not a one-day ad.",
+    "hero_context": "Murcia · software engineer · a case described only a handful of times in the literature · I document the process with full transparency.",
+    "hero_cta": "Let's talk about partnering",
+    "hero_cta_dossier": "See the dossier (PDF)",
+    "hero_tagline": "// I'm looking for few brands, but real ones",
     "hero_edition_label": "Edition prepared for:",
-    "hero_avatar_alt": "",
-    "historia_eyebrow": "// the story in 20 seconds",
-    "modelo_eyebrow": "// the model",
-    "historia_title": "A story {em}.",
-    "historia_title_em": "impossible to ignore",
-    "historia_p1": "Miriam González ({'@'}miriamgonp), {age} years old, a software engineer and tech creator. She has an {b1} metastatic breast cancer (BC-NED, <1% of cases) and uses {b2} to research her own tumor, documenting it in the open.",
-    "historia_p1_b1": "ultra-rare",
-    "historia_p1_b2": "AI + precision oncology",
-    "historia_p2": "Real scientific backing: {b1} analyzes her samples · {b2} assists with the biopsy · the chair of the {b3} has taken an interest in her case.",
-    "historia_p2_b1": "Dana-Farber (Harvard)",
-    "historia_p2_b2": "Zurich",
-    "historia_p2_b3": "world's most important precision-oncology committee (WIN)",
-    "historia_badges": [
-      "Dana-Farber · Harvard",
-      "Zurich Hospital",
-      "WIN Committee"
-    ],
-    "historia_foot": "Full clinical detail at {link}. Data as of June 2026.",
-    "historia_foot_link": "helpmiriam.com/science",
-    "numeros_eyebrow": "// the numbers (verifiable)",
-    "numeros_title": "An audience that moves {em}.",
-    "numeros_title_em": "and converts",
-    "numeros_stats": [
-      { "value": "~248K", "caption": "total multichannel audience" },
-      { "value": "8.8%", "caption": "engagement by reach (IG)" },
-      { "value": "453K", "caption": "accounts reached / month · 3.6× followers" },
-      { "value": "+1M", "caption": "views / month (IG)" },
-      { "value": "63%", "caption": "of interaction = NEW audience" },
-      { "value": "72.5%", "caption": "real audience (Modash · above average)" }
-    ],
-    "numeros_growth": "📈 {b1} · {b2} (editorial consistency). Not a stalled account: it's growing.",
-    "numeros_growth_b1": "+4,734 new followers in the last month",
-    "numeros_growth_b2": "34 posts/month",
-    "numeros_th_canal": "Channel",
-    "numeros_th_audiencia": "Audience",
-    "numeros_th_senal": "Signal",
-    "numeros_channels": [
-      { "canal": "Instagram", "audiencia": "126.5K", "senal": "453K reach/month · 8.8% eng." },
-      { "canal": "X / Twitter (verified)", "audiencia": "41.2K", "senal": "~140K impressions/week" },
-      { "canal": "LinkedIn", "audiencia": "40.6K", "senal": "🏆 LinkedIn Top Voices 2022" },
-      { "canal": "TikTok", "audiencia": "23.2K", "senal": "228.5K likes" },
-      { "canal": "YouTube", "audiencia": "17K", "senal": "technology/programming channel" }
-    ],
-    "numeros_foot": "Sources: Instagram Insights · X Analytics · Modash · public profiles. June 2026. Screenshots available on request.",
-    "demo_eyebrow": "// who's listening",
-    "demo_title": "An adult, professional and {em} audience.",
-    "demo_title_em": "consumer",
-    "demo_cards": [
+
+    "pilares_eyebrow": "// how your brand fits",
+    "pilares_title": "Ways to collaborate {em}.",
+    "pilares_title_em": "that get noticed",
+    "pilares_intro": "Four ways to put your brand on this platform. Written so you can show them to your team as they are.",
+    "pilares_cards": [
       {
-        "title": "Instagram",
-        "lines": [
-          "Age: 25-44 = 73.5% (25-34: 44.7% · 35-44: 28.8%)",
-          "Gender: 65.9% men · 34.1% women",
-          "Geography: Spain and Latin America."
-        ]
+        "title": "Content co-creation",
+        "what": "We create native pieces together —reels, carousels, stories— that weave your product into a story people are already following.",
+        "gain": "Not an inserted ad: content the audience actually wants to see."
       },
       {
-        "title": "X / Twitter",
-        "lines": [
-          "Geography: Spain 54% · Mexico 11% · Argentina 8%",
-          "Gender: 80.5% men (tech/professional profile)",
-          "Age: 25-44 (66%)"
-        ]
+        "title": "Product placement",
+        "what": "Your product, genuinely used and on camera, in my day to day (tech, travel/mobility, wellbeing).",
+        "gain": "Natural, credible presence, with no advertising script."
       },
       {
-        "title": "LinkedIn",
-        "lines": [
-          "Profile: professional and B2B — devs, engineering and decision-makers",
-          "Recognition: Top Voices 2022"
-        ]
+        "title": "Co-funded research",
+        "what": "«Research together with your brand»: you fund a concrete piece of the case —a test, a panel, a trip to Zurich— and we tell it with full transparency.",
+        "gain": "Your brand associated with real science and measurable impact."
+      },
+      {
+        "title": "Mentions and branding",
+        "what": "Your logo on my profile and on the website (with real traffic) and a «thanks to your brand» at the end of every post, podcast shout-out style.",
+        "gain": "Sustained brand recall, not a one-off impression."
       }
     ],
-    "demo_eco": "It's not an audience, it's an {b1}: 5 platforms (~248K) that reinforce one another — Instagram (mass, global Hispanic), LinkedIn (B2B/decision-makers, Top Voices), X (tech), TikTok (discovery) and YouTube (the case's long-form documentary). One collaboration, several audiences and formats.",
-    "demo_eco_b1": "ecosystem",
-    "prueba_eyebrow": "// proof that my people act",
-    "prueba_title": "Not passive likes. {em}",
-    "prueba_title_em": "They move money and mobilize.",
-    "prueba_stats": [
-      { "value": "38.897 €", "caption": "raised (100K goal) · proof of conversion" },
-      { "value": "~1,000", "caption": "donors = own/warm audience" },
-      { "value": "3,845", "caption": "clicks/month to the bio link" }
+    "pilares_dossier_line": "Want it in writing to show your team?",
+    "pilares_dossier_cta": "Download the dossier (PDF)",
+    "pilares_cta": "Contact me",
+
+    "audiencia_eyebrow": "// my kind of audience",
+    "audiencia_title": "Who {em} reaches.",
+    "audiencia_title_em": "your brand",
+    "audiencia_stats": [
+      { "value": "~248K", "caption": "multi-platform community" },
+      { "value": "+1M", "caption": "views / month (IG)" },
+      { "value": "72.5%", "caption": "verified real audience (Modash)" }
     ],
-    "prueba_carlos_title": "🎙️ Real case — «Carlos Roca / Episode 100» campaign",
-    "prueba_carlos_p": "She mobilized her community toward a concrete goal: the campaign reels added up to {b1} in a few days. Proof of {b2} — exactly what a brand wants to activate.",
-    "prueba_carlos_p_b1": "≈335,000 views",
-    "prueba_carlos_p_b2": "mobilization on demand",
-    "prueba_virals_title": "Viral content (last 3 months)",
-    "prueba_th_post": "Post",
-    "prueba_th_plays": "Views",
-    "prueba_origen_tag": "ORIGIN POST",
-    "prueba_virals": [
-      { "post": "X · «…Twitter, work your magic»", "plays": "1,000,000" },
-      { "post": "IG · Coliseo «Looking for help with an ultra-rare case»", "plays": "753,487" },
-      { "post": "IG · «SPREAD KINDNESS / age 35»", "plays": "430,022" },
-      { "post": "IG · «about technology and programming / it's NOW»", "plays": "249,321" },
-      { "post": "IG · collab «the tech community gifts me a Mac»", "plays": "189,110" },
-      { "post": "IG · carousel «Gallium-68 PET · my cancer has two engines»", "plays": "56,474" }
-    ],
-    "prueba_linkedin_title": "🏆 LinkedIn — viral post (Top Voices 2022)",
-    "prueba_linkedin_quote": "«…metastatic breast cancer, the rarest 1%. They gave me 5 years, I'm already at 2. I don't sit still: I research my own tumor with AI and seek treatment with a team…»",
-    "prueba_linkedin_stats": "176,484 impressions · 2,291 reactions · 194 shares",
-    "ganas_eyebrow": "// what you gain",
-    "ganas_title": "Your brand {em}, not a logo on a banner.",
-    "ganas_title_em": "inside the story",
-    "ganas_cards": [
-      { "title": "Content co-creation", "desc": "reel / carousel / stories designed together, not ads slapped on." },
-      { "title": "Your brand in my open research", "desc": "presence in the case a whole community follows." },
-      { "title": "Product tested with no filters", "desc": "an honest review before an audience that trusts." },
-      { "title": "Challenges to my community and events", "desc": "I launch a challenge with your brand and my people mobilize; or I take you to your event (reel + stories)." }
-    ],
-    "ganas_fit": "{b1} where your product meets my real life — {b2} · {b3} (international hospitals, flights, fintech/currency exchange, car/charging) · {b4}. That's where the collaboration is authentic.",
-    "ganas_fit_b1": "Natural fits:",
-    "ganas_fit_b2": "tech and health",
-    "ganas_fit_b3": "travel and mobility",
-    "ganas_fit_b4": "self-care, fashion and healthy food",
-    "ganas_model": "The community donates, and I'm infinitely grateful 💜. To brands I propose something different: {b1}. {b2} collaboration by donation — your contribution funds the precision research and we co-create something memorable. {em} your sponsorship helps close the 100.000 € goal and funds the next molecular analysis.",
-    "ganas_model_b1": "co-create",
-    "ganas_model_b2": "Model:",
-    "ganas_model_em": "Hook:",
-    "partners_eyebrow": "// brands that already dared",
-    "partners_title": "You're not starting from scratch. {em}",
-    "partners_title_em": "There are already brands inside.",
+    "audiencia_frame": "Tech + health profile, Spain and Latin America, professional and engaged. If you want the fine breakdown —ages, geography, channel by channel—, it's in the dossier.",
+    "audiencia_carlos": "And it moves things: a single collaboration (episode with {b1}) mobilized {b2}.",
+    "audiencia_carlos_b1": "Carlos Roca",
+    "audiencia_carlos_b2": "≈335,000 views",
+    "audiencia_partners_label": "Already dared",
     "partners": [
       { "label": "Tahe", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
       { "label": "Notion", "url": "https://www.notion.com" },
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
-    "partners_quotes": [
-      { "quote": "«Hi, Míriam! Check your DMs for a surprise. 🤍»", "author": "Notion ({'@'}NotionHQ), in public · 21.6K views" },
-      { "quote": "«It was a joy to spend this day with you and help you look even more like a goddess 💜🔥🔥»", "author": "Tahe ({'@'}taheoficial), verified partner brand · public comment" }
-    ],
-    "partners_press": "{b1} El País · La Opinión de Murcia · La 7.",
-    "partners_press_b1": "In the press:",
-    "cta_eyebrow": "// let's talk",
-    "cta_title": "Does your brand {em}?",
-    "cta_title_em": "dare",
-    "cta_p": "Real co-creation. The best deal you'll be offered this year.",
-    "cta_button": "Let's talk",
-    "cta_secondary": "{'@'}miriamgonp",
-    "cta_tagline": "Limited edition. No restock. Like me. 💜"
+    "audiencia_cta": "A good fit? Write to me",
+
+    "cta_eyebrow": "// get in touch",
+    "cta_title": "I'm looking for few brands, {em}. Are you one?",
+    "cta_title_em": "but real ones",
+    "cta_p": "Tell me what you do and we'll build something made for you. I answer personally.",
+    "cta_button": "Write to me",
+    "cta_dossier": "Download dossier (PDF)",
+    "cta_microcopy": "A charitable project, yes —but this is a professional collaboration and it's negotiated as such.",
+
+    "popup_title": "Your brand and me, together?",
+    "popup_text": "I read every message personally. Tell me who you are and we'll see how we fit.",
+    "popup_cta": "Contact me",
+    "popup_dismiss": "Not now"
   },
   "expenses": {
     "title": "Where the money goes",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -891,6 +891,23 @@
     "pilares_dossier_cta": "Download the dossier (PDF)",
     "pilares_cta": "Contact me",
 
+    "encajes_title": "Natural fits",
+    "encajes_intro": "Where your product meets my real life — that's where the collaboration feels authentic. And if there's already a brand from your sector, there's still room: that's what mentions are for.",
+    "encajes_groups": [
+      {
+        "label": "Tech and health",
+        "tags": ["software and tools", "AI and data", "digital health", "wearables", "cybersecurity"]
+      },
+      {
+        "label": "Travel and mobility",
+        "tags": ["international hospitals", "flights", "fintech / currency exchange", "car / charging"]
+      },
+      {
+        "label": "Self-care, fashion and healthy food",
+        "tags": ["cosmetics and care", "comfortable fashion", "nutrition and healthy food", "wellbeing and rest"]
+      }
+    ],
+
     "audiencia_eyebrow": "// my kind of audience",
     "audiencia_title": "Who {em} reaches.",
     "audiencia_title_em": "your brand",
@@ -900,16 +917,20 @@
       { "value": "72.5%", "caption": "verified real audience (Modash)" }
     ],
     "audiencia_frame": "Tech + health profile, Spain and Latin America, professional and engaged. If you want the fine breakdown —ages, geography, channel by channel—, it's in the dossier.",
-    "audiencia_carlos": "And it moves things: a single collaboration (episode with {b1}) mobilized {b2}.",
-    "audiencia_carlos_b1": "Carlos Roca",
-    "audiencia_carlos_b2": "≈335,000 views",
+
+    "movilizan_title": "They mobilize on cue",
+    "movilizan_p": "This isn't an audience that just watches: when I ask for something concrete, it pushes. In a recent campaign, the ask turned into {b}.",
+    "movilizan_proof": "≈335,000 actions mobilized",
+    "movilizan_caption": "A community that goes from scrolling to acting when it matters.",
+
     "audiencia_partners_label": "Already dared",
     "partners": [
-      { "label": "Tahe", "url": "https://tahecosmetics.com" },
+      { "label": "Tahe Cosmetics", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
       { "label": "Notion", "url": "https://www.notion.com" },
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
+    "partners_more": "…and more to come 🤫",
     "audiencia_cta": "A good fit? Write to me",
 
     "cta_eyebrow": "// get in touch",
@@ -918,6 +939,7 @@
     "cta_p": "Tell me what you do and we'll build something made for you. I answer personally.",
     "cta_button": "Write to me",
     "cta_dossier": "Download dossier (PDF)",
+    "cta_podcast": "And what's coming: I'm relaunching my podcast «No me da la vida» to tell the AI and technology behind this project. A good moment to come aboard. 🎙️",
     "cta_microcopy": "A charitable project, yes —but this is a professional collaboration and it's negotiated as such.",
 
     "popup_title": "Your brand and me, together?",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -845,8 +845,8 @@
   },
   "marcas": {
     "meta_title": "Colabora con una historia que va a tener todas las miradas — helpmiriam.com",
-    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te ofrezco ese escaparate para tu marca —con rigor y sin postureo— y una colaboración real, no un anuncio de un día.",
-    "og_description": "Un escaparate único, con dignidad: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro. Colaboración a largo plazo, no un logo en un banner.",
+    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te ofrezco ese escaparate para tu marca —con rigor y sin postureo—. Proyecto benéfico, sí, pero esto es una colaboración profesional y la negociamos como tal.",
+    "og_description": "Un escaparate único, con dignidad: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro. Una colaboración profesional a largo plazo, no un logo en un banner.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Descargar el dossier para marcas en PDF",
 
@@ -854,8 +854,8 @@
     "hero_eyebrow": "// para marcas",
     "hero_title": "En los próximos meses, {em} van a estar aquí.",
     "hero_title_em": "todas las miradas",
-    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te ofrezco ese escaparate para tu marca —con rigor y sin postureo— y una colaboración real, no un anuncio de un día.",
-    "hero_context": "Murcia · ingeniera de software · caso descrito apenas un puñado de veces en la literatura · divulgo el proceso con transparencia total.",
+    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro —Murcia, ingeniera de software, un caso descrito apenas un puñado de veces en la literatura del que se va a hablar—. Te ofrezco ese escaparate para tu marca, con rigor y sin postureo, y te propongo una colaboración real, no un anuncio de un día. Lo hacemos juntas.",
+    "hero_context": "Que quede claro de entrada: es un proyecto benéfico, sí, pero esto es una colaboración profesional y la negociamos como tal. No te pido un donativo; te propongo un partnership. Divulgo todo el proceso con transparencia total.",
     "hero_cta": "Hablemos de colaborar",
     "hero_cta_dossier": "Ver el dossier (PDF)",
     "hero_tagline": "// busco pocas marcas, pero de verdad",
@@ -864,7 +864,7 @@
     "pilares_eyebrow": "// cómo encaja tu marca",
     "pilares_title": "Formas de colaborar {em}.",
     "pilares_title_em": "que se notan",
-    "pilares_intro": "Cuatro maneras de subir tu marca a esta plataforma. Pensadas para que las puedas enseñar a tu equipo tal cual.",
+    "pilares_intro": "Cuatro maneras de subir tu marca a esta plataforma conmigo. Las he pensado para que las enseñes a tu equipo tal cual y elijáis la que mejor os encaje.",
     "pilares_cards": [
       {
         "title": "Cocreación de contenido",
@@ -916,7 +916,7 @@
       { "value": "+1M", "caption": "visualizaciones / mes (IG)" },
       { "value": "72,5%", "caption": "audiencia real verificada (Modash)" }
     ],
-    "audiencia_frame": "Perfil tech + salud, España y Latinoamérica, profesional y comprometido. Si quieres el desglose fino —edades, geografía, canal a canal—, está en el dossier.",
+    "audiencia_frame": "La gente a la que va a llegar tu marca: perfil tech + salud, España y Latinoamérica, profesional y comprometido. Si quieres el desglose fino —edades, geografía, canal a canal—, te lo paso en el dossier.",
 
     "movilizan_title": "Se movilizan a la orden",
     "movilizan_p": "No es una audiencia que solo mira: cuando le pido algo concreto, empuja. En una campaña reciente, pedirlo se tradujo en {b}.",
@@ -936,11 +936,11 @@
     "cta_eyebrow": "// ponte en contacto",
     "cta_title": "Busco pocas marcas, {em}. ¿Eres una?",
     "cta_title_em": "pero de verdad",
-    "cta_p": "Cuéntame qué hacéis y montamos algo a vuestra medida. Respondo yo.",
+    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a tu medida. Te respondo yo, en persona.",
     "cta_button": "Escríbeme",
     "cta_dossier": "Descargar dossier (PDF)",
     "cta_podcast": "Y lo que viene: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. Buen momento para subirte. 🎙️",
-    "cta_microcopy": "Proyecto benéfico, sí —pero esto es una colaboración profesional y se negocia como tal.",
+    "cta_microcopy": "Te lo repito porque importa: proyecto benéfico, sí, pero esto es una colaboración profesional entre tú y yo, y la negociamos como tal.",
 
     "popup_title": "¿Tu marca y yo, juntas?",
     "popup_text": "Te leo personalmente. Cuéntame quién eres y vemos cómo encajar.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -844,158 +844,86 @@
     "links_signature": "— Equipo Miriam González · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Marcas que se atreven a co-crear — helpmiriam.com",
-    "meta_description": "Co-creación real para marcas: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro, ante una comunidad de ~248K que actúa.",
-    "og_description": "Co-creación real: tu marca dentro del relato, no un logo en un banner. Una comunidad de ~248K que mueve dinero y se moviliza.",
-    "print": "↓ PDF Edición Limitada",
-    "print_aria": "Descargar este dossier (deck) en PDF",
-    "hero_eyebrow": "// dossier para marcas",
-    "hero_title": "No te ofrezco seguidores.{br}Te ofrezco una {em}.",
-    "hero_title_em": "comunidad que actúa",
-    "hero_subtitle": "Co-creación real: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro, en abierto.",
-    "hero_tagline": "// marcas que se atreven a co-crear",
+    "meta_title": "Colabora con una historia que va a tener todas las miradas — helpmiriam.com",
+    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te ofrezco ese escaparate para tu marca —con rigor y sin postureo— y una colaboración real, no un anuncio de un día.",
+    "og_description": "Un escaparate único, con dignidad: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro. Colaboración a largo plazo, no un logo en un banner.",
+    "print": "↓ Dossier (PDF)",
+    "print_aria": "Descargar el dossier para marcas en PDF",
+
+    "_comment_hero": "Header — opción A (recomendada por el plan). Alternativas B y C como comentarios en marcas.vue.",
+    "hero_eyebrow": "// para marcas",
+    "hero_title": "En los próximos meses, {em} van a estar aquí.",
+    "hero_title_em": "todas las miradas",
+    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te ofrezco ese escaparate para tu marca —con rigor y sin postureo— y una colaboración real, no un anuncio de un día.",
+    "hero_context": "Murcia · ingeniera de software · caso descrito apenas un puñado de veces en la literatura · divulgo el proceso con transparencia total.",
+    "hero_cta": "Hablemos de colaborar",
+    "hero_cta_dossier": "Ver el dossier (PDF)",
+    "hero_tagline": "// busco pocas marcas, pero de verdad",
     "hero_edition_label": "Edición preparada para:",
-    "hero_avatar_alt": "",
-    "historia_eyebrow": "// la historia en 20 segundos",
-    "modelo_eyebrow": "// el modelo",
-    "historia_title": "Una historia {em}.",
-    "historia_title_em": "imposible de ignorar",
-    "historia_p1": "Miriam González ({'@'}miriamgonp), {age} años, ingeniera de software y divulgadora tech. Tiene un cáncer de mama metastásico {b1} (BC-NED, <1% de los casos) y usa {b2} para investigar su propio tumor, documentándolo en abierto.",
-    "historia_p1_b1": "ultra-raro",
-    "historia_p1_b2": "IA + oncología de precisión",
-    "historia_p2": "Respaldo científico real: {b1} analiza sus muestras · {b2} ayuda con la biopsia · la jefa del {b3} se ha interesado por su caso.",
-    "historia_p2_b1": "Dana-Farber (Harvard)",
-    "historia_p2_b2": "Zúrich",
-    "historia_p2_b3": "comité de oncología de precisión más importante del mundo (WIN)",
-    "historia_badges": [
-      "Dana-Farber · Harvard",
-      "Hospital de Zúrich",
-      "Comité WIN"
-    ],
-    "historia_foot": "Detalle clínico completo en {link}. Datos a junio 2026.",
-    "historia_foot_link": "helpmiriam.com/ciencia",
-    "numeros_eyebrow": "// los números (verificables)",
-    "numeros_title": "Una audiencia que se mueve {em}.",
-    "numeros_title_em": "y convierte",
-    "numeros_stats": [
-      { "value": "~248K", "caption": "audiencia total multicanal" },
-      { "value": "8,8%", "caption": "engagement por alcance (IG)" },
-      { "value": "453K", "caption": "cuentas alcanzadas / mes · 3,6× seguidores" },
-      { "value": "+1M", "caption": "visualizaciones / mes (IG)" },
-      { "value": "63%", "caption": "de la interacción = audiencia NUEVA" },
-      { "value": "72,5%", "caption": "audiencia real (Modash · mejor que la media)" }
-    ],
-    "numeros_growth": "📈 {b1} · {b2} (constancia editorial). No es una cuenta estancada: sube.",
-    "numeros_growth_b1": "+4.734 seguidores nuevos en el último mes",
-    "numeros_growth_b2": "34 publicaciones/mes",
-    "numeros_th_canal": "Canal",
-    "numeros_th_audiencia": "Audiencia",
-    "numeros_th_senal": "Señal",
-    "numeros_channels": [
-      { "canal": "Instagram", "audiencia": "126,5K", "senal": "453K alcance/mes · 8,8% eng." },
-      { "canal": "X / Twitter (verificada)", "audiencia": "41,2K", "senal": "~140K impresiones/semana" },
-      { "canal": "LinkedIn", "audiencia": "40,6K", "senal": "🏆 LinkedIn Top Voices 2022" },
-      { "canal": "TikTok", "audiencia": "23,2K", "senal": "228,5K likes" },
-      { "canal": "YouTube", "audiencia": "17K", "senal": "canal de tecnología/programación" }
-    ],
-    "numeros_foot": "Fuentes: Instagram Insights · X Analytics · Modash · perfiles públicos. Junio 2026. Capturas disponibles bajo petición.",
-    "demo_eyebrow": "// quién te escucha",
-    "demo_title": "Audiencia adulta, profesional y {em}.",
-    "demo_title_em": "de consumo",
-    "demo_cards": [
+
+    "pilares_eyebrow": "// cómo encaja tu marca",
+    "pilares_title": "Formas de colaborar {em}.",
+    "pilares_title_em": "que se notan",
+    "pilares_intro": "Cuatro maneras de subir tu marca a esta plataforma. Pensadas para que las puedas enseñar a tu equipo tal cual.",
+    "pilares_cards": [
       {
-        "title": "Instagram",
-        "lines": [
-          "Edad: 25-44 = 73,5% (25-34: 44,7% · 35-44: 28,8%)",
-          "Género: 65,9% hombres · 34,1% mujeres",
-          "Geografía: España y Latinoamérica."
-        ]
+        "title": "Cocreación de contenido",
+        "what": "Creamos juntas piezas nativas —reels, carruseles, stories— que integran tu producto en una historia que la gente ya está siguiendo.",
+        "gain": "No es un anuncio insertado: es contenido que la audiencia quiere ver."
       },
       {
-        "title": "X / Twitter",
-        "lines": [
-          "Geografía: España 54% · México 11% · Argentina 8%",
-          "Género: 80,5% hombres (perfil tech/profesional)",
-          "Edad: 25-44 (66%)"
-        ]
+        "title": "Product placement",
+        "what": "Tu producto, usado de verdad y en cámara, en mi día a día (tech, viajes/movilidad, bienestar).",
+        "gain": "Presencia natural y creíble, sin guion publicitario."
       },
       {
-        "title": "LinkedIn",
-        "lines": [
-          "Perfil: profesional y B2B — devs, ingeniería y decisores",
-          "Reconocimiento: Top Voices 2022"
-        ]
+        "title": "Research cofinanciada",
+        "what": "«Investigación junto a tu marca»: financias una pieza concreta del caso —una prueba, un panel, un viaje a Zúrich— y lo contamos con transparencia total.",
+        "gain": "Tu marca asociada a ciencia real y a impacto medible."
+      },
+      {
+        "title": "Menciones y branding",
+        "what": "Tu logo en mi perfil y en la web (con tráfico real) y un «gracias a tu marca» al cierre de cada post, estilo shout-out de podcast.",
+        "gain": "Recuerdo de marca sostenido, no un impacto único."
       }
     ],
-    "demo_eco": "No es un público, es un {b1}: 5 plataformas (~248K) que se refuerzan — Instagram (masivo, hispano global), LinkedIn (B2B/decisores, Top Voices), X (tech), TikTok (descubrimiento) y YouTube (el documental largo del caso). Una colaboración, varios públicos y formatos.",
-    "demo_eco_b1": "ecosistema",
-    "prueba_eyebrow": "// la prueba de que mi gente actúa",
-    "prueba_title": "No son likes pasivos. {em}",
-    "prueba_title_em": "Mueven dinero y se movilizan.",
-    "prueba_stats": [
-      { "value": "38.897 €", "caption": "recaudados (meta 100K) · prueba de conversión" },
-      { "value": "~1.000", "caption": "donantes = audiencia propia/cálida" },
-      { "value": "3.845", "caption": "clics/mes al enlace de la bio" }
+    "pilares_dossier_line": "¿Lo quieres por escrito para enseñárselo a tu equipo?",
+    "pilares_dossier_cta": "Descarga el dossier (PDF)",
+    "pilares_cta": "Contáctame",
+
+    "audiencia_eyebrow": "// mi tipo de audiencia",
+    "audiencia_title": "A quién llega {em}.",
+    "audiencia_title_em": "tu marca",
+    "audiencia_stats": [
+      { "value": "~248K", "caption": "comunidad multiplataforma" },
+      { "value": "+1M", "caption": "visualizaciones / mes (IG)" },
+      { "value": "72,5%", "caption": "audiencia real verificada (Modash)" }
     ],
-    "prueba_carlos_title": "🎙️ Caso real — Campaña «Carlos Roca / Episodio 100»",
-    "prueba_carlos_p": "Movilizó a su comunidad hacia un objetivo concreto: los reels de campaña sumaron {b1} en pocos días. Prueba de {b2} — exactamente lo que una marca quiere activar.",
-    "prueba_carlos_p_b1": "≈335.000 reproducciones",
-    "prueba_carlos_p_b2": "movilización a la orden",
-    "prueba_virals_title": "Contenido viral (últimos 3 meses)",
-    "prueba_th_post": "Post",
-    "prueba_th_plays": "Reproducciones",
-    "prueba_origen_tag": "POST ORIGEN",
-    "prueba_virals": [
-      { "post": "X · «…Twitter haz tu magia»", "plays": "1.000.000" },
-      { "post": "IG · Coliseo «Busco ayuda para un caso ultra raro»", "plays": "753.487" },
-      { "post": "IG · «SPREAD KINDNESS / 35 años»", "plays": "430.022" },
-      { "post": "IG · «de tecnología y programación / es AHORA»", "plays": "249.321" },
-      { "post": "IG · colab «la comunidad tech me regala un Mac»", "plays": "189.110" },
-      { "post": "IG · carrusel «PET Galio-68 · mi cáncer tiene dos motores»", "plays": "56.474" }
-    ],
-    "prueba_linkedin_title": "🏆 LinkedIn — post viral (Top Voices 2022)",
-    "prueba_linkedin_quote": "«…cáncer de mama metastásico del 1% más raro. Me dieron 5 años, ya llevo 2. No me quedo quieta: investigo mi propio tumor con IA y busco tratamiento con un equipo…»",
-    "prueba_linkedin_stats": "176.484 impresiones · 2.291 reacciones · 194 compartidos",
-    "ganas_eyebrow": "// qué ganas tú",
-    "ganas_title": "Tu marca {em}, no un logo en un banner.",
-    "ganas_title_em": "dentro del relato",
-    "ganas_cards": [
-      { "title": "Co-creación de contenido", "desc": "reel / carrusel / stories pensados juntas, no publi pegada." },
-      { "title": "Tu marca en mi research abierto", "desc": "presencia en el caso que sigue toda una comunidad." },
-      { "title": "Producto probado sin filtros", "desc": "review honesta ante una audiencia que confía." },
-      { "title": "Retos a mi comunidad y eventos", "desc": "lanzo un reto con tu marca y mi gente se moviliza; o te llevo a tu evento (reel + stories)." }
-    ],
-    "ganas_fit": "{b1} donde tu producto se cruza con mi vida real — {b2} · {b3} (hospitales internacionales, vuelos, fintech/cambio de divisa, coche/recarga) · {b4}. Ahí la colaboración es auténtica.",
-    "ganas_fit_b1": "Encajes naturales:",
-    "ganas_fit_b2": "tech y salud",
-    "ganas_fit_b3": "viajes y movilidad",
-    "ganas_fit_b4": "autocuidado, moda y comida sana",
-    "ganas_model": "La comunidad dona, y lo agradezco infinito 💜. A las marcas les propongo algo distinto: {b1}. {b2} colaboración por donación — tu aporte financia la investigación de precisión y co-creamos algo memorable. {em} tu patrocinio ayuda a cerrar la meta de 100.000 € y financia el próximo análisis molecular.",
-    "ganas_model_b1": "co-crear",
-    "ganas_model_b2": "Modelo:",
-    "ganas_model_em": "Gancho:",
-    "partners_eyebrow": "// marcas que ya se atrevieron",
-    "partners_title": "No empiezas de cero. {em}",
-    "partners_title_em": "Ya hay marcas dentro.",
+    "audiencia_frame": "Perfil tech + salud, España y Latinoamérica, profesional y comprometido. Si quieres el desglose fino —edades, geografía, canal a canal—, está en el dossier.",
+    "audiencia_carlos": "Y mueve cosas: una sola colaboración (episodio con {b1}) movilizó {b2}.",
+    "audiencia_carlos_b1": "Carlos Roca",
+    "audiencia_carlos_b2": "≈335.000 visualizaciones",
+    "audiencia_partners_label": "Ya se atrevieron",
     "partners": [
       { "label": "Tahe", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
       { "label": "Notion", "url": "https://www.notion.com" },
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
-    "partners_quotes": [
-      { "quote": "«¡Hola, Míriam! Revisa tus mensajes directos para ver una sorpresa. 🤍»", "author": "Notion ({'@'}NotionHQ), en público · 21,6K visualizaciones" },
-      { "quote": "«Fue un gustazo compartir contigo este día y ayudarte a lucir aún más diosa 💜🔥🔥»", "author": "Tahe ({'@'}taheoficial), marca partner verificada · comentario público" }
-    ],
-    "partners_press": "{b1} El País · La Opinión de Murcia · La 7.",
-    "partners_press_b1": "En prensa:",
-    "cta_eyebrow": "// hablemos",
-    "cta_title": "¿Tu marca {em}?",
-    "cta_title_em": "se atreve",
-    "cta_p": "Co-creación real. El mejor trato que te van a ofrecer este año.",
-    "cta_button": "Hablemos",
-    "cta_secondary": "{'@'}miriamgonp",
-    "cta_tagline": "Edición limitada. Sin reposición. Como yo. 💜"
+    "audiencia_cta": "¿Encajamos? Escríbeme",
+
+    "cta_eyebrow": "// ponte en contacto",
+    "cta_title": "Busco pocas marcas, {em}. ¿Eres una?",
+    "cta_title_em": "pero de verdad",
+    "cta_p": "Cuéntame qué hacéis y montamos algo a vuestra medida. Respondo yo.",
+    "cta_button": "Escríbeme",
+    "cta_dossier": "Descargar dossier (PDF)",
+    "cta_microcopy": "Proyecto benéfico, sí —pero esto es una colaboración profesional y se negocia como tal.",
+
+    "popup_title": "¿Tu marca y yo, juntas?",
+    "popup_text": "Te leo personalmente. Cuéntame quién eres y vemos cómo encajar.",
+    "popup_cta": "Contáctame",
+    "popup_dismiss": "Ahora no"
   },
   "expenses": {
     "title": "Destino del dinero",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -847,7 +847,7 @@
     "meta_title": "Un escaparate a punto de despegar. Sube tu marca. — helpmiriam.com",
     "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un perfil que no se repite y una historia con mucha atención por delante. No te pido un donativo; te propongo un partnership para convertir esa atención en ojos para tu marca. Benéfico, sí, pero también profesional, y lo trabajamos como tal.",
     "og_description": "Un escaparate a punto de despegar. Te propongo subir tu marca a esta historia —no un logo de un día— con una divulgadora tech que investiga su propio cáncer ultra-raro. Partnership profesional a largo plazo, con transparencia total.",
-    "print": "↓ Dossier (PDF)",
+    "print": "Dossier (PDF)",
     "print_aria": "Descargar el dossier para marcas en PDF",
 
     "_comment_hero": "Header — pase de copy de Adri (18-jun, PREVALECE): H1 lidera con su imagen del «escaparate a punto de despegar» + llamada directa a la marca («Sube tu marca»). El encuadre partnership-no-donativo baja al hero_context. Registro DOSIER (sobrio, de igual a igual). Alternativas A y C, en el comentario de marcas.vue.",
@@ -915,7 +915,7 @@
       { "value": "+1M", "caption": "visualizaciones / mes (IG)" },
       { "value": "72,5%", "caption": "audiencia real verificada (Modash)" }
     ],
-    "audiencia_frame": "Perfil tech y salud, en España y Latinoamérica, profesional y comprometido. No te voy a llenar esto de gráficas: las marcas que escriben lo hacen por la parte mediática y por sumarse a algo real, no por el tamaño exacto de la audiencia. Si quieres el desglose fino —edades, geografía, canal a canal—, lo tienes en el dossier.",
+    "audiencia_frame": "No te voy a llenar esto de gráficas: las marcas que escriben lo hacen por la parte mediática y por sumarse a algo real, no por el tamaño exacto de la audiencia. Si quieres el desglose fino, lo tienes en el dossier.",
 
     "movilizan_title": "Y cuando hace falta, responden",
     "movilizan_p": "No es una audiencia que solo mira: cuando le pido algo concreto, responde. En una campaña reciente, ese «échame una mano» se tradujo en {b}.",
@@ -937,8 +937,7 @@
     "cta_title_em": "no un logo de un día",
     "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. No es un formulario que se pierde: detrás hay personas y te respondemos de verdad.",
     "cta_button": "Hablemos de tu marca",
-    "cta_podcast": "Y el momento ayuda: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. En los próximos meses esto va a tener mucha atención: un buen momento para subirte.",
-    "cta_microcopy": "Una última cosa, porque importa: es un proyecto benéfico, sí, pero también una colaboración profesional entre tú y yo, y la trabajamos como tal.",
+    "cta_podcast": "Y se vienen iniciativas potentes para contar todo lo que hay detrás — el detalle, en el dossier.",
 
     "popup_title": "¿Subes tu marca a este escaparate?",
     "popup_text": "No es un buzón que se ignora: detrás hay personas y te respondemos de verdad. Cuéntame quién eres y vemos cómo encajar.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -858,7 +858,7 @@
     "hero_context": "Y lo digo claro de entrada: no te pido un donativo; te propongo un partnership. Es un proyecto benéfico, sí, pero también una colaboración profesional, y la trabajamos como tal.",
     "hero_cta": "Cuéntame qué hacéis",
     "hero_cta_dossier": "Ver el dossier (para tu equipo)",
-    "hero_tagline": "// te respondo yo, en persona · busco pocas marcas, pero las adecuadas",
+    "hero_tagline": "// abierta a las marcas adecuadas · detrás hay personas, no un buzón",
     "hero_edition_label": "Edición preparada para:",
 
     "pilares_eyebrow": "// formas de colaborar",
@@ -933,15 +933,15 @@
     "audiencia_cta": "¿Encajamos?",
 
     "cta_eyebrow": "// ponte en contacto",
-    "cta_title": "Busco pocas marcas, {em}.",
-    "cta_title_em": "pero las adecuadas",
-    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. Te respondo yo, en persona —no un formulario ni un equipo.",
+    "cta_title": "Un partnership de verdad, {em}.",
+    "cta_title_em": "no un logo de un día",
+    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. No es un formulario que se pierde: detrás hay personas y te respondemos de verdad.",
     "cta_button": "Hablemos de tu marca",
     "cta_podcast": "Y el momento ayuda: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. En los próximos meses esto va a tener mucha atención: un buen momento para subirte.",
     "cta_microcopy": "Una última cosa, porque importa: es un proyecto benéfico, sí, pero también una colaboración profesional entre tú y yo, y la trabajamos como tal.",
 
     "popup_title": "¿Subes tu marca a este escaparate?",
-    "popup_text": "Te leo yo, en persona. Cuéntame quién eres y vemos cómo encajar.",
+    "popup_text": "No es un buzón que se ignora: detrás hay personas y te respondemos de verdad. Cuéntame quién eres y vemos cómo encajar.",
     "popup_cta": "Cuéntame qué hacéis",
     "popup_dismiss": "Ahora no"
   },

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -844,18 +844,18 @@
     "links_signature": "— Equipo Miriam González · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Una historia que la gente ya sigue. Tu marca, dentro. — helpmiriam.com",
-    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar, y mucho. No te pido un donativo; te propongo un partnership: subir tu marca a esta historia con rigor y sin postureo. Benéfico, sí, pero también profesional, y lo trabajamos como tal.",
-    "og_description": "Una historia que ya tiene miradas encima y va a tener muchas más. Te propongo meter tu marca dentro —no un logo de un día— con una divulgadora tech que investiga su propio cáncer ultra-raro. Partnership profesional a largo plazo, con transparencia total.",
+    "meta_title": "Un escaparate a punto de despegar. Sube tu marca. — helpmiriam.com",
+    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un perfil que no se repite y una historia con mucha atención por delante. No te pido un donativo; te propongo un partnership para convertir esa atención en ojos para tu marca. Benéfico, sí, pero también profesional, y lo trabajamos como tal.",
+    "og_description": "Un escaparate a punto de despegar. Te propongo subir tu marca a esta historia —no un logo de un día— con una divulgadora tech que investiga su propio cáncer ultra-raro. Partnership profesional a largo plazo, con transparencia total.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Descargar el dossier para marcas en PDF",
 
-    "_comment_hero": "Header — opción B (decidida con Adri, 18-jun): lidera con la atención/escaparate ya existente y la posición de la marca DENTRO de la historia. Encuadre debajo = partnership, no donativo. Alternativas A y C, en el comentario de marcas.vue.",
+    "_comment_hero": "Header — pase de copy de Adri (18-jun, PREVALECE): H1 lidera con su imagen del «escaparate a punto de despegar» + llamada directa a la marca («Sube tu marca»). El encuadre partnership-no-donativo baja al hero_context. Registro DOSIER (sobrio, de igual a igual). Alternativas A y C, en el comentario de marcas.vue.",
     "hero_eyebrow": "// para marcas",
-    "hero_title": "Una historia que la gente ya sigue. {em}.",
-    "hero_title_em": "Tu marca, dentro",
-    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro —un caso descrito apenas un puñado de veces en la literatura—, y en los próximos meses va a tener muchas miradas encima. Te propongo subir tu marca a esa historia: no un logo de un día, sino una colaboración que se nota y dura. La montamos juntas.",
-    "hero_context": "Lo digo claro de entrada: no te pido un donativo; te propongo un partnership. Es un proyecto benéfico, sí, pero también una colaboración profesional, y la trabajamos como tal —con transparencia total en cada paso.",
+    "hero_title": "Un escaparate a punto de despegar. {em}.",
+    "hero_title_em": "Sube tu marca",
+    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un perfil que no se repite. En los próximos meses esta historia va a tener muchas miradas encima, y te propongo subir tu marca a ella —no un logo de un día, sino una presencia que se nota y dura— para convertir esa atención en ojos para tu marca. Con transparencia total, de principio a fin.",
+    "hero_context": "Y lo digo claro de entrada: no te pido un donativo; te propongo un partnership. Es un proyecto benéfico, sí, pero también una colaboración profesional, y la trabajamos como tal.",
     "hero_cta": "Cuéntame qué hacéis",
     "hero_cta_dossier": "Ver el dossier (para tu equipo)",
     "hero_tagline": "// te respondo yo, en persona · busco pocas marcas, pero las adecuadas",
@@ -889,7 +889,6 @@
     ],
     "pilares_dossier_line": "¿Lo quieres por escrito para llevarlo a tu equipo?",
     "pilares_dossier_cta": "Descarga el dossier (PDF)",
-    "pilares_cta": "Cuéntame qué hacéis",
 
     "encajes_title": "Dónde encaja tu producto",
     "encajes_intro": "Donde tu producto se cruza con mi vida real, ahí la colaboración se nota auténtica. Y si ya hay una marca de tu sector, sigue habiendo sitio: para eso están las menciones.",
@@ -930,19 +929,18 @@
       { "label": "Notion", "url": "https://www.notion.com" },
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
-    "partners_more": "…y más por venir 🤫",
-    "audiencia_cta": "¿Encajamos? Cuéntame qué hacéis",
+    "partners_more": "…y más por venir",
+    "audiencia_cta": "¿Encajamos?",
 
     "cta_eyebrow": "// ponte en contacto",
     "cta_title": "Busco pocas marcas, {em}.",
     "cta_title_em": "pero las adecuadas",
     "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. Te respondo yo, en persona —no un formulario ni un equipo.",
     "cta_button": "Hablemos de tu marca",
-    "cta_dossier": "Ver el dossier (para tu equipo)",
-    "cta_podcast": "Y el momento ayuda: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. En los próximos meses esto va a tener mucha atención —buen momento para subirte. 🎙️",
+    "cta_podcast": "Y el momento ayuda: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. En los próximos meses esto va a tener mucha atención: un buen momento para subirte.",
     "cta_microcopy": "Una última cosa, porque importa: es un proyecto benéfico, sí, pero también una colaboración profesional entre tú y yo, y la trabajamos como tal.",
 
-    "popup_title": "¿Subimos tu marca a la historia?",
+    "popup_title": "¿Subes tu marca a este escaparate?",
     "popup_text": "Te leo yo, en persona. Cuéntame quién eres y vemos cómo encajar.",
     "popup_cta": "Cuéntame qué hacéis",
     "popup_dismiss": "Ahora no"

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -891,6 +891,23 @@
     "pilares_dossier_cta": "Descarga el dossier (PDF)",
     "pilares_cta": "Contáctame",
 
+    "encajes_title": "Encajes naturales",
+    "encajes_intro": "Donde tu producto se cruza con mi vida real — ahí la colaboración es auténtica. Y si ya hay una marca de tu sector, sigue habiendo sitio: ahí entran las menciones.",
+    "encajes_groups": [
+      {
+        "label": "Tech y salud",
+        "tags": ["software y herramientas", "IA y datos", "salud digital", "wearables", "ciberseguridad"]
+      },
+      {
+        "label": "Viajes y movilidad",
+        "tags": ["hospitales internacionales", "vuelos", "fintech / cambio de divisa", "coche / recarga"]
+      },
+      {
+        "label": "Autocuidado, moda y comida sana",
+        "tags": ["cosmética y cuidado", "moda cómoda", "nutrición y comida sana", "bienestar y descanso"]
+      }
+    ],
+
     "audiencia_eyebrow": "// mi tipo de audiencia",
     "audiencia_title": "A quién llega {em}.",
     "audiencia_title_em": "tu marca",
@@ -900,16 +917,20 @@
       { "value": "72,5%", "caption": "audiencia real verificada (Modash)" }
     ],
     "audiencia_frame": "Perfil tech + salud, España y Latinoamérica, profesional y comprometido. Si quieres el desglose fino —edades, geografía, canal a canal—, está en el dossier.",
-    "audiencia_carlos": "Y mueve cosas: una sola colaboración (episodio con {b1}) movilizó {b2}.",
-    "audiencia_carlos_b1": "Carlos Roca",
-    "audiencia_carlos_b2": "≈335.000 visualizaciones",
+
+    "movilizan_title": "Se movilizan a la orden",
+    "movilizan_p": "No es una audiencia que solo mira: cuando le pido algo concreto, empuja. En una campaña reciente, pedirlo se tradujo en {b}.",
+    "movilizan_proof": "≈335.000 acciones movilizadas",
+    "movilizan_caption": "Una comunidad que pasa del scroll a la acción cuando hace falta.",
+
     "audiencia_partners_label": "Ya se atrevieron",
     "partners": [
-      { "label": "Tahe", "url": "https://tahecosmetics.com" },
+      { "label": "Tahe Cosmetics", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
       { "label": "Notion", "url": "https://www.notion.com" },
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
+    "partners_more": "…y más por venir 🤫",
     "audiencia_cta": "¿Encajamos? Escríbeme",
 
     "cta_eyebrow": "// ponte en contacto",
@@ -918,6 +939,7 @@
     "cta_p": "Cuéntame qué hacéis y montamos algo a vuestra medida. Respondo yo.",
     "cta_button": "Escríbeme",
     "cta_dossier": "Descargar dossier (PDF)",
+    "cta_podcast": "Y lo que viene: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. Buen momento para subirte. 🎙️",
     "cta_microcopy": "Proyecto benéfico, sí —pero esto es una colaboración profesional y se negocia como tal.",
 
     "popup_title": "¿Tu marca y yo, juntas?",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -844,27 +844,27 @@
     "links_signature": "— Equipo Miriam González · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Colabora con una historia que va a tener todas las miradas — helpmiriam.com",
-    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te ofrezco ese escaparate para tu marca —con rigor y sin postureo—. Proyecto benéfico, sí, pero esto es una colaboración profesional y la negociamos como tal.",
-    "og_description": "Un escaparate único, con dignidad: tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro. Una colaboración profesional a largo plazo, no un logo en un banner.",
+    "meta_title": "Colabora con una historia que mucha gente va a seguir — helpmiriam.com",
+    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te propongo acompañar tu marca dentro de esta historia, con rigor y sin postureo. Es un proyecto benéfico, sí, pero también una colaboración profesional, y la trabajamos como tal.",
+    "og_description": "Tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro, contado con cuidado y transparencia. Una colaboración profesional a largo plazo, no un logo en un banner.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Descargar el dossier para marcas en PDF",
 
     "_comment_hero": "Header — opción A (recomendada por el plan). Alternativas B y C como comentarios en marcas.vue.",
     "hero_eyebrow": "// para marcas",
-    "hero_title": "En los próximos meses, {em} van a estar aquí.",
-    "hero_title_em": "todas las miradas",
-    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro —Murcia, ingeniera de software, un caso descrito apenas un puñado de veces en la literatura del que se va a hablar—. Te ofrezco ese escaparate para tu marca, con rigor y sin postureo, y te propongo una colaboración real, no un anuncio de un día. Lo hacemos juntas.",
-    "hero_context": "Que quede claro de entrada: es un proyecto benéfico, sí, pero esto es una colaboración profesional y la negociamos como tal. No te pido un donativo; te propongo un partnership. Divulgo todo el proceso con transparencia total.",
+    "hero_title": "En los próximos meses, mucha gente {em}.",
+    "hero_title_em": "va a seguir esta historia",
+    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro —Murcia, ingeniera de software, un caso descrito apenas un puñado de veces en la literatura—. Lo cuento con rigor y sin postureo, y te propongo acompañar tu marca dentro de esa historia: una colaboración de verdad, no un anuncio de un día. Lo hacemos juntas.",
+    "hero_context": "Lo digo claro de entrada: es un proyecto benéfico, sí, pero también es una colaboración profesional y la trabajamos como tal. No te pido un donativo; te propongo un partnership. Y todo el proceso lo cuento con transparencia total.",
     "hero_cta": "Hablemos de colaborar",
     "hero_cta_dossier": "Ver el dossier (PDF)",
-    "hero_tagline": "// busco pocas marcas, pero de verdad",
+    "hero_tagline": "// busco pocas marcas, pero las adecuadas",
     "hero_edition_label": "Edición preparada para:",
 
     "pilares_eyebrow": "// cómo encaja tu marca",
     "pilares_title": "Formas de colaborar {em}.",
-    "pilares_title_em": "que se notan",
-    "pilares_intro": "Cuatro maneras de subir tu marca a esta plataforma conmigo. Las he pensado para que las enseñes a tu equipo tal cual y elijáis la que mejor os encaje.",
+    "pilares_title_em": "con sentido",
+    "pilares_intro": "Cuatro maneras de sumar tu marca a este proyecto conmigo. Las he pensado para que se las enseñes a tu equipo tal cual y elijáis la que mejor os encaje.",
     "pilares_cards": [
       {
         "title": "Cocreación de contenido",
@@ -918,12 +918,12 @@
     ],
     "audiencia_frame": "La gente a la que va a llegar tu marca: perfil tech + salud, España y Latinoamérica, profesional y comprometido. Si quieres el desglose fino —edades, geografía, canal a canal—, te lo paso en el dossier.",
 
-    "movilizan_title": "Se movilizan a la orden",
-    "movilizan_p": "No es una audiencia que solo mira: cuando le pido algo concreto, empuja. En una campaña reciente, pedirlo se tradujo en {b}.",
+    "movilizan_title": "Y cuando hace falta, responden",
+    "movilizan_p": "No es una audiencia que solo mira: cuando le pido algo concreto, responde. En una campaña reciente, ese «échame una mano» se tradujo en {b}.",
     "movilizan_proof": "≈335.000 acciones movilizadas",
-    "movilizan_caption": "Una comunidad que pasa del scroll a la acción cuando hace falta.",
+    "movilizan_caption": "Una comunidad que pasa del scroll a la acción cuando de verdad importa.",
 
-    "audiencia_partners_label": "Ya se atrevieron",
+    "audiencia_partners_label": "Ya confiaron",
     "partners": [
       { "label": "Tahe Cosmetics", "url": "https://tahecosmetics.com" },
       { "label": "GitHub", "url": "https://github.com" },
@@ -934,13 +934,13 @@
     "audiencia_cta": "¿Encajamos? Escríbeme",
 
     "cta_eyebrow": "// ponte en contacto",
-    "cta_title": "Busco pocas marcas, {em}. ¿Eres una?",
-    "cta_title_em": "pero de verdad",
-    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a tu medida. Te respondo yo, en persona.",
+    "cta_title": "Busco pocas marcas, {em}.",
+    "cta_title_em": "pero las adecuadas",
+    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. Te respondo yo, en persona.",
     "cta_button": "Escríbeme",
     "cta_dossier": "Descargar dossier (PDF)",
     "cta_podcast": "Y lo que viene: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. Buen momento para subirte. 🎙️",
-    "cta_microcopy": "Te lo repito porque importa: proyecto benéfico, sí, pero esto es una colaboración profesional entre tú y yo, y la negociamos como tal.",
+    "cta_microcopy": "Una última cosa, porque importa: es un proyecto benéfico, sí, pero también una colaboración profesional entre tú y yo, y la trabajamos como tal.",
 
     "popup_title": "¿Tu marca y yo, juntas?",
     "popup_text": "Te leo personalmente. Cuéntame quién eres y vemos cómo encajar.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -844,55 +844,55 @@
     "links_signature": "— Equipo Miriam González · Beyond the Protocol"
   },
   "marcas": {
-    "meta_title": "Colabora con una historia que mucha gente va a seguir — helpmiriam.com",
-    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar. Te propongo acompañar tu marca dentro de esta historia, con rigor y sin postureo. Es un proyecto benéfico, sí, pero también una colaboración profesional, y la trabajamos como tal.",
-    "og_description": "Tu marca dentro del relato de una divulgadora tech que investiga su propio cáncer ultra-raro, contado con cuidado y transparencia. Una colaboración profesional a largo plazo, no un logo en un banner.",
+    "meta_title": "Una historia que la gente ya sigue. Tu marca, dentro. — helpmiriam.com",
+    "meta_description": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro: un caso del que se va a hablar, y mucho. No te pido un donativo; te propongo un partnership: subir tu marca a esta historia con rigor y sin postureo. Benéfico, sí, pero también profesional, y lo trabajamos como tal.",
+    "og_description": "Una historia que ya tiene miradas encima y va a tener muchas más. Te propongo meter tu marca dentro —no un logo de un día— con una divulgadora tech que investiga su propio cáncer ultra-raro. Partnership profesional a largo plazo, con transparencia total.",
     "print": "↓ Dossier (PDF)",
     "print_aria": "Descargar el dossier para marcas en PDF",
 
-    "_comment_hero": "Header — opción A (recomendada por el plan). Alternativas B y C como comentarios en marcas.vue.",
+    "_comment_hero": "Header — opción B (decidida con Adri, 18-jun): lidera con la atención/escaparate ya existente y la posición de la marca DENTRO de la historia. Encuadre debajo = partnership, no donativo. Alternativas A y C, en el comentario de marcas.vue.",
     "hero_eyebrow": "// para marcas",
-    "hero_title": "En los próximos meses, mucha gente {em}.",
-    "hero_title_em": "va a seguir esta historia",
-    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro —Murcia, ingeniera de software, un caso descrito apenas un puñado de veces en la literatura—. Lo cuento con rigor y sin postureo, y te propongo acompañar tu marca dentro de esa historia: una colaboración de verdad, no un anuncio de un día. Lo hacemos juntas.",
-    "hero_context": "Lo digo claro de entrada: es un proyecto benéfico, sí, pero también es una colaboración profesional y la trabajamos como tal. No te pido un donativo; te propongo un partnership. Y todo el proceso lo cuento con transparencia total.",
-    "hero_cta": "Hablemos de colaborar",
-    "hero_cta_dossier": "Ver el dossier (PDF)",
-    "hero_tagline": "// busco pocas marcas, pero las adecuadas",
+    "hero_title": "Una historia que la gente ya sigue. {em}.",
+    "hero_title_em": "Tu marca, dentro",
+    "hero_subtitle": "Soy ingeniera y divulgadora con un cáncer de mama ultra-raro —un caso descrito apenas un puñado de veces en la literatura—, y en los próximos meses va a tener muchas miradas encima. Te propongo subir tu marca a esa historia: no un logo de un día, sino una colaboración que se nota y dura. La montamos juntas.",
+    "hero_context": "Lo digo claro de entrada: no te pido un donativo; te propongo un partnership. Es un proyecto benéfico, sí, pero también una colaboración profesional, y la trabajamos como tal —con transparencia total en cada paso.",
+    "hero_cta": "Cuéntame qué hacéis",
+    "hero_cta_dossier": "Ver el dossier (para tu equipo)",
+    "hero_tagline": "// te respondo yo, en persona · busco pocas marcas, pero las adecuadas",
     "hero_edition_label": "Edición preparada para:",
 
-    "pilares_eyebrow": "// cómo encaja tu marca",
-    "pilares_title": "Formas de colaborar {em}.",
-    "pilares_title_em": "con sentido",
-    "pilares_intro": "Cuatro maneras de sumar tu marca a este proyecto conmigo. Las he pensado para que se las enseñes a tu equipo tal cual y elijáis la que mejor os encaje.",
+    "pilares_eyebrow": "// formas de colaborar",
+    "pilares_title": "Cuatro formas de meter tu marca {em}.",
+    "pilares_title_em": "en la historia",
+    "pilares_intro": "Lo más rápido de pillar, primero. Cuatro maneras concretas de sumar tu marca, pensadas para que se las enseñes a tu equipo tal cual —si te toca defenderlo ante tu jefe, esto es lo que le pones delante— y elijáis la que mejor os encaje. Se combinan.",
     "pilares_cards": [
       {
         "title": "Cocreación de contenido",
         "what": "Creamos juntas piezas nativas —reels, carruseles, stories— que integran tu producto en una historia que la gente ya está siguiendo.",
-        "gain": "No es un anuncio insertado: es contenido que la audiencia quiere ver."
+        "gain": "No es un anuncio que la gente se salta: es contenido que la audiencia quiere ver, con tu marca dentro."
       },
       {
         "title": "Product placement",
         "what": "Tu producto, usado de verdad y en cámara, en mi día a día (tech, viajes/movilidad, bienestar).",
-        "gain": "Presencia natural y creíble, sin guion publicitario."
+        "gain": "Presencia natural y creíble, sin guion publicitario —se ve de verdad, no se lee como anuncio."
       },
       {
         "title": "Research cofinanciada",
         "what": "«Investigación junto a tu marca»: financias una pieza concreta del caso —una prueba, un panel, un viaje a Zúrich— y lo contamos con transparencia total.",
-        "gain": "Tu marca asociada a ciencia real y a impacto medible."
+        "gain": "Tu marca asociada a ciencia real y a un impacto que se ve y se cuenta, no a un eslogan."
       },
       {
         "title": "Menciones y branding",
         "what": "Tu logo en mi perfil y en la web (con tráfico real) y un «gracias a tu marca» al cierre de cada post, estilo shout-out de podcast.",
-        "gain": "Recuerdo de marca sostenido, no un impacto único."
+        "gain": "Presencia constante en cada publicación, no un impacto único que se olvida al día siguiente."
       }
     ],
-    "pilares_dossier_line": "¿Lo quieres por escrito para enseñárselo a tu equipo?",
+    "pilares_dossier_line": "¿Lo quieres por escrito para llevarlo a tu equipo?",
     "pilares_dossier_cta": "Descarga el dossier (PDF)",
-    "pilares_cta": "Contáctame",
+    "pilares_cta": "Cuéntame qué hacéis",
 
-    "encajes_title": "Encajes naturales",
-    "encajes_intro": "Donde tu producto se cruza con mi vida real — ahí la colaboración es auténtica. Y si ya hay una marca de tu sector, sigue habiendo sitio: ahí entran las menciones.",
+    "encajes_title": "Dónde encaja tu producto",
+    "encajes_intro": "Donde tu producto se cruza con mi vida real, ahí la colaboración se nota auténtica. Y si ya hay una marca de tu sector, sigue habiendo sitio: para eso están las menciones.",
     "encajes_groups": [
       {
         "label": "Tech y salud",
@@ -908,15 +908,15 @@
       }
     ],
 
-    "audiencia_eyebrow": "// mi tipo de audiencia",
-    "audiencia_title": "A quién llega {em}.",
-    "audiencia_title_em": "tu marca",
+    "audiencia_eyebrow": "// las miradas que vas a tener encima",
+    "audiencia_title": "El alcance al que {em}.",
+    "audiencia_title_em": "te subes",
     "audiencia_stats": [
       { "value": "~248K", "caption": "comunidad multiplataforma" },
       { "value": "+1M", "caption": "visualizaciones / mes (IG)" },
       { "value": "72,5%", "caption": "audiencia real verificada (Modash)" }
     ],
-    "audiencia_frame": "La gente a la que va a llegar tu marca: perfil tech + salud, España y Latinoamérica, profesional y comprometido. Si quieres el desglose fino —edades, geografía, canal a canal—, te lo paso en el dossier.",
+    "audiencia_frame": "Perfil tech y salud, en España y Latinoamérica, profesional y comprometido. No te voy a llenar esto de gráficas: las marcas que escriben lo hacen por la parte mediática y por sumarse a algo real, no por el tamaño exacto de la audiencia. Si quieres el desglose fino —edades, geografía, canal a canal—, lo tienes en el dossier.",
 
     "movilizan_title": "Y cuando hace falta, responden",
     "movilizan_p": "No es una audiencia que solo mira: cuando le pido algo concreto, responde. En una campaña reciente, ese «échame una mano» se tradujo en {b}.",
@@ -931,20 +931,20 @@
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
     "partners_more": "…y más por venir 🤫",
-    "audiencia_cta": "¿Encajamos? Escríbeme",
+    "audiencia_cta": "¿Encajamos? Cuéntame qué hacéis",
 
     "cta_eyebrow": "// ponte en contacto",
     "cta_title": "Busco pocas marcas, {em}.",
     "cta_title_em": "pero las adecuadas",
-    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. Te respondo yo, en persona.",
-    "cta_button": "Escríbeme",
-    "cta_dossier": "Descargar dossier (PDF)",
-    "cta_podcast": "Y lo que viene: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. Buen momento para subirte. 🎙️",
+    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. Te respondo yo, en persona —no un formulario ni un equipo.",
+    "cta_button": "Hablemos de tu marca",
+    "cta_dossier": "Ver el dossier (para tu equipo)",
+    "cta_podcast": "Y el momento ayuda: relanzo mi podcast «No me da la vida» para contar la IA y la tecnología que hay detrás de este proyecto. En los próximos meses esto va a tener mucha atención —buen momento para subirte. 🎙️",
     "cta_microcopy": "Una última cosa, porque importa: es un proyecto benéfico, sí, pero también una colaboración profesional entre tú y yo, y la trabajamos como tal.",
 
-    "popup_title": "¿Tu marca y yo, juntas?",
-    "popup_text": "Te leo personalmente. Cuéntame quién eres y vemos cómo encajar.",
-    "popup_cta": "Contáctame",
+    "popup_title": "¿Subimos tu marca a la historia?",
+    "popup_text": "Te leo yo, en persona. Cuéntame quién eres y vemos cómo encajar.",
+    "popup_cta": "Cuéntame qué hacéis",
     "popup_dismiss": "Ahora no"
   },
   "expenses": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -930,12 +930,13 @@
       { "label": "Never Surrender", "url": "https://neversurrenderf.org/" }
     ],
     "partners_more": "…y más por venir",
+    "audiencia_cta_line": "¿Ves a tu marca aquí dentro? Escríbeme y lo vemos juntas.",
     "audiencia_cta": "¿Encajamos?",
 
     "cta_eyebrow": "// ponte en contacto",
     "cta_title": "Un partnership de verdad, {em}.",
     "cta_title_em": "no un logo de un día",
-    "cta_p": "Cuéntame qué hacéis y lo montamos juntas, a vuestra medida. No es un formulario que se pierde: detrás hay personas y te respondemos de verdad.",
+    "cta_p": "Cuéntame qué hacéis y, si tiene sentido para los dos, lo montamos juntas: una colaboración funciona cuando le suma a tu marca y a este proyecto a la vez. No es un formulario que se pierde: detrás hay personas y te respondemos de verdad.",
     "cta_button": "Hablemos de tu marca",
     "cta_podcast": "Y se vienen iniciativas potentes para contar todo lo que hay detrás — el detalle, en el dossier.",
 


### PR DESCRIPTION
Implementa la review de marketing de Adri Zip en **/marcas** (Nuxt, ES+EN).

## Cambios
- Reordenada a **4 bloques** (formas de colaborar arriba).
- **Header nuevo** (opción A; B/C comentadas en el código).
- **4 pilares**: cocreación · product placement · research cofinanciada · menciones/branding.
- **Pop-up de /marcas → "contáctame"** (no donación), scope solo /marcas.
- **CTAs "contáctame"** en cada bloque + dossier más visible.
- **Demografía aligerada** (al dossier).

Verificado: `oxlint` 0 errores, paridad i18n ES/EN. No se corrió build completo de Nuxt.

## ⚠️ Para revisar (NO mergear aún) — decisiones de Miriam
1. **Header**: elegida opción A. ¿OK o B/C?
2. **Refrescar cifras de audiencia** con datos reales.
3. Correr `pnpm build`/preview una vez para verificar render.

El **Deploy Preview de Netlify** aparecerá abajo. No publica nada hasta merge a `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)