### PR TITLE
fix(pathways): CTAs de contacto no abrían en iOS Chrome — href real de respaldo

### DIFF
--- a/app/components/VisitorPathways.vue
+++ b/app/components/VisitorPathways.vue
@@ -49,7 +49,7 @@
           </ol>
           <div class="pathway-card__cta">
             <component
-              :is="path.as ?? (path.external ? 'a' : 'NuxtLink')"
+              :is="path.external ? 'a' : NuxtLink"
               v-bind="path.linkProps"
               :class="path.primary ? 'btn-cta w-full justify-center' : 'btn-secondary w-full justify-center'"
               :style="path.external ? 'text-decoration: none' : undefined"
@@ -57,7 +57,7 @@
             >
               <Icon v-if="path.ctaIcon" :name="path.ctaIcon" class="w-4 h-4" aria-hidden="true" />
               {{ path.cta }}
-              <span v-if="path.external" class="sr-only"> {{ $t('a11y.new_tab') }}</span>
+              <span v-if="path.linkProps.target === '_blank'" class="sr-only"> {{ $t('a11y.new_tab') }}</span>
             </component>
             <p v-if="path.caption" class="pathway-card__caption">{{ path.caption }}</p>
           </div>
@@ -131,6 +131,14 @@ const { t, tm, rt } = useI18n()
 const localePath = useLocalePath()
 const { GOFUNDME_URL, trackSupport, trackScience, trackPathway } = useSupport()
 
+// Resolvemos el COMPONENTE real NuxtLink (no la cadena 'NuxtLink'). Pasar el
+// string a <component :is> obliga a Vue a resolverlo por nombre en runtime, algo
+// frágil: si falla (p. ej. un tropiezo de hidratación en iOS Chrome) el enlace se
+// renderiza sin `href` y el botón queda MUERTO. Con el componente real, NuxtLink
+// emite siempre un <a href> navegable, así que el enlace funciona aunque el JS
+// falle. Bug reportado: CTAs «escribir a Miriam/al equipo» no abrían en iOS Chrome.
+const NuxtLink = resolveComponent('NuxtLink')
+
 const titleId = computed(() => `pathways-title-${props.variant}`)
 
 function arr(key: string): string[] {
@@ -153,9 +161,11 @@ interface HomePath {
   ctaIcon?: string
   caption?: string
   primary?: boolean
+  // `external` ⇒ se renderiza como <a> nativo (destino externo con target=_blank,
+  // o ancla en-página). El resto usa el componente NuxtLink (navegación de router
+  // con <a href> real de respaldo). Nunca un <component :is="'NuxtLink'"> por cadena.
   external?: boolean
   linkProps: Record<string, string>
-  as?: 'a' | 'NuxtLink'
   onClick?: () => void
 }
 
@@ -187,7 +197,9 @@ const homePaths = computed<HomePath[]>(() => [
     cta: t('pathways.curious_cta'),
     ctaIcon: 'ph:book-open-text',
     caption: t('pathways.curious_caption'),
-    as: 'a',
+    // Ancla en-página: <a href="#…"> nativo. El href real navega aunque el JS no
+    // corra (el onClick solo añade el scroll suave y abre el <details>).
+    external: true,
     linkProps: { href: '#pathway-brief' },
     onClick: () => {
       const el = document.getElementById('pathway-brief')


### PR DESCRIPTION
## Bug reportado
Una **usuaria real** desde **iPhone con Chrome**: los botones **«Escribir a Miriam»** y **«Escribir al equipo técnico»** *no hacen nada al pulsar* — no navegan a contacto.

## Causa raíz
En `app/components/VisitorPathways.vue`, el `<component :is>` de las tarjetas resolvía a la **cadena** `'NuxtLink'` para los enlaces internos:

```vue
:is="path.as ?? (path.external ? 'a' : 'NuxtLink')"   // ← string 'NuxtLink'
```

Dos problemas que se combinan y resultan fatales **en iOS Chrome**:
1. Pasar el nombre por **string** obliga a Vue a resolver el componente en runtime (`resolveDynamicComponent`) — frágil ante cualquier tropiezo de hidratación.
2. Esos enlaces solo llevaban **`to=`** (navegación de router), **sin `href` real**. Si la resolución/hidratación falla, el `<a>` queda **sin `href`** → el botón está **muerto**, no hay navegación nativa de respaldo. Justo el síntoma: *"no hace nada al hacer click"*.

Los enlaces que **sí** funcionaban en el mismo móvil (redes/GoFundMe, chips de /colabora) son `<a href>` nativos: tienen href real.

Hipótesis descartadas: **(c) Turnstile** no es la causa (fail-open; nunca bloquea el formulario, y el usuario ni llega a él porque falla la navegación). **(d) mailto** no interviene.

## Fix
- `:is` vinculado al **componente real `NuxtLink`** (`resolveComponent('NuxtLink')`), **nunca** a la cadena. NuxtLink emite siempre un `<a href>` real → **el enlace navega aunque el JS/hidratación falle** (el fallback robusto que pedía el bug).
- Modelo unificado: `external` ⇒ `<a>` nativo (destino externo `target=_blank` **o** ancla en-página); el resto ⇒ `NuxtLink`. Eliminado el campo `as`.
- La pista de accesibilidad *"se abre en pestaña nueva"* ahora depende de `target=_blank` (no de `external`), para que el ancla `#pathway-brief` no la anuncie por error.

**Diff: 1 fichero, +16/−4.**

## Verificación
- ✅ `pnpm generate` (build de producción) **OK**, Nuxt Link Checker **0 errores / 0 páginas fallando** (270 rutas).
- ✅ **HTML prerenderizado** de la home (lo que sirve Netlify a iOS): los **14 CTAs llevan `href` real, 0 sin href**, incluidos `/contacto?role=tech` y `/contacto?role=patient`. **Sin etiqueta `<nuxtlink>` sin resolver.** → funciona **aunque el JS no cargue**.
- ✅ Click nativo en dev: navega por SPA a `/contacto?role=tech` y **prerrellena el rol**.
- ✅ `/contacto?role=tech` renderiza formulario + `<select>` con `tech` seleccionado (en SSR, sin JS).
- ✅ `oxlint` limpio. Sin regresiones visuales (6 tarjetas, layout intacto).

## 4 lentes
- **Accesibilidad:** href real navegable por teclado/lector; corregida la pista de "pestaña nueva".
- **Marketing/Producto:** desbloquea la vía de contacto (acerca a colaboradores tech y a pacientes → estrella polar).
- **Psicología:** el botón hace lo que promete; cero fricción.
- **Neurodivergencia:** comportamiento literal y predecible (un enlace que es un enlace).

> ⚠️ **No mergear** — para revisión de Miriam/Dani + comprobación en el **preview de Netlify** (idealmente probar en un iPhone real con Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)