### PR TITLE
fix(footer): disclaimer sin "paciente" — nombra a Miriam (activa)

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -419,7 +419,7 @@
     "privacy_notice": "Your data is only used to respond to your message. It is not shared with third parties."
   },
   "footer": {
-    "disclaimer": "This site is an informational resource maintained by the patient's support team. It does not replace professional medical advice.",
+    "disclaimer": "This site is maintained by Miriam González's support team. It is for informational purposes and does not replace professional medical advice.",
     "updated": "Last updated",
     "month_updated": "June",
     "nav_heading": "Navigation",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -442,7 +442,7 @@
     "privacy_notice": "Tus datos solo se usan para responder a tu mensaje. No se comparten con terceros."
   },
   "footer": {
-    "disclaimer": "Este sitio es un recurso informativo mantenido por el equipo de apoyo de la paciente. No sustituye asesoramiento médico profesional.",
+    "disclaimer": "Este sitio lo mantiene el equipo de apoyo de Miriam González. Tiene fines informativos y no sustituye el asesoramiento médico profesional.",
     "updated": "Última actualización",
     "month_updated": "junio de",
     "nav_heading": "Navegación",


### PR DESCRIPTION
## Qué y por qué

El brief era: «el tagline de /links dice "paciente", cámbialo». Al revisar el repo, **ese tagline ya estaba corregido** (PR #128 ya en `main`): hoy /links dice «Ingeniera de software · divulgadora tech…», sin "paciente".

Pero "paciente"/"patient" **seguía vivo en el disclaimer del footer global** (`app/components/SiteFooter.vue`), que aparece en **todas** las páginas — incluida `/links` justo en el punto de conversión. Eso es lo que de verdad rompía la coherencia: mandamos tráfico desde una marca "ingeniera, activa" a una página cuyo pie decía "la paciente" (pasiva).

Choca con el muro de marca (fuente de verdad `07 · Marca/Bios-Redes-2026-06-20.md`: **SIN "paciente"**, es activa). Este PR lo corrige manteniendo las dos funciones legales del disclaimer (lo mantiene un *equipo de apoyo*, no Miriam en persona; **no es consejo médico**).

## Cambio (viejo → nuevo)

**ES** (`i18n/locales/es.json` › `footer.disclaimer`)
- Antes: «Este sitio es un recurso informativo mantenido por el equipo de apoyo de **la paciente**. No sustituye asesoramiento médico profesional.»
- Ahora: «Este sitio lo mantiene el equipo de apoyo de **Miriam González**. Tiene fines informativos y no sustituye el asesoramiento médico profesional.»

**EN** (`i18n/locales/en.json` › `footer.disclaimer`)
- Antes: «This site is an informational resource maintained by the **patient's** support team. It does not replace professional medical advice.»
- Ahora: «This site is maintained by **Miriam González's** support team. It is for informational purposes and does not replace professional medical advice.»

## Validación
- **Copy aprobado por Adri** (marketing prevalece en marca): aprobado-con-matiz; suyo el cambio «es material informativo» → «tiene fines informativos» (menos legalés, no la cosifica). Nombrar a Miriam = ✅ (refuerza marca personal + muro).
- JSON de ambos locales validado (`node JSON.parse` OK). Diff mínimo: 2 líneas, una por archivo. Sin cambios de diseño/estructura.
- **Disclaimer = misma key compartida** → cambia coherente en ES y EN, no rompe layout (es texto en el componente de footer existente).

## Fuera de scope (intencional)
Otras apariciones de "paciente"/"patient" son **contextuales**, no el muro: ensayo N-of-1 «para una sola paciente» (correcto técnicamente), `/colabora` hablando *a* otros pacientes (segmentación de audiencia), y el **boilerplate de prensa** «una paciente, un equipo internacional…». El boilerplate sí comparte el mismo problema de framing → queda anotado como tarea aparte (otra superficie), no bloquea este PR.

## Revisar
1. Preview de Netlify (abajo, cuando termine el build): mirar el **footer en cualquier página** y en `/links` + `/en/links`.
2. Si OK → **merge** (lo haces tú / Dani). No he mergeado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)