### PR TITLE
fix(links): tagline /links sin 'paciente' — ingeniera de software + divulgadora tech

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -994,7 +994,7 @@
     "aria_page": "Miriam González's links",
     "aria_nav": "Featured links",
     "avatar_alt": "Portrait of Miriam González",
-    "tagline": "Engineer and metastatic breast cancer patient. I use AI to find the best evidence-based treatment.",
+    "tagline": "Software engineer · tech communicator. I investigate my own tumor with AI and share it in the open.",
     "footnote": "helpmiriam.com · supportive material, not medical advice.",
     "elespanol_title": "My case in El Español",
     "elespanol_sub": "“The engineer using AI to fight her cancer” (Spanish)",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -994,7 +994,7 @@
     "aria_page": "Enlaces de Miriam González",
     "aria_nav": "Enlaces destacados",
     "avatar_alt": "Retrato de Miriam González",
-    "tagline": "Ingeniera y paciente de cáncer de mama metastásico. Uso la IA para buscar el mejor tratamiento basado en evidencia.",
+    "tagline": "Ingeniera de software · divulgadora tech. Investigo mi propio tumor con IA y lo comparto en abierto.",
     "footnote": "helpmiriam.com · material de apoyo, no consejo médico.",
     "elespanol_title": "Mi caso en El Español",
     "elespanol_sub": "«La ingeniera que usa la IA para luchar contra su cáncer»",


### PR DESCRIPTION
## Qué

Actualiza el **tagline de la tarjeta `/links`** (linktree) para quitar **"paciente"/"patient"** y alinearlo con el posicionamiento público de Miriam: **ingeniera de software · divulgadora tech**, con la frase clave *"investigo mi propio tumor con IA"*.

## Cambios (solo i18n, 2 líneas)

**`i18n/locales/es.json` → `links.tagline`**
- Antes: `Ingeniera y paciente de cáncer de mama metastásico. Uso la IA para buscar el mejor tratamiento basado en evidencia.`
- Después: `Ingeniera de software · divulgadora tech. Investigo mi propio tumor con IA y lo comparto en abierto.`

**`i18n/locales/en.json` → `links.tagline`**
- Antes: `Engineer and metastatic breast cancer patient. I use AI to find the best evidence-based treatment.`
- Después: `Software engineer · tech communicator. I investigate my own tumor with AI and share it in the open.`

## Resto de la sección `links`
Revisada en ambos idiomas. **No hay más ocurrencias** de "paciente/patient/científica/scientist". El resto de strings (botones elespanol/mapa/marcas/apoyar/caso, `footnote`) se dejan intactas. `elespanol_sub` se mantiene porque es la **cita literal del titular** de El Español («La ingeniera que usa la IA…»), usa el término permitido "ingeniera" y no contiene palabras vetadas.

## Notas
- Sin cambios de lógica ni estilos: solo los dos textos i18n indicados.
- JSON válido en ES y EN (verificado con `json.load`).
- Reusa el design system; no introduce patrones nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)