### PR TITLE
Hero — giro de marca: H1 (hecho clínico + agencia) + subtítulo («no ofrece») · preview

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -241,9 +241,9 @@
     "retry": "Retry"
   },
   "hero": {
-    "title": "A rare cancer, {op}.",
-    "title_short": "A rare cancer, a real opportunity.",
-    "title_emphasis": "a real opportunity",
+    "title": "Metastatic breast cancer. {op}.",
+    "title_short": "Metastatic breast cancer. I investigate it in the open.",
+    "title_emphasis": "I investigate it in the open",
     "subtitle": "{lead} has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
     "twofaces": "two sides",
     "subtitle_lead": "Miriam, {age},",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -244,7 +244,7 @@
     "title": "Metastatic breast cancer. {op}.",
     "title_short": "Metastatic breast cancer. I investigate it in the open.",
     "title_emphasis": "I investigate it in the open",
-    "subtitle": "{lead} has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
+    "subtitle": "{lead} has a tumor with {twofaces} for which standard oncology doesn't offer a personalized treatment. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
     "twofaces": "two sides",
     "subtitle_lead": "Miriam, {age},",
     "cta_donate": "Support Miriam",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -244,7 +244,7 @@
     "title": "Cáncer de mama metastásico. {op}.",
     "title_short": "Cáncer de mama metastásico. Lo investigo en abierto.",
     "title_emphasis": "Lo investigo en abierto",
-    "subtitle": "{lead} tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
+    "subtitle": "{lead} tiene un tumor con {twofaces} para el que el protocolo estándar no ofrece un tratamiento personalizado. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
     "twofaces": "dos caras",
     "subtitle_lead": "Miriam, {age} años,",
     "cta_donate": "Apoyar a Miriam",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -241,9 +241,9 @@
     "retry": "Reintentar"
   },
   "hero": {
-    "title": "Un cáncer raro, {op} real.",
-    "title_short": "Un cáncer raro, una oportunidad real.",
-    "title_emphasis": "una oportunidad",
+    "title": "Cáncer de mama metastásico. {op}.",
+    "title_short": "Cáncer de mama metastásico. Lo investigo en abierto.",
+    "title_emphasis": "Lo investigo en abierto",
     "subtitle": "{lead} tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
     "twofaces": "dos caras",
     "subtitle_lead": "Miriam, {age} años,",


### PR DESCRIPTION
> **Combina el giro completo del hero en un solo PR** (H1 + subtítulo). El cambio del subtítulo venía de #133, ahora **plegado aquí** (#133 cerrada).

## 1 · H1 de la home (`hero.title` / `title_emphasis` / `title_short`)
**Antes (vivo en `main`):**
- ES — «Un cáncer raro, _una oportunidad_ real.»
- EN — "A rare cancer, _a real opportunity_."

**Después:**
- ES — «Cáncer de mama metastásico. _Lo investigo en abierto_.»
- EN — "Metastatic breast cancer. _I investigate it in the open_."

El giro de marca había sacado del H1 el final "víctima" (*no hay respuestas*) pero perdió el **hecho clínico real**. Esto lo restaura sin victimismo: el hecho delante, la **agencia** cierra ("en abierto", eco del tagline aprobado).

## 2 · Subtítulo del hero (`hero.subtitle`) — plegado de #133
**Antes:**
- ES — «…un tumor con dos caras ~que los protocolos españoles no contemplan~.»
- EN — "…a tumor with two sides ~that Spanish protocols don't account for~."

**Después:**
- ES — «…un tumor con dos caras **para el que el protocolo estándar no ofrece un tratamiento personalizado**.»
- EN — "…a tumor with two sides **for which standard oncology doesn't offer a personalized treatment**."

Verbo de marca de Adri (20-jun, prevalece): **«no ofrece» > «no contempla»** («no contempla» insinúa ocultación). Término público del muro: **«tratamiento personalizado»**. Frases 2-3 del subtítulo intactas.

## Comité Web
- **Adri (marketing, prevalece):** H1 — vetó "metastásico + oportunidad"; agencia en la respuesta, "en abierto", punto separador, sin rol/"ingeniera" en el H1. Subtítulo — verbo «no ofrece».
- **Diseño:** el H1 (~52 car) ya cae en ~4-5 líneas en móvil **sin tocar CSS**; el subtítulo nuevo es ~29 car más largo en ES. **Revisar a 360-390px que el bloque H1+subtítulo no hunda el retrato.**

## Resto del giro paciente→ingeniera (contexto)
Rol + boilerplate + meta → #131 · footer → #130 · tagline /links → #128 (merged).

## ⚠️ Preview, no merge
Rama para el **preview de Netlify**. **No mergear sin el OK de Miriam/Dani.** El wording exacto del subtítulo es reconstrucción del patrón de Adri — ajustable. Muro OK: sin "vacuna", "científica" ni "Olune".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
