### PR TITLE
fix(forms): formularios de contacto y seguimiento daban 404 (detección Netlify)

### DIFF
--- a/public/__forms.html
+++ b/public/__forms.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<!--
+  Detección de Netlify Forms para una app Nuxt.
+
+  POR QUÉ EXISTE ESTE FICHERO
+  Netlify registra un formulario solo si lo DETECTA en HTML estático durante el
+  build. Con Nuxt (páginas prerenderizadas/hidratadas) su parser no siempre
+  engancha el <form data-netlify> de la página real, así que los envíos POST a "/"
+  devolvían 404 y la web mostraba "error al enviar" (formularios `contact` y
+  `case-follow`). Este fichero estático en public/ se copia tal cual al deploy y
+  contiene un esqueleto de cada formulario con TODOS sus campos: el parser lo lee,
+  registra los formularios y el POST AJAX desde Vue (a "/") ya funciona.
+
+  REGLAS
+  - Los `name` de los campos deben COINCIDIR exactamente con los del form real
+    (app/pages/contacto.vue y app/components/CaseFollowSignup.vue). Si añades o
+    renombras un campo allí, actualízalo aquí también.
+  - No se enlaza desde ningún sitio y lleva noindex: es solo para el detector.
+-->
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Netlify form detection</title>
+  </head>
+  <body>
+    <!-- Formulario de contacto · app/pages/contacto.vue -->
+    <form name="contact" netlify netlify-honeypot="bot-field" hidden>
+      <input type="hidden" name="form-name" value="contact" />
+      <input type="hidden" name="subject" />
+      <input name="bot-field" />
+      <input type="text" name="name" />
+      <input type="email" name="email" />
+      <select name="role">
+        <option value="oncologist"></option>
+        <option value="researcher"></option>
+        <option value="journalist"></option>
+        <option value="patient"></option>
+        <option value="tech"></option>
+        <option value="other"></option>
+      </select>
+      <textarea name="message"></textarea>
+    </form>
+
+    <!-- Suscripción al caso · app/components/CaseFollowSignup.vue -->
+    <form name="case-follow" netlify netlify-honeypot="bot-field" hidden>
+      <input type="hidden" name="form-name" value="case-follow" />
+      <input name="bot-field" />
+      <input type="email" name="email" />
+      <input type="checkbox" name="consent" />
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
## Problema (verificado en producción)
Los formularios **`contact`** (/contacto) y **`case-follow`** (/ciencia) daban **error al enviar**. Un POST de prueba a `https://helpmiriam.com/` devuelve **HTTP 404**: Netlify **no tiene registrado ningún formulario**, así que el envío AJAX a `/` falla. El marcado `data-netlify` está bien en el HTML servido; lo que falla es la **detección de formularios** de Netlify con páginas Nuxt prerenderizadas.

## Fix
`public/__forms.html`: esqueleto estático de ambos formularios (todos los campos, nombres idénticos a los `.vue`). El parser de Netlify lo lee en build y registra los formularios. **La UI real no cambia.**

## Cómo verificar en la preview
POST de prueba con el honeypot `bot-field` relleno (Netlify lo descarta como spam, no llega correo):
```
curl -s -o /dev/null -w "%{http_code}\n" -X POST <URL-PREVIEW>/ \
  -H "Content-Type: application/x-www-form-urlencoded" \
  --data-urlencode "form-name=contact" --data-urlencode "bot-field=bot" \
  --data-urlencode "name=test" --data-urlencode "email=test@example.com" \
  --data-urlencode "role=tech" --data-urlencode "message=test"
```
- **≠ 404** → arreglado; al mergear queda bien en producción.
- **= 404** → falta activar **"Form detection"** en el panel de Netlify (Project configuration → Forms). Eso es manual (cuenta de Miriam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)