### PR TITLE
Revert: el hero vuelve al original (deshace #132)

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -241,10 +241,10 @@
     "retry": "Retry"
   },
   "hero": {
-    "title": "Metastatic breast cancer. {op}.",
-    "title_short": "Metastatic breast cancer. I investigate it in the open.",
-    "title_emphasis": "I investigate it in the open",
-    "subtitle": "{lead} has a tumor with {twofaces} for which standard oncology doesn't offer a personalized treatment. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
+    "title": "A rare cancer, {op}.",
+    "title_short": "A rare cancer, a real opportunity.",
+    "title_emphasis": "a real opportunity",
+    "subtitle": "{lead} has a tumor with {twofaces} that Spanish protocols don't account for. The tests she needs to treat it aren't covered by public healthcare. This site exists to fund them.",
     "twofaces": "two sides",
     "subtitle_lead": "Miriam, {age},",
     "cta_donate": "Support Miriam",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -241,10 +241,10 @@
     "retry": "Reintentar"
   },
   "hero": {
-    "title": "Cáncer de mama metastásico. {op}.",
-    "title_short": "Cáncer de mama metastásico. Lo investigo en abierto.",
-    "title_emphasis": "Lo investigo en abierto",
-    "subtitle": "{lead} tiene un tumor con {twofaces} para el que el protocolo estándar no ofrece un tratamiento personalizado. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
+    "title": "Un cáncer raro, {op} real.",
+    "title_short": "Un cáncer raro, una oportunidad real.",
+    "title_emphasis": "una oportunidad",
+    "subtitle": "{lead} tiene un tumor con {twofaces} que los protocolos españoles no contemplan. Las pruebas que necesita para tratarlo no las cubre la sanidad pública. Esta web existe para financiarlas.",
     "twofaces": "dos caras",
     "subtitle_lead": "Miriam, {age} años,",
     "cta_donate": "Apoyar a Miriam",


### PR DESCRIPTION
Revierte por completo #132 (commit 26514d8): título Y subtítulo del hero vuelven al estado en vivo previo («Un cáncer raro, una oportunidad real.» / «A rare cancer, a real opportunity.», subtítulo «no contemplan / don't account for»). Solo i18n ES+EN; ningún otro fichero.

Motivo: los textos del hero no se cambian sin el visto bueno explícito de Miriam.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>