### PR TITLE
chore(netlify): doc enlaces cortos + forzar redeploy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -57,3 +57,7 @@
   [headers.values]
     X-Robots-Tag = "noindex, nofollow"
     X-Content-Type-Options = "nosniff"
+
+# ── Enlaces cortos (vanity) ──────────────────────────────────────────────────
+# Viven en routeRules de Nuxt (ver SHORT-LINKS.md): el _redirects generado se
+# procesa ANTES que este toml, así que aquí solo quedan funciones y cabeceras.


### PR DESCRIPTION
Tras restaurar creditos de Netlify, fuerza un deploy nuevo (un push a main = build) para publicar el fix de /3d-x (#120) que no llego a desplegarse. Cambio inocuo: comentario en netlify.toml documentando que los enlaces cortos viven en routeRules.