### PR TITLE
feat(ciencia): 'Mapa de metastasis' en el menu de Ciencia

### DIFF
--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -55,6 +55,7 @@ const chapters = computed(() =>
         { id: 'tejido-3veces', label: 'Anatomía patológica' },
         { id: 'molecular-profile-title', label: 'Perfil molecular' },
         { id: 'imaging-tissue-title', label: 'Imagen funcional' },
+        { id: 'mapa-metastasis-link', label: 'Mapa de metástasis' },
         { id: 'panel-title', label: 'El siguiente paso' },
         { id: 'treatment-title', label: 'Historia clínica' },
       ]
@@ -63,6 +64,7 @@ const chapters = computed(() =>
         { id: 'tejido-3veces', label: 'Pathology' },
         { id: 'molecular-profile-title', label: 'Molecular profile' },
         { id: 'imaging-tissue-title', label: 'Functional imaging' },
+        { id: 'mapa-metastasis-link', label: 'Metastasis map' },
         { id: 'panel-title', label: 'The next step' },
         { id: 'treatment-title', label: 'Clinical history' },
       ]

--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -99,7 +99,11 @@ function jumpTo(e: Event, id: string) {
   e.preventDefault()
   // A11y: el foco va al título destino; respeta prefers-reduced-motion.
   const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  el.setAttribute('tabindex', '-1')
+  // A11y: solo forzar tabindex en destinos NO focusables (un heading). Si el destino
+  // ya es focusable (el <a> del CTA del mapa), preservar su tabulación nativa.
+  if (!/^(A|BUTTON|INPUT|SELECT|TEXTAREA)$/.test(el.tagName) && el.getAttribute('tabindex') === null) {
+    el.setAttribute('tabindex', '-1')
+  }
   el.focus({ preventScroll: true })
   el.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' })
   activeId.value = id

--- a/app/components/SiteNav.vue
+++ b/app/components/SiteNav.vue
@@ -192,6 +192,7 @@ const scrolled = computed(() => y.value > 20)
 const navItems = [
   { key: 'home', to: { name: 'index' } },
   { key: 'science', to: { name: 'ciencia' } },
+  { key: 'map', to: { name: 'mapa-metastasis' } },
   { key: 'timeline', to: { name: 'timeline' } },
   { key: 'team', to: { name: 'equipo' } },
 ]

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -335,6 +335,7 @@
 
           <!-- Acceso al mapa interactivo de metástasis (doble trazador, lesión a lesión) -->
           <NuxtLink
+            id="mapa-metastasis-link"
             :to="localePath('/mapa-metastasis')"
             class="group flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-3.5 rounded-2xl px-4 sm:px-5 py-4 mt-5 transition-all active:scale-[0.99] sm:hover:-translate-y-0.5"
             style="background:rgba(232,212,237,0.30);text-decoration:none"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -6,6 +6,7 @@
   "nav": {
     "home": "Home",
     "science": "The science",
+    "map": "Map",
     "team": "Team",
     "timeline": "Timeline",
     "story": "Story",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -6,6 +6,7 @@
   "nav": {
     "home": "Inicio",
     "science": "La ciencia",
+    "map": "Mapa",
     "team": "Equipo",
     "timeline": "Cronología",
     "story": "Historia",


### PR DESCRIPTION
Anade la entrada **Mapa de metastasis** al INDICE de la pagina de Ciencia (bajo 'Imagen funcional'), enlazada al boton del mapa que ya existia pero no era visible en el menu. ES + EN. Revisar en el preview de Netlify.