### PR TITLE
fix(copy): quita «paciente» del rol de equipo y del schema jobTitle

### DIFF
--- a/app/pages/prensa.vue
+++ b/app/pages/prensa.vue
@@ -409,7 +409,7 @@ const pressJsonLd = computed(() =>
       '@type': 'Person',
       name: 'Miriam González',
       url: 'https://helpmiriam.com',
-      jobTitle: locale.value === 'es' ? 'Paciente e ingeniera de software' : 'Patient and software engineer',
+      jobTitle: locale.value === 'es' ? 'Ingeniera de software y divulgadora tech' : 'Software engineer and tech communicator',
     },
     audience: {
       '@type': 'Audience',

--- a/content/en/team.yml
+++ b/content/en/team.yml
@@ -1,5 +1,5 @@
 coreTeam:
-  - role: "Patient & founder"
+  - role: "Engineer & founder"
     name: Miriam González
     photo: /img/team/miriam.webp
     featured: true

--- a/content/es/team.yml
+++ b/content/es/team.yml
@@ -1,5 +1,5 @@
 coreTeam:
-  - role: "Paciente y fundadora"
+  - role: "Ingeniera y fundadora"
     name: Miriam González
     photo: /img/team/miriam.webp
     featured: true


### PR DESCRIPTION
Completa el reposicionamiento «paciente» → «ingeniera» en los **2 sitios que #144/#145 no llegaron a tocar**:

- `content/{es,en}/team.yml` → rol de Miriam: «Paciente y fundadora» / «Patient & founder» → **«Ingeniera y fundadora» / «Engineer & founder»**.
- `app/pages/prensa.vue` → JSON-LD `jobTitle` (lo que leen Google y los asistentes de IA): «Patient and software engineer» → **«Software engineer and tech communicator»**.

Solo copy, ramificado sobre el `main` de hoy. **Sustituye al PR #131** (quedó stale/redundante tras #144 y #145; se cierra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
