### PR TITLE
chore(design-system): scrub de datos reales (privacidad + perfil de ejemplo)

### DIFF
--- a/public/design-system/index.html
+++ b/public/design-system/index.html
@@ -1127,7 +1127,7 @@
                   line-height: 1.15;
                 "
               >
-                Necesitamos 30.000€ más.
+                Necesitamos 12.345 € más.
               </h4>
               <p
                 style="
@@ -3275,8 +3275,8 @@
               "
             >
               <div class="show-meta" style="color: #faf6f0">Cifra de campaña · coral sobre berenjena</div>
-              <div class="stat-number stat-number--cta">32.383&nbsp;€</div>
-              <div class="stat-label" style="color: #faf6f0">Recaudado · 1.247 personas</div>
+              <div class="stat-number stat-number--cta">12.345&nbsp;€</div>
+              <div class="stat-label" style="color: #faf6f0">Recaudado · 850 personas</div>
             </div>
             <div>
               <div class="show-meta">Cifra neutra · berenjena</div>
@@ -3449,7 +3449,7 @@
                 class="sample"
                 style="border-left-color: var(--color-miriam)"
               >
-                "<strong>Necesitamos</strong> 30.000€ más para la siguiente
+                "<strong>Necesitamos</strong> 12.345 € más para la siguiente
                 prueba molecular."
               </div>
               <p
@@ -3790,7 +3790,7 @@
                 <li>biopsia · informe AP · perfil molecular</li>
                 <li>FGFR1, Ki67, BC-NED, MAPK</li>
                 <li>cifras: "×13", "60%", "8 meses"</li>
-                <li>nombres: Miriam, Paola, Víctor, Vall d'Hebron</li>
+                <li>nombres: Miriam, y los de su equipo, médicos y hospital</li>
                 <li>"acceso a tratamiento", "ensayo clínico"</li>
               </ul>
             </div>
@@ -4183,8 +4183,7 @@ Style (aligned with existing team set):
   coral <span class="c-val">#FF6B47</span> if medical/operations team.
 — Optional small handwritten role label below the portrait.
 
-Mandatory reference: see existing portraits of Miriam, Paola, Víctor,
-Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
+Mandatory reference: see existing portraits of Miriam and her team. Same level of detail. Same line work.</pre>
 
           <h3 style="margin-top: 40px">
             Cuándo NO generar — pedir o dibujar a mano
@@ -4362,9 +4361,9 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               >. Los lectores de pantalla son ciudadanos de primera.
             </li>
             <li>
-              <strong>Imágenes con alt descriptivo</strong>: el avatar de Paola
-              no es "imagen 1", es "Paola — investigadora molecular, sosteniendo
-              viales con DNA y Cas9".
+              <strong>Imágenes con alt descriptivo</strong>: el avatar de una
+              investigadora no es "imagen 1", es "investigadora molecular,
+              sosteniendo viales con DNA y Cas9".
             </li>
             <li>
               <strong>Cifras con contexto leíble</strong>: "FGFR1 ×13" se lee
@@ -4684,8 +4683,8 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
               que rehacer 3 horas.
             </li>
             <li>
-              Los <strong>textos clínicos</strong> los firma siempre Paola antes
-              de publicarse. Sin excepción.
+              Los <strong>textos clínicos</strong> los firma siempre la revisora
+              clínica del equipo antes de publicarse. Sin excepción.
             </li>
             <li>
               Los textos en primera persona los firma siempre
@@ -6093,7 +6092,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 diseño. En febrero de 2026 le diagnostican cáncer de mama
                 metastásico. Tras varias líneas de tratamiento estándar, el
                 tumor responde mal — lo que la oncología llama "refractario". El
-                informe AP de Vall d'Hebron añade un detalle que cambia todo: el
+                informe AP del hospital de referencia añade un detalle que cambia todo: el
                 tumor presenta una amplificación FGFR1 de ×13 sobre un subtipo
                 BC-NED. La combinación está documentada solo cuatro veces en la
                 literatura científica internacional, lo que convierte su caso en
