### PR TITLE
feat(cronologia): hito del lanzamiento del mapa de metastasis (19 jun)

### DIFF
--- a/content/en/timeline.yml
+++ b/content/en/timeline.yml
@@ -218,3 +218,14 @@ entries:
       compression is real. Urgent SBRT radiotherapy is scheduled to shrink the lesion and protect
       the spinal cord.
     highlight: true
+
+  - date: 'Jun 19, 2026'
+    tag: Outreach
+    title: The metastasis map goes public
+    description: >
+      Miriam openly publishes the interactive map of her metastases: the tool that helps her team
+      understand the case and decide, for example, where to biopsy. That same day, El Español tells
+      her story. She shares it on X with great excitement.
+    highlight: true
+    link: https://x.com/miriamgonp/status/2068004136621109648
+    linkLabel: 'See the announcement on X →'

--- a/content/es/timeline.yml
+++ b/content/es/timeline.yml
@@ -220,3 +220,14 @@ entries:
       de compresión medular es real. Se programa radioterapia SBRT de urgencia para reducir la
       lesión y proteger la médula.
     highlight: true
+
+  - date: '19 jun 2026'
+    tag: Divulgación
+    title: El mapa de metástasis se hace público
+    description: >
+      Miriam publica en abierto el mapa interactivo de sus metástasis: la herramienta que ayuda
+      a su equipo a entender el caso y a decidir, por ejemplo, dónde biopsiar. Ese mismo día
+      El Español cuenta su historia. Lo comparte en X con mucha ilusión.
+    highlight: true
+    link: https://x.com/miriamgonp/status/2068004136621109648
+    linkLabel: 'Ver el anuncio en X →'


### PR DESCRIPTION
Anade un hito a la cronologia: **«El mapa de metastasis se hace publico»** (19 jun 2026, tag Divulgacion), en el **mismo estilo** que los demas (date/tag/title/description/highlight + link/linkLabel), con **enlace al tweet del anuncio** (https://x.com/miriamgonp/status/2068004136621109648). ES + EN sincronizados. No embebe el tweet (mantiene la linea sin cookies). Revisar en el preview de Netlify antes de mergear.