### PR TITLE
fix(diseño): pulido TOC — ✕ del visor + bolita de la cronología

### DIFF
--- a/app/components/TimelineEntry.vue
+++ b/app/components/TimelineEntry.vue
@@ -89,21 +89,29 @@ const innerStyle = computed(() => {
 </script>
 
 <style scoped>
-/* «Vivo»: 3 latidos al entrar y calma (nada late para siempre). */
+/* MOAT del color de página: el raíl se CORTA limpio al llegar al nodo (un hueco de
+   3px arriba y abajo) en vez de atravesarlo sucio. El disco de fondo del dot ya tapa
+   la línea hasta el aro; este anillo la tapa 3px MÁS ALLÁ del aro → hueco visible.
+   (Pedido de Miriam: «la línea la atraviesa sucia».) */
+.tl-dot {
+  box-shadow: 0 0 0 3px #faf6f0;
+}
+/* «Vivo»: 3 latidos al entrar y calma (nada late para siempre). El moat se conserva
+   como primera sombra para que el hueco del raíl no desaparezca durante el pulso. */
 .tl-dot-live {
   animation: tl-pulse 2s ease-in-out 3;
 }
 @keyframes tl-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 107, 71, 0.35); }
-  50% { box-shadow: 0 0 0 6px rgba(255, 107, 71, 0); }
+  0%, 100% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 0 rgba(255, 107, 71, 0.35); }
+  50% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 6px rgba(255, 107, 71, 0); }
 }
 /* Eco de llegada: doble pulso más amplio, una sola vez, y vuelve a la calma. */
 .tl-dot-echo {
   animation: tl-echo 1.2s ease-in-out 2;
 }
 @keyframes tl-echo {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 107, 71, 0.5); }
-  50% { box-shadow: 0 0 0 14px rgba(255, 107, 71, 0); }
+  0%, 100% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 0 rgba(255, 107, 71, 0.5); }
+  50% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 14px rgba(255, 107, 71, 0); }
 }
 /* Afordancia del enlace: leve realce de fondo al pasar/enfocar (toque cómodo). */
 .tl-link:hover,

--- a/app/pages/mapa-metastasis.vue
+++ b/app/pages/mapa-metastasis.vue
@@ -5199,7 +5199,10 @@ svg [role="button"]:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.7rem 0.9rem;
+  /* El ✕ vive en este bar, pegado a la esquina redondeada del panel (radio 0.9rem).
+     El padding der/arr debe SUPERAR ese radio para que el botón despeje la curva y
+     respire — si no, queda embutido en la esquina (ver auditoría TOC). */
+  padding: 0.95rem 1.1rem;
   border-bottom: 1px solid rgba(45, 27, 61, 0.12);
 }
 .foco-key-lb__title { font-weight: 700; color: #2d1b3d; font-size: 0.95rem; line-height: 1.1; }


### PR DESCRIPTION
Auditoría de detalle a zoom: el ✕ del visor en grande respira en la esquina redondeada; el raíl de la cronología se corta limpio al llegar al nodo (no lo atraviesa). Build verde, verificado a zoom.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>