@@ -6105,7 +6104,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 molecularmente dirigido. La web documenta cada paso con rigor
                 clínico, total transparencia financiera y voz directa, sin
                 retórica de "lucha" ni victimismo. La meta de la primera fase:
-                80.000€ para la siguiente prueba molecular y consulta
+                12.345 € para la siguiente prueba molecular y consulta
                 internacional.
               </p>
             </div>
@@ -6306,7 +6305,7 @@ Alejandro, Ceci, Alby, Alba. Same level of detail. Same line work.</pre>
                 margin-bottom: 4px;
               "
             >
-              [designar a alguien] · prensa
+              [Nombre] · prensa
             </div>
             <div style="font-size: 14px; color: var(--color-text)">
               <a
@@ -6368,7 +6367,7 @@ no es una respuesta automática, lo escribo yo desde casa.
 
 Cada euro entra en una cuenta auditada que verás reflejada en
 helpmiriam.com → Transparencia. Cuando alcancemos el primer
-hito (80.000 €) te avisaré por aquí con lo que hayamos podido
+hito ([<span class="c-val">meta</span>] €) te avisaré por aquí con lo que hayamos podido
 hacer con él.
 
 Si quieres saber algo concreto del caso, responde a este email
@@ -6393,17 +6392,17 @@ Miriam<span class="c-com">.</span></pre>
           <pre class="code" style="margin-top: 8px">
 <span class="c-com">Post / update:</span>
 
-Hemos llegado a los 80.000 €.
+Hemos llegado a los [<span class="c-val">meta</span>] €.
 
-1.247 personas han donado. Es la cifra más concreta que puedo
+[<span class="c-val">N</span>] personas han donado. Es la cifra más concreta que puedo
 darte hoy. Con ese dinero pagamos:
 
-— La siguiente prueba molecular en Vall d'Hebron (32.000 €)
-— La consulta internacional con [<span class="c-val">centro</span>] (18.000 €)
-— Reserva para la primera dosis del tratamiento (30.000 €)
+— La siguiente prueba molecular en [<span class="c-val">centro hospitalario</span>] ([<span class="c-val">importe</span>] €)
+— La consulta internacional con [<span class="c-val">centro</span>] ([<span class="c-val">importe</span>] €)
+— Reserva para la primera dosis del tratamiento ([<span class="c-val">importe</span>] €)
 
-El plazo de la ventana clínica sigue siendo de seis semanas.
-La siguiente meta es 130.000 € — desglose detallado en
+El plazo de la ventana clínica sigue siendo de [<span class="c-val">N</span>] semanas.
+La siguiente meta es [<span class="c-val">meta</span>] € — desglose detallado en
 helpmiriam.com.
 
 Gracias por estar aquí.</pre>
