### PR TITLE
feat(marcas): remate personal "Única. Como yo." en el cierre

### DIFF
--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -401,6 +401,12 @@
           </div>
           <!-- Teaser final (abre boca, sin desvelar): el detalle va al dossier. -->
           <p class="text-sm text-cream/85 leading-relaxed max-w-xl mx-auto">{{ t('marcas.cta_podcast') }}</p>
+          <!-- Remate personal y poético — cierra la página con la firma de Miriam.
+               Usa la .firma del DS (Fraunces italic, la rúbrica de la marca) en
+               miriam-claro para que contraste sobre la berenjena. NO es escasez:
+               es un guiño íntimo a que ella es única/irrepetible, en el mismo tono
+               win-win del resto. Hairline superior = el divisor editorial del sitio. -->
+          <p class="m-signoff firma heading-display text-lg text-miriam-claro">{{ t('marcas.cta_tagline') }}</p>
         </div>
       </div>
     </section>
@@ -500,6 +506,22 @@ export default { name: 'MarcasPage' }
     padding-top: 7rem;    /* 112px, = section-spacing sm */
     padding-bottom: calc(5.5rem + 2px); /* 88px + 2px de sangrado (ver .cta-band) */
   }
+}
+
+/* Remate personal del cierre — la firma íntima de Miriam ("Única. Como yo.").
+   Filete fino superior centrado (mismo divisor editorial que .dossier-row, pero
+   estrecho y centrado bajo el teaser) + margen que la separa del párrafo anterior
+   sin pegarse. Hereda .firma (Fraunces italic) del DS; el color miriam-claro se
+   fija con utilidad Tailwind en el template para contraste sobre berenjena
+   (gana al text-miriam de .firma por orden de capas). Puro remate, no CTA. */
+.m-signoff {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(232, 212, 237, 0.22);
+  width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+  letter-spacing: -0.01em;
 }
 
 /* Avatar del hero — mismo patrón que TeamPortrait y el retrato del hero de la

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -939,6 +939,7 @@
     "cta_p": "Tell me what you do and, if it makes sense for both of us, we'll build it together: a collaboration works when it adds up for your brand and for this project at once. This isn't a form that gets lost: there are people behind it and we reply for real.",
     "cta_button": "Let's talk about your brand",
     "cta_podcast": "And big initiatives are on the way to show everything behind this — the details are in the dossier.",
+    "cta_tagline": "One of a kind. Like me.",
 
     "popup_title": "Bring your brand onto this showcase?",
     "popup_text": "This isn't an inbox that gets ignored: there are people behind it and we reply for real. Tell me who you are and we'll see how we fit.",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -939,6 +939,7 @@
     "cta_p": "Cuéntame qué hacéis y, si tiene sentido para los dos, lo montamos juntas: una colaboración funciona cuando le suma a tu marca y a este proyecto a la vez. No es un formulario que se pierde: detrás hay personas y te respondemos de verdad.",
     "cta_button": "Hablemos de tu marca",
     "cta_podcast": "Y se vienen iniciativas potentes para contar todo lo que hay detrás — el detalle, en el dossier.",
+    "cta_tagline": "Única. Como yo.",
 
     "popup_title": "¿Subes tu marca a este escaparate?",
     "popup_text": "No es un buzón que se ignora: detrás hay personas y te respondemos de verdad. Cuéntame quién eres y vemos cómo encajar.",


### PR DESCRIPTION
## Qué

Re-añade a `/marcas` (· `/en/brands`) un remate personal y poético en el cierre: **«Única. Como yo.»** (ES) / **«One of a kind. Like me.»** (EN).

Es la recuperación de **solo la parte personal** de la antigua línea «Edición limitada. Sin reposición. Como yo.» — un guiño íntimo a que Miriam es única/irrepetible. **Sin escasez**: nada de «edición limitada / sin reposición» ni nada que suene a exclusividad. Tono win-win, coherente con la página (su regla: muchas marcas, sin escasez; Adri prevalece).

## Dónde + cómo queda

Va al final de la **banda de cierre** (sección 4 · «Ponte en contacto»), justo tras el teaser `cta_podcast`, separado por un filete fino centrado. Se renderiza con la `.firma` del design-system (**Fraunces italic**, la rúbrica de la marca) en `text-miriam-claro` (el violeta de identidad que ya usa el hero sobre la berenjena). Se lee como una firma/grace note, **no como un CTA**.

## Cambios

- `i18n/locales/es.json` · `i18n/locales/en.json` — nueva clave `marcas.cta_tagline` (ES/EN sincronizadas; sets de claves idénticos).
- `app/pages/marcas.vue` — render del remate + estilo scoped `.m-signoff` (hairline superior centrado, `fit-content`).

## Comité Web · 4 lentes

- **Accesibilidad** — contraste **5.46:1** (`#c77dd2` sobre berenjena `#2d1b3d`): pasa AA para texto normal (4.5:1). Decorativo en `<p>` real, sin trampas de teclado/aria.
- **Marketing (Adri prevalece)** — recupera lo emocional **sin** la escasez retirada; refuerza unicidad sin presión.
- **Psicología** — jerarquía limpia (H2 → subtítulo → CTA → teaser → firma); el remate cierra, no compite.
- **Neurodivergencia** — lenguaje literal y breve, sin sobrecarga; un único acento de identidad por bloque (se respeta «un acento por bloque»).

## Homogeneidad

Reusa tokens y patrones del DS (`.firma`, `heading-display`, `miriam-claro`, el divisor editorial tipo `.dossier-row`). No inventa patrones nuevos.

## Verificación

- `npm run lint` ✓ (0 warnings / 0 errors) · `npm run build` ✓ (0 failing pages, 0 errors).
- Preview manual (dev server): ES (`/marcas`) y EN (`/en/brands`), desktop **y** móvil 375px — render correcto, centrado, sin errores de consola.

NO merge / NO main — para que lo revises y mergees tú.

🤖 Generated with [Claude Code](https://claude.com/claude-code)