### PR TITLE
fix(contacto): Turnstile colgado no bloquea el envío (timeout de seguridad)

### DIFF
--- a/app/components/TurnstileWidget.vue
+++ b/app/components/TurnstileWidget.vue
@@ -24,6 +24,22 @@ const loadError = ref(false)
 let widgetId: string | undefined
 let scriptEl: HTMLScriptElement | null = null
 
+// Turnstile puede quedarse colgado sin emitir token NI error (sitekey con el
+// dominio mal configurado en Cloudflare, red rara, bloqueadores). En ese caso no
+// llama a ningún callback y el formulario se quedaría con el botón de envío muerto
+// para todo el mundo. Un temporizador de seguridad convierte ese "cuelgue mudo" en
+// el mismo camino de degradación que ya tratamos para un error explícito: avisamos
+// al padre para que NO bloquee el envío (Netlify mantiene honeypot + antispam).
+const RESOLVE_TIMEOUT_MS = 8000
+let resolveTimer: ReturnType<typeof setTimeout> | undefined
+let settled = false
+function clearResolveTimer() {
+  if (resolveTimer) {
+    clearTimeout(resolveTimer)
+    resolveTimer = undefined
+  }
+}
+
 declare global {
   interface Window {
     turnstile?: {
@@ -62,9 +78,15 @@ function renderWidget() {
     action: props.action ?? 'form',
     theme: 'light',
     language: 'auto',
-    callback: (token: string) => emit('token', token),
+    callback: (token: string) => {
+      settled = true
+      clearResolveTimer()
+      emit('token', token)
+    },
     'expired-callback': () => emit('expired'),
     'error-callback': () => {
+      settled = true
+      clearResolveTimer()
       loadError.value = true
       emit('error')
     },
@@ -73,16 +95,27 @@ function renderWidget() {
 
 onMounted(async () => {
   if (!enabled.value) return
+  // Si en RESOLVE_TIMEOUT_MS no ha llegado token ni error (cuelgue mudo), lo damos
+  // por no disponible y avisamos al padre para no dejar el botón bloqueado.
+  resolveTimer = setTimeout(() => {
+    if (!settled) {
+      settled = true
+      emit('error')
+    }
+  }, RESOLVE_TIMEOUT_MS)
   try {
     await loadScript()
     renderWidget()
   } catch {
+    settled = true
+    clearResolveTimer()
     loadError.value = true
     emit('error')
   }
 })
 
 onBeforeUnmount(() => {
+  clearResolveTimer()
   if (widgetId && window.turnstile) {
     window.turnstile.remove(widgetId)
   }


### PR DESCRIPTION
## El problema (detectado en vivo)

Una contacta legítima (periodista) avisó de que **no podía escribir desde la web**. Reproducido en `helpmiriam.com/contacto`:

- El botón **«Enviar mensaje» nace `disabled`** y solo se activa cuando Cloudflare Turnstile emite un token.
- La **sitekey de producción** (`0x4AAAAAA…`) **se cuelga en mudo** sobre el dominio `helpmiriam.com`: no renderiza el iframe, **no emite token y NO dispara `error-callback`** (verificado con la sitekey de *test* de Cloudflare → esa sí emite token al instante, así que la maquinaria funciona; el problema es la clave/su dominio).
- Como el código solo degradaba ante un **error explícito** o un fallo de carga del script, un **cuelgue silencioso** dejaba el botón muerto **para todo el mundo**.
- Afecta a los **dos** formularios que usan el widget: `pages/contacto.vue` y `components/CaseFollowSignup.vue`.

## El arreglo de raíz (fuera de este PR)

Re-autorizar el dominio `helpmiriam.com` (+`www`) en la **sitekey de Turnstile en Cloudflare** (o regenerar la clave y actualizar las env de Netlify). Eso lo hace Miriam.

## Lo que hace este PR (blindaje, defensa en profundidad)

`TurnstileWidget.vue`: temporizador de seguridad de **8 s**. Si no llega token ni error (cuelgue mudo), se trata como **«captcha no disponible»** — el mismo camino de degradación que ya existía para el error explícito — y el formulario **deja enviar**. Netlify (honeypot + antispam) queda de red de seguridad, tal como ya documenta el propio código.

Así, un fallo del captcha (clave mal configurada, Cloudflare caído, bloqueadores del usuario) **nunca vuelve a tragarse los contactos en silencio**.

## Verificación

- `oxlint` ✅ (0 warnings, 0 errores).
- Causa raíz confirmada en el navegador en vivo (sitekey test vs producción).
- Build real → **Deploy Preview de Netlify** de este PR.
- Pendiente: probar el preview con la clave ya arreglada. **No fusionar hasta que Miriam lo revise.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)