### PR TITLE
fix(color): alinea stragglers de firma #a44db2 → #9d44ab (AA)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <NuxtLoadingIndicator color="#a44db2" :height="3" />
+  <NuxtLoadingIndicator color="#9d44ab" :height="3" />
   <NuxtLayout>
     <NuxtPage />
   </NuxtLayout>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -280,7 +280,7 @@
     font-variant-numeric: tabular-nums;
   }
   .data-table tbody tr:last-child td { border-bottom: 0; }
-  .data-table tbody tr:hover td { background: rgba(164, 77, 178, 0.04); }
+  .data-table tbody tr:hover td { background: rgba(157, 68, 171, 0.04); }
   .data-table .col-marker {
     @apply font-mono;
     font-size: 13px;
@@ -515,8 +515,8 @@
   .form-input::placeholder { color: rgba(58, 51, 64, 0.55); }
   .form-input:focus {
     outline: none;
-    border-color: #a44db2;
-    box-shadow: 0 0 0 3px rgba(164, 77, 178, 0.18);
+    border-color: #9d44ab;
+    box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.18);
   }
   .form-label {
     @apply block text-sm font-medium text-berenjena mb-1.5;
@@ -653,11 +653,11 @@
   }
   .notes-disclosure > summary:hover,
   .notes-disclosure > summary:focus-visible {
-    color: #a44db2;
+    color: #9d44ab;
     outline: none;
   }
   .notes-disclosure[open] > summary {
-    color: #a44db2;
+    color: #9d44ab;
     margin-bottom: 4px;
   }
   @media (prefers-reduced-motion: reduce) {
@@ -1015,7 +1015,7 @@
     width: 2.25rem;
     height: 2.25rem;
     border-radius: 10px;
-    background: rgba(164, 77, 178, 0.12);
+    background: rgba(157, 68, 171, 0.12);
     color: #2d1b3d;
   }
   .pathway-card__time {
@@ -1095,7 +1095,7 @@
     transition: background 0.15s ease, border-color 0.15s ease;
   }
   .pathway-chip:hover {
-    background: rgba(164, 77, 178, 0.1);
+    background: rgba(157, 68, 171, 0.1);
     border-color: rgba(157, 68, 171, 0.28);
   }
   .pathway-chip__label {
@@ -1140,7 +1140,7 @@
     text-transform: uppercase;
     padding: 0.2rem 0.55rem;
     border-radius: 999px;
-    background: rgba(164, 77, 178, 0.12);
+    background: rgba(157, 68, 171, 0.12);
     color: #2d1b3d;
   }
   .pathway-brief__list {
@@ -1166,7 +1166,7 @@
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 6px;
-    background: rgba(164, 77, 178, 0.14);
+    background: rgba(157, 68, 171, 0.14);
     font-family: 'JetBrains Mono', monospace;
     font-size: 11px;
     font-weight: 700;

--- a/app/components/OgImage/Default.takumi.vue
+++ b/app/components/OgImage/Default.takumi.vue
@@ -30,7 +30,7 @@ defineProps({
     <!-- Text column -->
     <div class="flex flex-col justify-center h-full" style="padding: 60px; gap: 24px; flex: 1;">
       <div class="flex items-center" style="gap: 12px;">
-        <div style="width: 32px; height: 4px; background-color: #a44db2;" />
+        <div style="width: 32px; height: 4px; background-color: #9d44ab;" />
         <span
           style="font-family: 'JetBrains Mono', monospace; font-size: 18px; letter-spacing: 0.16em; text-transform: uppercase; color: #6b5a78;"
         >
@@ -58,7 +58,7 @@ defineProps({
         <span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; color: #2d1b3d;">
           Miriam González · 35
         </span>
-        <span style="color: #a44db2;">·</span>
+        <span style="color: #9d44ab;">·</span>
         <span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; color: #5a4a68;">
           BC-NED · FGFR1 ×13 · SSTR2+
         </span>

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -69,7 +69,7 @@
           <span
             aria-hidden="true"
             class="absolute left-[10px] top-2 bottom-3 w-[2px] rounded-full"
-            style="background: linear-gradient(180deg, #a44db2 0%, rgba(164,77,178,0.15) 100%)"
+            style="background: linear-gradient(180deg, #9d44ab 0%, rgba(157, 68, 171,0.15) 100%)"
           />
           <!-- key=selected → al filtrar, el bloque se remonta y reproduce un fundido
                CSS limpio (evita el estado atascado de <Transition mode="out-in">


### PR DESCRIPTION
## Qué

El token `miriam.DEFAULT` **ya estaba en `#9d44ab`** en producción (AA-normal sobre crema *y* tarjeta elevada; `#a44db2` solo AA-large). Este PR alinea los **7 usos a fuego** de `#a44db2` que quedaban, todos en **contexto claro** (verificado, sin trampa de fondo oscuro):

- Barra de carga (`app.vue`)
- Foco de formularios + tintes de `data-table` / `pathway` (`main.css`)
- Acentos de las imágenes OG sociales (`OgImage/Default.takumi.vue`)
- Gradiente de la espina del timeline (`timeline.vue`)

También sus `rgba(164,77,178,…)` equivalentes → `rgba(157,68,171,…)`.

## Autoridad
Violeta = **muro de Ceci**. `#9d44ab` lo dictó su **MCP** (`check_contrast`): 5.07:1 crema / 4.77:1 tarjeta elevada = AA-normal en ambas. Ratificación humana de Ceci: aceptada por Miriam.

## Fuera de scope (cleanup aparte, pendiente de decisión)
- Scale legacy `500: #a44db2` en `tailwind.config.js`.
- 28 usos de `#a855b5` (otro violeta viejo).

## Cómo revisar
Preview de Netlify → foco de un input, hover de una fila de tabla, timeline, y una imagen OG. El cambio es sutil (los dos violetas son casi idénticos); el objetivo es contraste AA + una sola firma.