### PR TITLE
fix(links): enlaces cortos 404 → routeRules (gana al catch-all del _redirects)

### DIFF
--- a/SHORT-LINKS.md
+++ b/SHORT-LINKS.md
@@ -5,7 +5,19 @@ prensa y mensajes. Redirigen al destino real **con UTM**, así que se ven limpio
 y además medimos el canal en **Umami**. Mejor que un Bitly: es tu dominio, tu
 control y tu analítica.
 
-> Se definen como `[[redirects]]` en `netlify.toml`. Cambios → requieren deploy.
+> Se definen como `routeRules` en **`nuxt.config.ts`** (no en `netlify.toml`).
+> Cambios → requieren deploy.
+>
+> **¿Por qué no en `netlify.toml`?** `nuxt generate` produce un `dist/_redirects`
+> que acaba con un catch-all `/* /404.html 404`. Netlify procesa el fichero
+> `_redirects` **antes** que `netlify.toml`, así que ese catch-all interceptaba
+> los enlaces cortos y devolvía **404** (ni `force=true` lo arreglaba: `force`
+> solo gana a un fichero del mismo nombre, no a una regla previa del propio
+> `_redirects`). Como `routeRules`, nitro escribe las reglas 302 en `_redirects`
+> **antes** del catch-all, así que ganan. Además se **excluyen del prerender**
+> (`nitro.prerender.ignore`) para que no se genere un `.html` de meta-refresh que
+> «sombrearía» el 302 (regla de _shadowing_ de Netlify). Detalle en los
+> comentarios de `nuxt.config.ts`.
 
 ## Cómo funciona
 
@@ -42,17 +54,27 @@ control y tu analítica.
 
 ## Cómo añadir uno nuevo
 
-1. Edita `netlify.toml`, añade un bloque:
+1. En `nuxt.config.ts`, añade la regla dentro de `routeRules`:
 
