### PR TITLE
fix(colabora): quita la cabecera redundante de las 5 vías

### DIFF
--- a/app/components/VisitorPathways.vue
+++ b/app/components/VisitorPathways.vue
@@ -7,17 +7,27 @@
     :style="variant === 'colabora' ? '' : 'border-bottom: 1px solid rgba(45,27,61,0.08)'"
   >
     <div :class="variant === 'home' ? 'section-wide' : ''">
-      <p class="eyebrow mb-3 block">{{ $t('pathways.eyebrow') }}</p>
-      <h2
-        :id="titleId"
-        class="heading-display text-2xl sm:text-3xl text-berenjena mb-2"
-        style="letter-spacing: -0.02em"
-      >
-        {{ variant === 'home' ? $t('pathways.home_title') : $t('pathways.colabora_title') }}
-      </h2>
-      <p class="text-sm sm:text-base text-tinta leading-relaxed max-w-2xl mb-3">
-        {{ variant === 'home' ? $t('pathways.home_sub') : $t('pathways.colabora_sub') }}
-      </p>
+      <!--
+        Cabecera (eyebrow + título + subtítulo) SOLO en home. En /colabora la
+        sección que envuelve este componente (collaborate.profiles_*) ya aporta
+        eyebrow + h2 + subtítulo, así que repetirlos aquí era redundante. Para no
+        romper el landmark, la variante colabora conserva un h2 `sr-only` con el
+        mismo id que referencia `aria-labelledby` de la <section>.
+      -->
+      <template v-if="variant === 'home'">
+        <p class="eyebrow mb-3 block">{{ $t('pathways.eyebrow') }}</p>
+        <h2
+          :id="titleId"
+          class="heading-display text-2xl sm:text-3xl text-berenjena mb-2"
+          style="letter-spacing: -0.02em"
+        >
+          {{ $t('pathways.home_title') }}
+        </h2>
+        <p class="text-sm sm:text-base text-tinta leading-relaxed max-w-2xl mb-3">
+          {{ $t('pathways.home_sub') }}
+        </p>
+      </template>
+      <h2 v-else :id="titleId" class="sr-only">{{ $t('pathways.colabora_title') }}</h2>
       <p class="pathway-comfort max-w-2xl" role="note">
         <Icon name="ph:leaf" class="pathway-comfort__icon" aria-hidden="true" />
         {{ $t('pathways.comfort') }}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -43,7 +43,6 @@
     "home_title": "Pick your path",
     "home_sub": "You don't have to read everything. Tell us who you are and we'll take you to the next step.",
     "colabora_title": "Jump to your profile",
-    "colabora_sub": "Five routes, one per person. Tap yours and go straight to what matters for you.",
     "comfort": "Take all the time you need. You can come back anytime; nothing is lost.",
     "grid_aria": "Paths based on who is visiting",
     "chips_aria": "Jump to each way of helping",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -43,7 +43,6 @@
     "home_title": "Elige tu camino",
     "home_sub": "No hace falta leerlo todo. Dinos quién eres y te llevamos al siguiente paso.",
     "colabora_title": "Salta a tu perfil",
-    "colabora_sub": "Cinco vías, una por persona. Toca la tuya y baja directo a lo que te toca.",
     "comfort": "Tómate el tiempo que necesites. Puedes volver cuando quieras; nada se pierde.",
     "grid_aria": "Caminos según quién visita la web",
     "chips_aria": "Ir directo a cada forma de ayudar",


### PR DESCRIPTION
## Qué

En **/colabora**, la sección de las **5 vías por perfil** tenía **dos encabezados apilados** diciendo lo mismo:

1. La **cabecera de sección de la página** (`collaborate.profiles_*`): *"Por perfil / Según quién seas. / Elige la vía que encaja contigo…"* — la que envuelve el componente.
2. La **cabecera interna del componente** `VisitorPathways` (variant `colabora`): *"¿Por dónde empiezo? / Salta a tu perfil / Cinco vías, una por persona…"*.

Miriam lo vio como redundante → **quito la cabecera interna (2)** y dejo la de sección (1), que es la que da nombre al landmark.

## Cómo

`app/components/VisitorPathways.vue`:
- El bloque **eyebrow + h2 + subtítulo** (`pathways.eyebrow` + `home_title`/`home_sub`) ahora se renderiza **solo en `variant="home"`** (la home no tiene cabecera externa, ahí no es redundante).
- En **`variant="colabora"`** se conserva un **`<h2 sr-only>`** con el mismo `:id="titleId"` que referencia el `aria-labelledby` de la `<section>` → no se rompe el landmark ni su nombre accesible. Reutiliza `pathways.colabora_title`.
- Las **5 vías (chips por perfil)** quedan **100% intactas**; el bloque `home` (6 tarjetas + brief) no se toca.

Limpieza i18n:
- Elimino `pathways.colabora_sub` (huérfana tras el cambio) en `es.json` **y** `en.json`.
- `pathways.colabora_title` (ahora la usa el `sr-only`) y `pathways.eyebrow` (la usa home) **se mantienen** — no son huérfanas.

## Verificación
- `oxlint` sobre el componente: **0 warnings, 0 errors**.
- `es.json` / `en.json`: **JSON válido**.
- `colabora_sub` no queda referenciada en ningún sitio (grep limpio).
- Header de sección de **/colabora** (`collaborate.profiles_*`, `id="profiles-title"`) **intacto**.

## 4 lentes
- **Accesibilidad:** se mantiene el heading del landmark vía `sr-only` (sin duplicar verbatim el h2 visible externo); sin cambios de foco/teclado; sin nuevos patrones.
- **Psicología / carga cognitiva:** menos ruido — un solo encabezado en lugar de dos repetidos.
- **Neurodivergencia:** jerarquía más clara, sin repetición.
- **Marketing:** copy de las vías sin cambios; solo se elimina duplicación.

> No mergear: dejar para **preview Netlify** y revisión. Cambio pequeño y aislado (worktree del técnico; sin tocar `/marcas`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)