### PR TITLE
fix(exactitud): cifra de rareza fiel a su fuente SEER + SSTR+ atado a su prueba

### DIFF
--- a/app/components/OgImage/Default.takumi.vue
+++ b/app/components/OgImage/Default.takumi.vue
@@ -60,7 +60,7 @@ defineProps({
         </span>
         <span style="color: #a44db2;">·</span>
         <span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; color: #5a4a68;">
-          BC-NED · FGFR1 ×13 · SSTR2+
+          BC-NED · FGFR1 ×13 · SSTR+ (PET Ga-DOTATOC)
         </span>
       </div>
     </div>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -566,7 +566,7 @@
       "AI tools, case management and outreach."
     ],
     "s4_full_breakdown": "See the full breakdown",
-    "story_p1_rarity": "fewer than 1 in 1,000 cases",
+    "story_p1_rarity": "0.1%–5% of all breast cancers",
     "story_p1_source": "Source: SEER population analysis · Transl. Cancer Res., 2023",
     "s4_p1_blind": "blind"
   },

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -589,7 +589,7 @@
       "Herramientas de IA, gestión y difusión del caso."
     ],
     "s4_full_breakdown": "Ver el desglose completo",
-    "story_p1_rarity": "menos de 1 de cada 1.000 casos",
+    "story_p1_rarity": "el 0,1 %–5 % de los cánceres de mama",
     "story_p1_source": "Fuente: análisis poblacional SEER · Transl. Cancer Res., 2023",
     "s4_p1_blind": "a ciegas"
   },


### PR DESCRIPTION
## Qué es
Corrección de **exactitud** (no estética): la cifra pública de rareza **contradecía su propia cita**. Verificado por el comité médico contra la fuente primaria.

## Cambios

### 1. Cifra de rareza fiel a la fuente (`home.story_p1_rarity`, es + en)
- **Antes:** «menos de 1 de cada 1.000 casos» / «fewer than 1 in 1,000 cases»
- **Ahora:** «el 0,1 %–5 % de los cánceres de mama» / «0.1%–5% of all breast cancers»

**Por qué:** la fuente citada en la propia frase —SEER, Xia et al., *Transl Cancer Res* 2023 (PMID **37701099**)— da el rango **0,1 %–5 %**. «Menos de 1 de cada 1.000» equivale a **<0,1 %**, que queda **por debajo** del propio rango citado: la web afirmaba algo más raro de lo que sostiene su fuente. `home.story_p1_source` (la cita SEER) se mantiene **sin tocar**.

> ⚠️ **Para decisión de Miriam/Dani:** la frase contenedora es «…tan raro que se ve en **[cifra]**». Para que «se ve en …» case gramaticalmente, la cifra se redactó como «**el** 0,1 %–5 % de los cánceres de mama» (en vez del literal «entre el 0,1 % y el 5 %», que daba «se ve en entre el…»). El **rango numérico de la fuente es idéntico**; solo cambia el conector para que lea natural. Si preferís el literal «entre el 0,1 % y el 5 %», se ajusta la frase contenedora `story_p1` en un commit.

### 2. SSTR2+ atado a su prueba (`OgImage/Default.takumi.vue`)
- **Antes:** badge `BC-NED · FGFR1 ×13 · SSTR2+` (suelto, sin fuente)
- **Ahora:** `BC-NED · FGFR1 ×13 · SSTR+ (PET Ga-DOTATOC)`

**Por qué:** el informe primario dice «receptores de somatostatina» por **PET ⁶⁸Ga-DOTATOC**; el «2» de «SSTR2» es **inferencia del trazador**, no texto del informe. Cambio mínimo y honesto que ata el marcador a su prueba. La tabla de `MolecularProfileDetailed.vue` **ya cita su fuente** → se deja intacta (como pedía el encargo).

## Verificación
- Build completo (`pnpm build`) ✅
- Render comprobado en el dev server (ES y EN): la frase lee correcta en ambos idiomas.
- JSON de locales válido.

## Ficheros
- `i18n/locales/es.json`
- `i18n/locales/en.json`
- `app/components/OgImage/Default.takumi.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)