-   ```toml
-   [[redirects]]
-     from = "/caso-x"
-     to = "/ciencia?utm_source=twitter&utm_medium=post&utm_campaign=actualizacion-jun"
-     status = 302
+   ```ts
+   routeRules: {
+     // …
+     '/caso-x': { redirect: { to: '/ciencia?utm_source=twitter&utm_medium=post&utm_campaign=actualizacion-jun', statusCode: 302 } },
+   },
    ```
 
-2. Añádelo a la tabla de arriba.
-3. Push + deploy (Netlify). Listo: ya funciona `helpmiriam.com/caso-x`.
+2. Añade la **misma ruta** a `nitro.prerender.ignore` (para que no se genere su
+   `.html` y gane el 302 limpio):
+
+   ```ts
+   ignore: [ /* … */ '/caso-x' ],
+   ```
+
+3. Añádelo a la tabla de arriba.
+4. Verifica local: `pnpm generate` y comprueba que en `dist/_redirects` la regla
+   `/caso-x … 302` aparece **antes** del catch-all `/*` y que **no** existe
+   `dist/caso-x.html`.
+5. Push + deploy (Netlify). Listo: ya funciona `helpmiriam.com/caso-x`.
 
 ## Cómo leerlo en Umami
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -29,45 +29,13 @@
   force = true
 
 # ── Enlaces cortos de marca (campañas) ───────────────────────────────────────
-# Links cortos en NUESTRO dominio (helpmiriam.com/3d…) que redirigen al destino
-# real con UTM, para repartir en redes y medir el canal en Umami. 302 (temporal)
-# = se pueden repuntar/re-etiquetar sin caché permanente. Convención y cómo
-# añadir nuevos: SHORT-LINKS.md.
-#
-# Campaña «lanzamiento-herramienta» — mapa 3D de metástasis:
-[[redirects]]
-  from = "/3d"
-  to = "/mapa-metastasis?utm_source=short&utm_medium=link&utm_campaign=lanzamiento-herramienta"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/3d-x"
-  to = "/mapa-metastasis?utm_source=twitter&utm_medium=post&utm_campaign=lanzamiento-herramienta"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/3d-in"
-  to = "/mapa-metastasis?utm_source=linkedin&utm_medium=post&utm_campaign=lanzamiento-herramienta"
-  status = 302
-  force = true
-
-[[redirects]]
-  from = "/3d-ig"
-  to = "/mapa-metastasis?utm_source=instagram&utm_medium=bio&utm_campaign=lanzamiento-herramienta"
-  status = 302
-  force = true
-
-# Donación — link corto de marca para repartir rápido. Apunta a GoFundMe.
-# 302 (temporal) → repunteable si cambia la campaña/plataforma. Es un salto a un
-# dominio externo: NO se mide en Umami (no carga página nuestra); es solo el
-# enlace limpio y de marca para compartir.
-[[redirects]]
-  from = "/donar"
-  to = "https://www.gofundme.com/f/biopsia-molecular-que-puede-cambiar-su-tratamiento"
-  status = 302
-  force = true
+# Los links cortos (helpmiriam.com/3d…, /donar) NO viven aquí: se definen como
+# `routeRules` en nuxt.config.ts. Motivo: `nuxt generate` emite un
+# `dist/_redirects` con un catch-all `/*  /404.html  404` que Netlify procesa
+# ANTES que netlify.toml, así que interceptaba estos links y devolvía 404 (ni
+# `force=true` lo arreglaba: force solo gana a un fichero del mismo nombre, no a
+# una regla previa del propio _redirects). Como routeRules, nitro los escribe en
+# _redirects ANTES del catch-all y ganan. Convención y tabla: SHORT-LINKS.md.
 
 # ── Cabeceras de seguridad (auditoría 5.5) ───────────────────────────────────
 # Sitio de salud + donaciones = la confianza es crítica. Subconjunto SEGURO que

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -150,6 +150,35 @@ export default defineNuxtConfig({
 
   css: ['~/assets/css/main.css'],
 
+  // ── Enlaces cortos de marca (campañas) ───────────────────────────────────
+  // Links cortos en NUESTRO dominio (helpmiriam.com/3d…) que redirigen al
+  // destino real con UTM, para repartir en redes y medir el canal en Umami.
+  //
+  // POR QUÉ AQUÍ (routeRules) y NO en netlify.toml — root cause del 404 (#117–#119):
+  //   `nuxt generate` produce un `dist/_redirects` que termina con un catch-all
+  //   `/*  /404.html  404`. Netlify procesa el FICHERO `_redirects` ANTES que
+  //   `netlify.toml`, así que ese catch-all interceptaba /3d-x, /3d, … (que NO
+  //   tenían fichero propio) y devolvía 404 antes de llegar a los redirects de
+  //   netlify.toml. `force=true` en netlify.toml NO lo arreglaba: force solo gana
+  //   a un FICHERO del mismo nombre, no a una regla previa del propio _redirects.
+  //   Definidos como routeRules, nitro escribe estas reglas 302 en `dist/_redirects`
+  //   ANTES del catch-all, así que ganan. 302 = repunteable sin caché permanente.
+  //   Cómo añadir/leer en Umami y la tabla de activos: SHORT-LINKS.md.
+  //
+  // OJO «shadowing» de Netlify (por eso el `prerender.ignore` de abajo): una
+  //   routeRule redirect también prerenderiza un fichero `3d-x.html` (meta-refresh).
+  //   Si ese fichero existe y la regla de _redirects NO es `force`, Netlify sirve
+  //   el FICHERO (200 + meta-refresh), sombreando el 302. Para que gane el 302
+  //   limpio, se EXCLUYEN estas rutas del prerender (nitro.prerender.ignore), así
+  //   solo queda la regla 302 en _redirects, sin `.html` que la sombree.
+  routeRules: {
+    '/3d': { redirect: { to: '/mapa-metastasis?utm_source=short&utm_medium=link&utm_campaign=lanzamiento-herramienta', statusCode: 302 } },
+    '/3d-x': { redirect: { to: '/mapa-metastasis?utm_source=twitter&utm_medium=post&utm_campaign=lanzamiento-herramienta', statusCode: 302 } },
+    '/3d-in': { redirect: { to: '/mapa-metastasis?utm_source=linkedin&utm_medium=post&utm_campaign=lanzamiento-herramienta', statusCode: 302 } },
+    '/3d-ig': { redirect: { to: '/mapa-metastasis?utm_source=instagram&utm_medium=bio&utm_campaign=lanzamiento-herramienta', statusCode: 302 } },
+    '/donar': { redirect: { to: 'https://www.gofundme.com/f/biopsia-molecular-que-puede-cambiar-su-tratamiento', statusCode: 302 } },
+  },
+
   nitro: {
     prerender: {
       crawlLinks: true,
@@ -160,7 +189,13 @@ export default defineNuxtConfig({
       // /design-system/ es un export estático en public/, no una ruta de Nuxt.
       // crawlLinks lo descubre desde /colabora, intenta prerenderizarlo, da 404
       // y aborta el build. Lo ignoramos: el archivo estático se copia igual.
-      ignore: ['/design-system', '/mapa-metastasis.md', '/en/mapa-metastasis.md'],
+      // Los enlaces cortos (/3d…, /donar): se EXCLUYEN del prerender para que NO
+      // se genere su `.html` de meta-refresh, que sombrearía el 302 del _redirects
+      // (ver nota «shadowing» en `routeRules` arriba). Así queda solo el 302 limpio.
+      ignore: [
+        '/design-system', '/mapa-metastasis.md', '/en/mapa-metastasis.md',
+        '/3d', '/3d-x', '/3d-in', '/3d-ig', '/donar',
+      ],
       // URLs SIN barra final, coherentes con los links y el canonical del sitio
       // (que ya usan «/colabora», no «/colabora/»). Genera «colabora.html» en
       // vez de «colabora/index.html», así Netlify sirve «/colabora» directo sin


### PR DESCRIPTION
## El bug

`https://helpmiriam.com/3d-x` y los demás enlaces cortos (`/3d`, `/3d-in`, `/3d-ig`, `/donar`) devolvían **404 en producción**, pese a estar definidos como redirects `302 force=true` en `netlify.toml`. El intento previo de `force=true` (#119) **no** lo arregló.

## Root cause — CONFIRMADO contra el artefacto de build

`pnpm generate` (Nuxt/nitro, preset estático) escribe un **`dist/_redirects`** que **termina con un catch-all**:

```
# dist/_redirects ANTES del fix:
/sitemap.xml	/sitemap_index.xml	302
/* /404.html 404          ← intercepta TODO
```

Netlify procesa el fichero **`_redirects` ANTES que `netlify.toml`**. Como `/3d-x` (y los otros) **no tenían fichero propio** en `dist`, caían en ese catch-all `/* → /404.html 404` **antes** de que se evaluaran los redirects de `netlify.toml`. De ahí el 404.

Por qué `force=true` no servía: `force` solo hace que una regla de `netlify.toml` gane a un **fichero estático del mismo nombre** — **no** a una regla anterior dentro del propio `_redirects`. El catch-all ganaba siempre.

Coherente con lo observado: `/fundraiser.json` (también redirect de `netlify.toml`) **sí** funcionaba (200), porque existe como **fichero** en `dist` y el catch-all `404` no sombrea ficheros existentes. Los enlaces cortos, sin fichero, no tenían esa suerte.

```
# dist/_redirects DESPUÉS del fix:
/sitemap.xml	/sitemap_index.xml	302
/donar	https://www.gofundme.com/f/biopsia-molecular-que-puede-cambiar-su-tratamiento	302
/3d-ig	/mapa-metastasis?utm_source=instagram&utm_medium=bio&utm_campaign=lanzamiento-herramienta	302
/3d-in	/mapa-metastasis?utm_source=linkedin&utm_medium=post&utm_campaign=lanzamiento-herramienta	302
/3d-x	/mapa-metastasis?utm_source=twitter&utm_medium=post&utm_campaign=lanzamiento-herramienta	302
/3d	/mapa-metastasis?utm_source=short&utm_medium=link&utm_campaign=lanzamiento-herramienta	302
/* /404.html 404          ← ahora va DESPUÉS de los 5 enlaces cortos
```

## El fix (canónico Nuxt-on-Netlify)

1. **Mueve los 5 enlaces cortos a `routeRules` en `nuxt.config.ts`** (302 + UTM intactos). nitro los escribe en `dist/_redirects` **antes** del catch-all → ganan.
2. **`nitro.prerender.ignore`** para esas rutas. Sutileza de Netlify («**shadowing**»): una `routeRule` redirect también prerenderiza un fichero `3d-x.html` con `<meta http-equiv="refresh">`; si ese fichero existe y la regla de `_redirects` **no** es `force`, Netlify sirve el **fichero** (200 + meta-refresh) y **sombrea** el 302. Excluyéndolas del prerender, no se genera el `.html` y queda el **302 limpio**. *(Esto explica por qué, sin el `ignore`, `netlify dev` servía 200 en vez de 302.)*
3. **Quita** el bloque redundante de enlaces cortos de `netlify.toml` (se conservan `/fundraiser.json`, `/donations.json` y las cabeceras de seguridad).
4. Actualiza **`SHORT-LINKS.md`** (nuevo sitio + cómo añadir uno nuevo, con el paso de `prerender.ignore` y la verificación local).

## Verificación local (motor de redirects de Netlify, equivalente a producción)

`pnpm generate` + `netlify dev` (modo redirect-aware) sobre el build limpio:

| Ruta | Resultado |
|---|---|
| `/3d` | **302** → `/mapa-metastasis?utm_source=short&utm_medium=link&utm_campaign=lanzamiento-herramienta` |
| `/3d-x` | **302** → `…utm_source=twitter&utm_medium=post…` |
| `/3d-in` | **302** → `…utm_source=linkedin&utm_medium=post…` |
| `/3d-ig` | **302** → `…utm_source=instagram&utm_medium=bio…` |
| `/donar` | **302** → `https://www.gofundme.com/f/biopsia-molecular-que-puede-cambiar-su-tratamiento` |
| `/mapa-metastasis` | 200 (control) |
| `/fundraiser.json` | 200 → función (control, sigue OK) |
| ruta inexistente | 404 (catch-all sigue protegiendo rutas que de verdad no existen) |

- `/3d-x` seguido con `curl -L` → acaba en `/mapa-metastasis?utm_source=twitter…` con **1** redirect.
- En `dist/_redirects` las 5 reglas aparecen **antes** del catch-all; **no** se generan ficheros `dist/3d*.html`.
- `pnpm lint` (oxlint): **0 warnings, 0 errors**. Build limpio OK.

## Notas
- 🤖 No mergear sin OK. Preview de Netlify del PR para confirmación final en el dominio real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)