### PR TITLE
Anonimizar nombre del hospital en superficie pública (GATE-1)

### DIFF
--- a/app/components/MolecularProfileDetailed.vue
+++ b/app/components/MolecularProfileDetailed.vue
@@ -74,8 +74,8 @@
       <p class="mt-3 text-xs text-tinta leading-relaxed font-mono">
         {{
           locale === 'es'
-            ? 'Fuentes: TSO500 sobre tejido FFPE primario (DIPCAN, MD Anderson Madrid, 2024) · IHQ sobre tejido primario · ctDNA Guardant360 / VHIO360 (abril–mayo 2026) · PET-CT Galio-68 DOTATOC (Virgen de la Arrixaca, mayo 2026).'
-            : 'Sources: TSO500 on primary FFPE tissue (DIPCAN, MD Anderson Madrid, 2024) · IHC on primary tissue · Guardant360 / VHIO360 ctDNA (April–May 2026) · Ga-68 DOTATOC PET-CT (Virgen de la Arrixaca, May 2026).'
+            ? 'Fuentes: TSO500 sobre tejido FFPE primario (DIPCAN, MD Anderson Madrid, 2024) · IHQ sobre tejido primario · ctDNA Guardant360 / VHIO360 (abril–mayo 2026) · PET-CT Galio-68 DOTATOC (centro hospitalario, mayo 2026).'
+            : 'Sources: TSO500 on primary FFPE tissue (DIPCAN, MD Anderson Madrid, 2024) · IHC on primary tissue · Guardant360 / VHIO360 ctDNA (April–May 2026) · Ga-68 DOTATOC PET-CT (hospital centre, May 2026).'
         }}
       </p>
       <p class="mt-2 text-xs text-tinta leading-relaxed">

--- a/app/pages/mapa-metastasis.vue
+++ b/app/pages/mapa-metastasis.vue
@@ -4,8 +4,8 @@
  *
  * Reúne y visualiza fuentes propias de la paciente, sin interpretación añadida
  * más allá de lo que dicen los informes:
- *  - PET-CT ¹⁸F-FDG (Virgen de la Arrixaca, 24/03/2026)
- *  - PET-CT ⁶⁸Ga-DOTATOC (Virgen de la Arrixaca, 26/05/2026)
+ *  - PET-CT ¹⁸F-FDG (centro hospitalario, 24/03/2026)
+ *  - PET-CT ⁶⁸Ga-DOTATOC (centro hospitalario, 26/05/2026)
  *  - RMN de columna cervical y dorsal (11/06/2026)
  * Las imágenes se reconstruyen a partir de los DICOM de esos mismos estudios.
  * Herramienta de comprensión y apoyo a la conversación clínica — no es consejo médico.