@@ -6433,7 +6432,7 @@ Hemos visto su trabajo en [<span class="c-val">paper / línea de investigación<
 gustaría someter el caso a su criterio. Adjuntamos:
 
 — Informe AP completo
-— Perfil molecular con anotaciones de [<span class="c-val">Dra. Paola</span>]
+— Perfil molecular con anotaciones de [<span class="c-val">especialista</span>]
 — Resumen del recorrido clínico hasta la fecha (2 páginas)
 
 Si dispone de 30 minutos para una llamada en las próximas dos
@@ -6464,8 +6463,8 @@ prensa@helpmiriam.com / +34 [<span class="c-val">tel</span>]</pre>
 Mañana me hacen la siguiente analítica. Es de control,
 no de decisión, así que no espero noticias grandes.
 
-Me da tiempo a contaros que hemos pasado los 70.000 €
-(faltan 10 para el primer hito), que la consulta con
+Me da tiempo a contaros que hemos pasado los [<span class="c-val">importe</span>] €
+(faltan [<span class="c-val">N</span>] para el primer hito), que la consulta con
 [<span class="c-val">especialista</span>] ya está pedida, y que llevo dos días
 durmiendo seis horas seguidas — pequeño récord.
 
@@ -6627,8 +6626,7 @@ Equipo Miriam<span class="c-com">.</span></pre>
             uso.
           </p>
           <p style="margin-top: 16px">
-            helpmiriam.com · @miriamgonp · gofund.me/3e25cae99 ·
-            miriamgonp@gmail.com
+            helpmiriam.com · @miriamgonp · gofund.me/3e25cae99
           </p>
           <p
             style="

--- a/public/design-system/index.html
+++ b/public/design-system/index.html
@@ -343,8 +343,8 @@
               textura viene de la tinta y el grano del papel.
             </li>
             <li>
-              <strong>Datos siempre con cifra absoluta</strong> (Ki67 60%, FGFR1
-              ×13). Nunca redondear, nunca "alto".
+              <strong>Datos siempre con cifra absoluta</strong> (PLX9 42%, XLR2
+              ×9). Nunca redondear, nunca "alto".
             </li>
             <li>
               <strong>WCAG 2.2 AA mínimo</strong>. Toque mínimo 44 px. Foco
@@ -401,7 +401,7 @@
               <div class="num">01 — Base</div>
               <h4>Datos</h4>
               <p>
-                BC-NED, FGFR1 ×13, neuroendocrino ~80%, Ki67 60%. La ciencia se
+                BC-SCC, XLR2 ×9, escamoso ~35%, PLX9 42%. La ciencia se
                 cuenta sin diluir.
               </p>
               <div class="quote">"Esto es real y serio."</div>
@@ -657,7 +657,7 @@
                   <span>#E8D4ED</span><span>232 · 212 · 237</span>
                 </div>
                 <p>
-                  Badges con marcadores genómicos (FGFR1 ×13), callouts
+                  Badges con marcadores genómicos (XLR2 ×9), callouts
                   identitarios.
                 </p>
               </div>
@@ -780,7 +780,7 @@
                   line-height: 1;
                 "
               >
-                ×13
+                ×9
               </div>
               <div
                 style="
@@ -790,7 +790,7 @@
                   margin-top: 8px;
                 "
               >
-                FGFR1 amplificación
+                XLR2 amplificación
               </div>
               <div
                 style="
@@ -820,7 +820,7 @@
                   line-height: 1;
                 "
               >
-                60%
+                42%
               </div>
               <div
                 style="
@@ -830,7 +830,7 @@
                   margin-top: 8px;
                 "
               >
-                Ki67 proliferación
+                PLX9 proliferación
               </div>
               <div
                 style="
@@ -1084,8 +1084,8 @@
                   margin: 0;
                 "
               >
-                El informe AP confirma BC-NED con amplificación FGFR1 ×13. Caso
-                documentado solo 4 veces en literatura.
+                El informe AP confirma BC-SCC con amplificación XLR2 ×9. Un
+                perfil molecular poco frecuente en la literatura.
               </p>
               <div
                 style="
@@ -2005,7 +2005,7 @@
               <span>Display</span><b>Fraunces 600</b
               ><span>96 / -0.05em / 1.05</span>
             </div>
-            <div class="glyph">FGFR1 ×13.</div>
+            <div class="glyph">XLR2 ×9.</div>
           </div>
           <div class="specimen h2">
             <div class="meta">
@@ -2027,7 +2027,7 @@
             </div>
             <div class="glyph">
               Miriam tiene 35 años y un cáncer de mama metastásico con
-              diferenciación neuroendocrina ~80% y amplificación FGFR1 ×13. Su
+              diferenciación escamosa atípica ~35% y amplificación XLR2 ×9. Su
               tumor no responde a los tratamientos estándar. Un equipo
               internacional busca, con ayuda de IA, una terapia que la oncología
               convencional no contempla.
@@ -2047,14 +2047,14 @@
               <span>Datos científicos</span><b>JetBrains Mono 500</b
               ><span>22 / 0 / 1.5</span>
             </div>
-            <div class="glyph">FGFR1 ×13 · CCND1 ×20 · Ki67 60% · BC-NED</div>
+            <div class="glyph">XLR2 ×9 · PPB6 ×6 · PLX9 42% · BC-SCC</div>
           </div>
           <div class="specimen stat">
             <div class="meta">
               <span>Cifra firma</span><b>Fraunces 600</b
               ><span>120 / -0.06em / 0.95</span>
             </div>
-            <div class="glyph" style="color: var(--color-miriam)">×13</div>
+            <div class="glyph" style="color: var(--color-miriam)">×9</div>
           </div>
 
           <h3>Por qué esta combinación</h3>
@@ -2622,7 +2622,7 @@
             >
               <img
                 src="assets/miriam-avatar.png"
-                alt="Avatar Miriam — ilustración a tinta con pelo violeta, gafas redondas, anotaciones científicas FGFR1×13 y neuroendocrine cell cluster"
+                alt="Avatar Miriam — ilustración a tinta con pelo violeta, gafas redondas, anotaciones científicas XLR2×9 y squamous cell cluster"
                 style="display: block; width: 100%; height: auto"
               />
             </div>
@@ -2736,7 +2736,7 @@
                   font-size="14"
                 >
                   <text x="20" y="155" transform="rotate(-8 20 155)">
-                    FGFR1 ×13
+                    XLR2 ×9
                   </text>
                   <path
                     d="M 65 155 Q 50 175, 60 195"
@@ -2746,7 +2746,7 @@
                     marker-end="url(#a)"
                   />
                   <text x="240" y="180" transform="rotate(6 240 180)">
-                    BC-NED
+                    BC-SCC
                   </text>
                   <path
                     d="M 240 185 Q 230 200, 220 195"
@@ -3085,7 +3085,7 @@
               max-width: 64ch;
             "
           >
-            El caso entero descansa entre dos polos — la ciencia (FGFR1, Ki67,
+            El caso entero descansa entre dos polos — la ciencia (XLR2, PLX9,
             biopsias) y la persona (sus rizos, sus gatos, su humor). El favicon
             necesitaba el guiño personal sin caer en literalidad. Una
             constelación mínima resuelve ambas: cosmos = esperanza sin ser
@@ -3262,9 +3262,9 @@
           <div class="show" style="gap: 64px; align-items: flex-end">
             <div>
               <div class="show-meta">Cifra firma · violeta</div>
-              <div class="stat-number stat-number--firma">×13</div>
+              <div class="stat-number stat-number--firma">×9</div>
               <div class="stat-label">
-                Amplificación FGFR1 detectada en biopsia
+                Amplificación XLR2 detectada en biopsia
               </div>
             </div>
             <div
@@ -3280,8 +3280,8 @@
             </div>
             <div>
               <div class="show-meta">Cifra neutra · berenjena</div>
-              <div class="stat-number">~80%</div>
-              <div class="stat-label">Diferenciación neuroendocrina</div>
+              <div class="stat-number">~35%</div>
+              <div class="stat-label">Diferenciación escamosa atípica</div>
             </div>
           </div>
 
@@ -3289,11 +3289,11 @@
             <div class="show-meta" style="width: 100%">
               Badge marcador genómico · JetBrains Mono
             </div>
-            <span class="badge-genomic">FGFR1 ×13</span>
-            <span class="badge-genomic">CCND1 ×20</span>
-            <span class="badge-genomic">FGF3/4/19</span>
-            <span class="badge-genomic">Ki67 60%</span>
-            <span class="badge-genomic">BC-NED</span>
+            <span class="badge-genomic">XLR2 ×9</span>
+            <span class="badge-genomic">PPB6 ×6</span>
+            <span class="badge-genomic">XLRL1/2/5</span>
+            <span class="badge-genomic">PLX9 42%</span>
+            <span class="badge-genomic">BC-SCC</span>
           </div>
 
           <h3>Snippet</h3>
@@ -3322,7 +3322,7 @@
             <div class="card" style="max-width: 480px">
               <div class="eyebrow" style="margin-bottom: 12px">Diagnóstico</div>
               <h3 style="border: 0; padding: 0; margin: 0 0 12px">
-                Cáncer de mama metastásico con diferenciación neuroendocrina
+                Cáncer de mama metastásico con diferenciación escamosa atípica
               </h3>
               <p
                 style="
@@ -3335,13 +3335,13 @@
                 <span
                   class="badge-genomic"
                   style="font-size: 12px; padding: 2px 8px"
-                  >BC-NED</span
+                  >BC-SCC</span
                 >
-                y amplificación múltiple del receptor FGFR1.
+                y amplificación múltiple del receptor XLR2.
               </p>
               <div style="display: flex; gap: 8px; flex-wrap: wrap">
-                <span class="badge-genomic">FGFR1 ×13</span>
-                <span class="badge-genomic">Ki67 60%</span>
+                <span class="badge-genomic">XLR2 ×9</span>
+                <span class="badge-genomic">PLX9 42%</span>
               </div>
             </div>
           </div>
@@ -3366,30 +3366,30 @@
               </thead>
               <tbody>
                 <tr>
-                  <td><span class="marker">FGFR1</span></td>
-                  <td><span class="marker">×13</span></td>
+                  <td><span class="marker">XLR2</span></td>
+                  <td><span class="marker">×9</span></td>
                   <td>
                     Amplificación de alto nivel · diana terapéutica candidata
                   </td>
                 </tr>
                 <tr>
-                  <td><span class="marker">CCND1</span></td>
-                  <td><span class="marker">×20</span></td>
-                  <td>Co-amplificación 11q13 · proliferación elevada</td>
+                  <td><span class="marker">PPB6</span></td>
+                  <td><span class="marker">×6</span></td>
+                  <td>Co-amplificación 7p21 · proliferación elevada</td>
                 </tr>
                 <tr>
-                  <td><span class="marker">FGF3 / FGF4 / FGF19</span></td>
+                  <td><span class="marker">XLRL1 / XLRL2 / XLRL5</span></td>
                   <td><span class="marker">amp</span></td>
-                  <td>Ligandos del eje FGFR · activación autocrina</td>
+                  <td>Ligandos del eje XLR · activación autocrina</td>
                 </tr>
                 <tr>
-                  <td><span class="marker">Dif. neuroendocrina</span></td>
-                  <td><span class="marker">~80%</span></td>
-                  <td>Subtipo BC-NED · sin protocolo estándar</td>
+                  <td><span class="marker">Dif. escamosa atípica</span></td>
+                  <td><span class="marker">~35%</span></td>
+                  <td>Subtipo BC-SCC · sin protocolo estándar</td>
                 </tr>
                 <tr>
-                  <td><span class="marker">Ki67</span></td>
-                  <td><span class="marker">60%</span></td>
+                  <td><span class="marker">PLX9</span></td>
+                  <td><span class="marker">42%</span></td>
                   <td>Proliferación alta</td>
                 </tr>
               </tbody>
@@ -3413,7 +3413,7 @@
               <h4>Tercera persona</h4>
               <div class="sample">
                 "Miriam tiene cáncer de mama metastásico con diferenciación
-                neuroendocrina."
+                escamosa atípica."
               </div>
               <div class="sample">
                 "Su tumor no responde a los tratamientos estándar."
@@ -3472,7 +3472,7 @@
               <div class="surf">🩺 Documentos clínicos</div>
               <h4>Tercera persona técnica</h4>
               <div class="sample">
-                "La paciente presenta amplificación FGFR1 ×13."
+                "La paciente presenta amplificación XLR2 ×9."
               </div>
               <div class="sample">
                 "Se confirma progresión ósea en estudio de mayo."
@@ -3754,7 +3754,7 @@
           </p>
           <pre class="code">
 <span class="c-com">Contexto: caso Miriam González — paciente real con cáncer de mama metastásico</span>
-<span class="c-com">refractario y un perfil molecular único (FGFR1 ×13, BC-NED). Web personal,</span>
+<span class="c-com">refractario y un perfil molecular único (XLR2 ×9, BC-SCC). Web personal,</span>
 <span class="c-com">no es ONG ni campaña corporativa. Pide ayuda concreta para acceder a un</span>
 <span class="c-com">tratamiento experimental. Audiencia: lectores adultos, posiblemente</span>
 <span class="c-com">pacientes oncológicos o familiares.</span>
@@ -3767,8 +3767,8 @@
 <span class="c-key">Prohibido</span>: "luchadora", "guerrera", "guerrera contra el cáncer",
             "valiente", "inspiración", "viaje", "empoderamiento",
             "juntos podemos", emojis, exclamaciones.
-<span class="c-key">Permitido</span>: cifras crudas, términos clínicos exactos (FGFR1, Ki67,
-            BC-NED), fechas concretas, nombres propios.</pre>
+<span class="c-key">Permitido</span>: cifras crudas, términos clínicos exactos (XLR2, PLX9,
+            BC-SCC), fechas concretas, nombres propios.</pre>
 
           <h3 style="margin-top: 40px">Reglas duras de léxico</h3>
           <div
@@ -3788,8 +3788,8 @@
               >
                 <li>amplificación · expresión · refractario</li>
                 <li>biopsia · informe AP · perfil molecular</li>
-                <li>FGFR1, Ki67, BC-NED, MAPK</li>
-                <li>cifras: "×13", "60%", "8 meses"</li>
+                <li>XLR2, PLX9, BC-SCC, XLR</li>
+                <li>cifras: "×9", "42%", "5 meses"</li>
                 <li>nombres: Miriam, y los de su equipo, médicos y hospital</li>
                 <li>"acceso a tratamiento", "ensayo clínico"</li>
               </ul>
@@ -4136,8 +4136,8 @@ versions of the same idea.</pre>
 [<span class="c-com">visual DNA block above</span>]
 
 Generate an illustration for: [<span class="c-val">describe the scene —</span>
-<span class="c-val">"a microscope with a tissue sample labeled FGFR1, handwritten</span>
-<span class="c-val">annotations around it explaining ×13 amplification"</span>].
+<span class="c-val">"a microscope with a tissue sample labeled XLR2, handwritten</span>
+<span class="c-val">annotations around it explaining ×9 amplification"</span>].
 Framing: 3:2 horizontal or 4:5 vertical depending on use.
 Output: 2000 px long edge, cream background <span class="c-val">#FAF6F0</span>.
 
@@ -4366,8 +4366,8 @@ Mandatory reference: see existing portraits of Miriam and her team. Same level o
               sosteniendo viales con DNA y Cas9".
             </li>
             <li>
-              <strong>Cifras con contexto leíble</strong>: "FGFR1 ×13" se lee
-              como "FGFR1 amplificado trece veces". Añadir
+              <strong>Cifras con contexto leíble</strong>: "XLR2 ×9" se lee
+              como "XLR2 amplificado nueve veces". Añadir
               <code style="font-family: var(--font-mono); font-size: 12px"
                 >aria-label</code
               >
@@ -5958,8 +5958,8 @@ Mandatory reference: see existing portraits of Miriam and her team. Same level o
                 "
               >
                 Miriam González (35, Murcia) tiene un cáncer de mama metastásico
-                refractario con un perfil molecular único: amplificación FGFR1
-                ×13 sobre BC-NED, documentado solo cuatro veces en literatura.
+                refractario con un perfil molecular único: amplificación XLR2
+                ×9 sobre BC-SCC, poco frecuente en la literatura.
                 Busca financiar el acceso a un tratamiento experimental fuera
                 del SNS.
               </p>
@@ -6023,8 +6023,8 @@ Mandatory reference: see existing portraits of Miriam and her team. Same level o
                 Miriam González, 35 años, vive en Murcia y tiene cáncer de mama
                 metastásico refractario a las líneas de tratamiento estándar. Su
                 biopsia revela un perfil molecular excepcional — amplificación
-                FGFR1 ×13 sobre un subtipo BC-NED — que aparece descrito apenas
-                cuatro veces en la literatura científica internacional. Junto
+                XLR2 ×9 sobre un subtipo BC-SCC — poco habitual en la
+                literatura científica internacional. Junto
                 con un equipo de doce especialistas y la sub-marca Beyond the
                 Protocol, ha lanzado una iniciativa para financiar el acceso a
                 un tratamiento experimental no cubierto por el sistema público.
@@ -6093,8 +6093,8 @@ Mandatory reference: see existing portraits of Miriam and her team. Same level o
                 metastásico. Tras varias líneas de tratamiento estándar, el
                 tumor responde mal — lo que la oncología llama "refractario". El
                 informe AP del hospital de referencia añade un detalle que cambia todo: el
-                tumor presenta una amplificación FGFR1 de ×13 sobre un subtipo
-                BC-NED. La combinación está documentada solo cuatro veces en la
+                tumor presenta una amplificación XLR2 de ×9 sobre un subtipo
+                BC-SCC — una combinación poco habitual en la
                 literatura científica internacional, lo que convierte su caso en
                 uno de los más singulares conocidos. <br /><br />Miriam, junto
                 con su equipo de doce especialistas y bajo el paraguas de Beyond
@@ -6142,7 +6142,7 @@ Mandatory reference: see existing portraits of Miriam and her team. Same level o
                   line-height: 1;
                 "
               >
-                ×13
+                ×9
               </div>
               <div
                 style="
@@ -6152,7 +6152,7 @@ Mandatory reference: see existing portraits of Miriam and her team. Same level o
                   margin-top: 6px;
                 "
               >
-                FGFR1 amplificación
+                XLR2 amplificación
               </div>
             </div>
             <div
@@ -6419,14 +6419,14 @@ Gracias por estar aquí.</pre>
             <strong>equipo en plural</strong>, registro clínico, sin súplica.
           </p>
           <pre class="code" style="margin-top: 8px">
-<span class="c-com">Asunto:</span> Caso refractario FGFR1 ×13 / BC-NED — consulta posible
+<span class="c-com">Asunto:</span> Caso refractario XLR2 ×9 / BC-SCC — consulta posible
 
 Dr./Dra. [<span class="c-val">apellido</span>]:
 
 Le escribimos desde el equipo clínico que sigue a Miriam González,
 paciente con cáncer de mama metastásico refractario. Su biopsia
-muestra una amplificación FGFR1 ×13 sobre subtipo BC-NED — un
-perfil descrito apenas cuatro veces en la literatura.
+muestra una amplificación XLR2 ×9 sobre subtipo BC-SCC — un
+perfil poco frecuente en la literatura.
 
 Hemos visto su trabajo en [<span class="c-val">paper / línea de investigación</span>] y nos
 gustaría someter el caso a su criterio. Adjuntamos:


### PR DESCRIPTION
La página pública `/design-system/` es un activo de marca (showcase tech). Un design system no debe llevar datos reales. Este PR la limpia para poder compartirla/viralizarla sin exponer nada real. **No toca estructura, CSS, HTML, accesibilidad ni SEO** — eso va en un pase aparte.

## Qué cambia (solo `public/design-system/index.html`)

**Privacidad**
- Email personal fuera del footer
- Sección "Plantillas de mensaje": cifras de campaña y hospital → placeholders (la sección se queda como patrón)
- Nombres de terceros (equipo, médicos, hospital) → roles genéricos
- Cifras de recaudación reales → ejemplos ficticios (12.345 €, 850 personas)

**Perfil molecular → ejemplo ficticio**
- El perfil real se sustituye por uno inventado coherente (XLR2 ×9, PPB6, PLX9 42%, subtipo BC-SCC) en badges, tablas, cifras-firma, alt-text, narrativa del caso y plantillas. El patrón se enseña idéntico, con cero dato real. Se quita el identificador de unicidad ("documentado 4 veces").

**Se mantiene (decisión de Miriam):** su nombre, edad y ciudad (es su marca/autoría del sistema).

## Verificación
- `grep` limpio: 0 datos reales (gmail, hospital, nombres de terceros, marcadores, cifras).
- HTML sano: `<pre>` balanceado 20/20, estructura/layout intactos.
- Rebased sobre `main` actual (incluye el fix de color #9d44ab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
