### PR TITLE
fix(hero): subtítulo — «no ofrece un tratamiento personalizado» (verbo de marca, Adri)

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -244,7 +244,7 @@
     "title": "A rare cancer, {op}.",
     "title_short": "A rare cancer, a real opportunity.",
     "title_emphasis": "a real opportunity",
-    "subtitle": "{lead} has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
+    "subtitle": "{lead} has a tumor with {twofaces} for which standard oncology doesn't offer a personalized treatment. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
     "twofaces": "two sides",
     "subtitle_lead": "Miriam, {age},",
     "cta_donate": "Support Miriam",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -244,7 +244,7 @@
     "title": "Un cáncer raro, {op} real.",
     "title_short": "Un cáncer raro, una oportunidad real.",
     "title_emphasis": "una oportunidad",
-    "subtitle": "{lead} tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
+    "subtitle": "{lead} tiene un tumor con {twofaces} para el que el protocolo estándar no ofrece un tratamiento personalizado. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
     "twofaces": "dos caras",
     "subtitle_lead": "Miriam, {age} años,",
     "cta_donate": "Apoyar a Miriam",


### PR DESCRIPTION
## Qué

Pivota el **subtítulo del hero** (`hero.subtitle`, ES+EN) al verbo de marca **«no ofrece / doesn't offer»**:

- **ES:** «…un tumor con dos caras ~que los protocolos españoles no contemplan~.» → «…un tumor con dos caras **para el que el protocolo estándar no ofrece un tratamiento personalizado**.»
- **EN:** «…a tumor with two sides ~that Spanish protocols don't account for~.» → «…a tumor with two sides **for which standard oncology doesn't offer a personalized treatment**.»

Las frases 2 y 3 del subtítulo **no cambian**. Cambio quirúrgico, ES+EN sincronizados, 1 línea por locale.

## Por qué

- **Verbo de marca (review de Adri, 20-jun, prevalece):** «no ofrece» > «no contempla» — «no contempla» insinúa ocultación, tono que el muro prohíbe. El subtítulo del hero era la **única superficie pública** que aún usaba «no contemplan / don't account for».
- **Término público sancionado por el muro:** «tratamiento personalizado».
- Completa el giro «paciente → ingeniera con agencia». El resto ya está repartido en otras ramas:
  - Rol de `team.yml`, `team.subtitle`, boilerplate de prensa y meta/OG → **#131**
  - `footer.disclaimer` → **#130**
  - **H1** del hero → **#132**

## Notas para la revisión

- ⛔️ **No mergear sin el OK de Miriam.** El texto exacto es una reconstrucción a partir del patrón canónico de Adri (no hay subtítulo literal en la fuente de verdad); ajustable en el preview.
- Toca `i18n/locales/{es,en}.json` (línea 247), **adyacente** al H1 de #132 (líneas 244-246): si se mergean por separado puede salir un conflicto trivial de contexto — o se combinan en un único PR de hero.
- El preview de Netlify ejecuta el `nuxt generate` real (verificación de i18n).