@@ -286,7 +286,7 @@ const LES: Lesion[] = [
 /*  · trazador — '18F-FDG' | '68Ga-DOTATOC' | '' (no aplica)               */
 /*  · fuente   — PROCEDENCIA, una de:                                       */
 /*       'informe'              → consta en el informe oficial de Medicina  */
-/*                                Nuclear (H. Virgen de la Arrixaca).        */
+/*                                Nuclear (centro hospitalario).        */
 /*       'dicom-medicion-david' → re-cuantificación asistida sobre el DICOM */
 /*                                nativo (SUV con corrección de decaimiento, */
 /*                                máscara ósea del CT). Verificación, NO     */
@@ -2167,7 +2167,7 @@ const MANIFEST_SCHEMA = {
     medido: 'true = MEDIDO (cantidad física) · false = INTERPRETADO (lectura/regla)',
   },
   fuentes: {
-    informe: 'informe oficial de Medicina Nuclear (H. Virgen de la Arrixaca)',
+    informe: 'informe oficial de Medicina Nuclear (centro hospitalario)',
     'dicom-medicion-david': 're-cuantificación asistida sobre el DICOM nativo (verificación, no diagnóstico)',
     'rmn-literal': 'texto literal del informe de RMN de columna (11/06/2026)',
     derivado: 'calculado por la página (heurístico/regla: score, fenotipo, Δ)',
@@ -4257,8 +4257,8 @@ const manifestValidated = (() => {
           <summary>{{ L('Fuentes, método y salvedades', 'Sources, method and caveats') }}</summary>
           <p class="mt-3 text-xs text-tinta leading-relaxed font-mono">
             {{ L(
-              'Fuentes. SUV y localizaciones: informe PET-CT ¹⁸F-FDG 24/03/2026 e informe PET-CT ⁶⁸Ga-DOTATOC 26/05/2026 (Medicina Nuclear, H. Virgen de la Arrixaca). Imágenes PET: MIP, fusión sagital y cortes axiales reconstruidos de los DICOM (PET con corrección de atenuación + TC). RMN: cortes sagitales de columna cervical y dorsal (STIR y T1) exportados de los DICOM; solo para visualización, pendientes de lectura radiológica formal. Los SUV recalculados de los DICOM concuerdan con el informe dentro de ~10–12% (diferencia esperable voxel-máx ↔ ROI).',
-              'Sources. SUV and locations: ¹⁸F-FDG PET-CT report 24/03/2026 and ⁶⁸Ga-DOTATOC PET-CT report 26/05/2026 (Nuclear Medicine, Virgen de la Arrixaca Hospital). PET images: MIP, sagittal fusion and axial slices reconstructed from the DICOM (attenuation-corrected PET + CT). MRI: sagittal cervical and thoracic spine slices (STIR and T1) exported from the DICOM; visualization only, pending formal radiology reading. SUVs recomputed from the DICOM agree with the report within ~10–12% (expected voxel-max ↔ ROI difference).') }}
+              'Fuentes. SUV y localizaciones: informe PET-CT ¹⁸F-FDG 24/03/2026 e informe PET-CT ⁶⁸Ga-DOTATOC 26/05/2026 (Medicina Nuclear, centro hospitalario). Imágenes PET: MIP, fusión sagital y cortes axiales reconstruidos de los DICOM (PET con corrección de atenuación + TC). RMN: cortes sagitales de columna cervical y dorsal (STIR y T1) exportados de los DICOM; solo para visualización, pendientes de lectura radiológica formal. Los SUV recalculados de los DICOM concuerdan con el informe dentro de ~10–12% (diferencia esperable voxel-máx ↔ ROI).',
+              'Sources. SUV and locations: ¹⁸F-FDG PET-CT report 24/03/2026 and ⁶⁸Ga-DOTATOC PET-CT report 26/05/2026 (Nuclear Medicine, hospital centre). PET images: MIP, sagittal fusion and axial slices reconstructed from the DICOM (attenuation-corrected PET + CT). MRI: sagittal cervical and thoracic spine slices (STIR and T1) exported from the DICOM; visualization only, pending formal radiology reading. SUVs recomputed from the DICOM agree with the report within ~10–12% (expected voxel-max ↔ ROI difference).') }}
           </p>
           <p class="mt-2 text-xs text-tinta leading-relaxed font-mono">
             {{ L(


### PR DESCRIPTION
## Qué

Sustituye el nombre del hospital ("H. Virgen de la Arrixaca" / "Virgen de la Arrixaca Hospital") por una fórmula genérica —"centro hospitalario" (ES) / "hospital centre" (EN)— en **todo lo que se renderiza al público**, más los comentarios del código.

## Por qué

Nombrar una institución en material público sin permiso trazado va contra la regla de marca. Decisión de Miriam (GATE-1): anonimizar ahora; es **reversible** (se restaura el nombre si se confirma el consentimiento institucional).

## Dónde (6 renderizadas + 3 comentarios)

- `app/pages/mapa-metastasis.vue` — bloque de fuentes ES (`:4260`) y EN (`:4261`), objeto `informe` (`:2170`) + comentarios (`:7,8,289`).
- `app/components/MolecularProfileDetailed.vue` — fuentes ES (`:77`) y EN (`:78`). **Esta 6ª aparición no estaba en la auditoría inicial**; se encontró barriendo todo `app/`.

Verificado: `grep -rn Arrixaca app/` = 0 apariciones. Solo cambian strings dentro de comillas existentes (sin cambios de lógica/sintaxis).

Nota: quedan menciones en docs internos no desplegados (`HANDOFF-mapa-3D-pipeline.md`, `CONTENT-REPO.md`) — fuera de alcance por no ser superficie pública.

🤖 Generated with [Claude Code](https://claude.com/claude-code)