### PR TITLE
fix(copy): quita «paciente» como identidad de Miriam (footer + subtítulo del equipo)

### DIFF
--- a/app/pages/equipo.vue
+++ b/app/pages/equipo.vue
@@ -175,22 +175,22 @@ useSeoMeta({
   ogTitle: () => (locale.value === 'es' ? 'El equipo' : 'The team'),
   ogDescription: () =>
     locale.value === 'es'
-      ? 'Una paciente, un equipo internacional e inteligencia artificial.'
-      : 'One patient, an international team, and artificial intelligence.',
+      ? 'Una ingeniera, un equipo internacional e inteligencia artificial.'
+      : 'An engineer, an international team, and artificial intelligence.',
   ogType: 'website',
   twitterCard: 'summary_large_image',
   twitterTitle: () => (locale.value === 'es' ? 'El equipo' : 'The team'),
   twitterDescription: () =>
     locale.value === 'es'
-      ? 'Una paciente, un equipo internacional e inteligencia artificial.'
-      : 'One patient, an international team, and artificial intelligence.',
+      ? 'Una ingeniera, un equipo internacional e inteligencia artificial.'
+      : 'An engineer, an international team, and artificial intelligence.',
 })
 
 defineOgImage('Default.takumi', {
   title: () => t('team.title'),
   description: () =>
     locale.value === 'es'
-      ? 'Una paciente, un equipo internacional e IA.'
-      : 'One patient, an international team, and AI.',
+      ? 'Una ingeniera, un equipo internacional e IA.'
+      : 'An engineer, an international team, and AI.',
 })
 </script>

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -691,7 +691,7 @@
   },
   "team": {
     "title": "The team",
-    "subtitle": "One patient, an international team and artificial intelligence, searching for the therapy that standard oncology doesn't yet consider.",
+    "subtitle": "An engineer, an international team and artificial intelligence, searching for the therapy that standard oncology doesn't yet consider.",
     "medical_support_network": "Medical support network",
     "more": "Details",
     "less": "Hide",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -418,7 +418,7 @@
     "privacy_notice": "Your data is only used to respond to your message. It is not shared with third parties."
   },
   "footer": {
-    "disclaimer": "This site is an informational resource maintained by the patient's support team. It does not replace professional medical advice.",
+    "disclaimer": "This site is an informational resource maintained by Miriam's support team. It does not replace professional medical advice.",
     "updated": "Last updated",
     "month_updated": "June",
     "nav_heading": "Navigation",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -441,7 +441,7 @@
     "privacy_notice": "Tus datos solo se usan para responder a tu mensaje. No se comparten con terceros."
   },
   "footer": {
-    "disclaimer": "Este sitio es un recurso informativo mantenido por el equipo de apoyo de la paciente. No sustituye asesoramiento médico profesional.",
+    "disclaimer": "Este sitio es un recurso informativo mantenido por el equipo de apoyo de Miriam. No sustituye asesoramiento médico profesional.",
     "updated": "Última actualización",
     "month_updated": "junio de",
     "nav_heading": "Navegación",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -353,7 +353,7 @@
   },
   "team": {
     "title": "El equipo",
-    "subtitle": "Una paciente, un equipo internacional e inteligencia artificial buscando la terapia que la oncología convencional aún no contempla.",
+    "subtitle": "Una ingeniera, un equipo internacional e inteligencia artificial buscando la terapia que la oncología convencional aún no contempla.",
     "miriam_team": "El equipo de Miriam",
     "medical_support_network": "Red médica de apoyo",
     "more": "Ver detalle",


### PR DESCRIPTION
## Qué

«paciente» como identidad de Miriam **viola el guardarraíl de marca** (es activa, ingeniera, no «paciente»). Este PR lo limpia en los **tres** sitios donde el copy/SEO de la web la etiquetaba así.

## Cambios

**1. Footer — `footer.disclaimer` (i18n ES+EN)**
ES: «…equipo de apoyo de **la paciente**» → «…de **Miriam**» · EN: «…**the patient's** support team» → «…**Miriam's** support team».

**2. Subtítulo de «El equipo» — `team.subtitle` (i18n ES+EN)**
ES: «**Una paciente**, un equipo internacional e IA…» → «**Una ingeniera**…» · EN: «**One patient**…» → «**An engineer**…».

**3. Meta SEO de /equipo — hardcodeado en `app/pages/equipo.vue`**
`og:description`, `twitter:description` y la descripción de la og-image decían «**Una paciente**»/«**One patient**» → «**Una ingeniera**»/«**An engineer**». (Esto es lo que ve Google y las tarjetas al compartir en redes.)

## Auditoría
Barridos los locales (17 usos) y TODOS los `.vue`. El resto de «paciente»/«patient» son legítimos y NO se tocan: otros pacientes, la categoría de visitante «Paciente/familiar» y `role=patient`, la definición clínica de un ensayo N-of-1, URLs de prensa externas, comentarios de código y textos anti-PHI. `fact_network_value` (también «Una paciente») lo corrige ya el PR #144 de prensa.

## Gate
Sin merge directo a main — **mergea Miriam** tras revisar la preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)