### PR TITLE
Migración DS · tokens (Fase 0+1, INVISIBLE)

### DIFF
--- a/app/assets/css/design-system-v2/btp-tokens.css
+++ b/app/assets/css/design-system-v2/btp-tokens.css
@@ -1,0 +1,188 @@
+/* VENDORIZADO del canon btp-tokens.css (Fase 0 migracion web). Recortado @media reduced-motion global; anadido puente RGB. Fuente de verdad = canon. Re-vendorizar si cambia. */
+/* BTP DS v2.0 — 2026-07 · FUENTE ÚNICA DE TOKENS
+   «Beyond the Protocol» — editorial nocturno.
+   Decisiones de dirección de arte: Fable (auditoría 7-jul-2026).
+
+   REGLA DE ORO: no se añade NI UN HEX nuevo. Los 5 colores + 2 derivados
+   oficiales son los únicos átomos; todo estado/velo/trazo se deriva con
+   color-mix(). Si "hace falta" un color, la respuesta es no. */
+
+:root {
+  /* ── Paleta: 5 colores (disciplina máxima) ───────────────────── */
+  --color-bg:        #faf6f0; /* Crema — fondo claro siempre (nunca blanco) */
+  --color-bg-card:   #f5efe6; /* Crema profunda — superficies elevadas */
+  --color-text:      #2d1b3d; /* Berenjena — texto/trazo/fondo oscuro (nunca negro) */
+  --color-text-soft: #3a3340; /* Tinta — texto secundario */
+  --color-miriam:    #9d44ab; /* Violeta FIRMA — validado por Ceci/MCP: 5.07:1 sobre crema y 4.77:1 sobre tarjeta elevada = AA-normal en AMBAS. Gana a #a44db2 (4.55/4.29 = solo AA-large). Producción sirve aún #a44db2 → alinear vía PR. */
+  --color-miriam-soft:#e8d4ed;/* Violeta soft — fondo de badges */
+  --color-cta:       #ff6b47; /* Coral — SOLO acción (nunca porta significado sobre crema) */
+  --color-cta-hover: #e5573a;
+
+  /* ── Derivados oficiales (los 2 únicos "extra" permitidos) ───── */
+  --color-miriam-claro: #c77dd2; /* Violeta sobre fondo oscuro (berenjena); NUNCA sobre crema */
+  --cielo-resplandor:   #3a2450; /* SOLO fondos de "cielo" (universo constelación) */
+
+  /* ── Aliases semánticos de identidad/acción (usa estos) ──────── */
+  --color-link:     var(--color-miriam);
+  --color-emphasis: var(--color-miriam);
+  --color-action:   var(--color-cta);
+
+  /* ── Estados derivados (color-mix, sin hexes nuevos) — COL-5 ─── */
+  --cta-active:        color-mix(in srgb, var(--color-cta) 85%, var(--color-text));
+  --miriam-hover:      color-mix(in srgb, var(--color-miriam) 88%, var(--color-text));
+  --miriam-active:     color-mix(in srgb, var(--color-miriam) 78%, var(--color-text));
+  --secundario-hover:  color-mix(in srgb, var(--color-text) 6%, transparent);
+  --seleccionado-bg:   var(--color-miriam-soft);
+  --seleccionado-text: var(--color-text);
+
+  /* ── Velos (backdrops / cielos) ──────────────────────────────── */
+  --velo-berenjena-60: color-mix(in srgb, var(--color-text) 60%, transparent); /* backdrop de dialog */
+  --velo-berenjena-12: color-mix(in srgb, var(--color-text) 12%, transparent);
+
+  /* ── Sombra: sistema plano. Solo capas flotantes (LAY-3). En CAPAS a baja
+     opacidad (hairline ring + contacto + ambiente) para huir del "sticker"
+     de una sola sombra plana = tell nº1 de IA. Nada de glassmorphism/blur. */
+  --sombra-flotante:
+    0 0 0 1px color-mix(in srgb, var(--color-text) 6%, transparent),
+    0 1px 2px color-mix(in srgb, var(--color-text) 8%, transparent),
+    0 8px 24px color-mix(in srgb, var(--color-text) 6%, transparent);
+
+  /* ── Tipografía ──────────────────────────────────────────────── */
+  --font-display: 'Fraunces', Georgia, serif;      /* italic = gesto de firma (eyebrow) */
+  --font-body:    'Hanken Grotesk', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;  /* cuerpo/UI: elección del tipógrafo (9-jul) — auto-hospedada, no system-ui */
+  --font-mono:    'JetBrains Mono', ui-monospace, monospace; /* SOLO datos tabulares */
+
+  /* Escala modular (base 17, ratio ~1.25) — TYP-2 */
+  --texto-xs:   13px;
+  --texto-sm:   15px;
+  --texto-base: 17px;
+  --texto-lg:   clamp(19px, 1.6vw, 21px);
+  --texto-xl:   clamp(22px, 2.2vw, 26px);
+  --texto-2xl:  clamp(26px, 3vw, 34px);   /* h2 canónico */
+  --texto-3xl:  clamp(32px, 4.2vw, 44px); /* h1 / hero */
+
+  /* ── Espaciado: escala base-4 con el 12 legitimado — LAY-2 ───── */
+  --sp-4:  4px;
+  --sp-8:  8px;
+  --sp-12: 12px;
+  --sp-16: 16px;
+  --sp-24: 24px;
+  --sp-32: 32px;
+  --sp-48: 48px;
+  --sp-64: 64px;
+  --sp-96: 96px;
+
+  /* ── Radios ──────────────────────────────────────────────────── */
+  --radius-sm:   6px;
+  --radius-md:   8px;
+  --radius-btn:  12px;
+  --radius-card: 16px;
+  --radius-pill: 9999px;
+
+  /* ── Breakpoints canónicos (doc; en @media van en literal) — LAY-1 */
+  --bp-sm: 480px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+
+  /* ── Movimiento — CRAFT-4 ────────────────────────────────────── */
+  --dur-micro:      150ms;  /* hovers, focos */
+  --dur-transicion: 300ms;  /* entradas, toasts, dialog */
+  --dur-ambiente:   5s;     /* parpadeo/respiración de estrellas */
+  --curva-salida:   cubic-bezier(0.22, 1, 0.36, 1);
+  --curva-entrada:  cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* ── Lectura ─────────────────────────────────────────────────── */
+  --measure: 65ch;
+
+  /* ── Tipografía compuesta (los componentes usan ESTOS) — TYP-3 ──
+     Atajo `font:` (familia+peso+tamaño+interlineado) por rol, para que
+     ninguna superficie declare fuentes a mano. El tracking va aparte
+     (no cabe en el shorthand `font`). */
+  --tipo-eyebrow: italic 600 var(--texto-sm)/1.3 var(--font-display);
+  --tipo-h1:      600 var(--texto-3xl)/1.08 var(--font-display);
+  --tipo-h2:      700 var(--texto-2xl)/1.15 var(--font-display);
+  --tipo-h3:      600 var(--texto-xl)/1.2  var(--font-display);
+  --tipo-body:    400 var(--texto-base)/1.6 var(--font-body);
+  --tipo-body-sm: 400 var(--texto-sm)/1.5  var(--font-body);
+  --tipo-dato:    500 var(--texto-base)/1.4 var(--font-mono);   /* SOLO tabular */
+  --tipo-cifra:   700 var(--texto-3xl)/1    var(--font-display); /* «Cifra Fraunces» */
+  --track-eyebrow: 0.08em;  /* versalitas espaciadas: único recurso «de sistema» */
+  --track-cifra:  -0.02em;  /* display grande: tracking negativo */
+
+  /* ── Data-viz clínica («pata 2») — DERIVADA, cero hex nuevos — VIZ ─────────
+     El color NUNCA es la única señal: icono + etiqueta + forma también. En
+     público, SOLO datos sintéticos (muro). CVD-safe: la rampa diverging va de
+     berenjena (frío) → crema (neutro) → coral (cálido), sin rojo/verde. */
+  --viz-eje:     var(--trazo-fuerte);
+  --viz-rejilla: var(--trazo-sutil);
+  --viz-tooltip-bg:   var(--color-text);
+  --viz-tooltip-text: var(--color-bg);
+  /* Diverging PuOr (7 pasos, berenjena ↔ neutro ↔ coral) */
+  --viz-div-1:   var(--color-text);
+  --viz-div-2:   color-mix(in srgb, var(--color-text) 55%, var(--color-bg));
+  --viz-div-3:   color-mix(in srgb, var(--color-text) 22%, var(--color-bg));
+  --viz-div-mid: var(--color-bg-card);
+  --viz-div-5:   color-mix(in srgb, var(--color-cta) 32%, var(--color-bg));
+  --viz-div-6:   color-mix(in srgb, var(--color-cta) 62%, var(--color-bg));
+  --viz-div-7:   var(--color-cta);
+  /* Severidad (secuencial, mono-hue sobre identidad) */
+  --viz-sev-1: color-mix(in srgb, var(--color-miriam) 16%, var(--color-bg));
+  --viz-sev-2: color-mix(in srgb, var(--color-miriam) 38%, var(--color-bg));
+  --viz-sev-3: color-mix(in srgb, var(--color-miriam) 60%, var(--color-bg));
+  --viz-sev-4: color-mix(in srgb, var(--color-miriam) 82%, var(--color-bg));
+  --viz-sev-5: var(--color-miriam);
+
+  /* ══ ROLES SEMÁNTICOS POR TEMA (los componentes usan ESTOS) ════
+     El componente no sabe en qué fondo vive: pinta con roles y el tema
+     los remapea. Modo oscuro = editorial y MANUAL (data-tema), nunca
+     prefers-color-scheme. — CMP-4 / A11Y-2 */
+  --fondo:        var(--color-bg);
+  --superficie:   var(--color-bg-card);
+  --texto-1:      var(--color-text);       /* texto principal */
+  --texto-2:      var(--color-text-soft);  /* texto secundario */
+  --texto-3:      color-mix(in srgb, var(--color-text-soft) 72%, var(--color-bg)); /* terciario / mute — 72% = 4.9:1 AA verificado (62% daba 3.7, fallaba) */
+  --identidad:    var(--color-miriam);     /* violeta que porta identidad sobre este fondo */
+  --anillo-foco:  var(--color-miriam);
+  /* Color con el que se ESCRIBE la acción en esta superficie.
+     Sobre crema NO puede ser coral (Consolidado D6: «coral nunca sobre crema»;
+     2.62:1 no llega ni al 3:1 de elemento gráfico) → berenjena.
+     Sobre berenjena sí es coral (ver bloque [data-tema="oscuro"]).
+     Retirado el coral-oscurecido derivado: inventaba un patrón que el canon prohíbe. */
+  --cta-texto:    var(--color-text);
+  --trazo-sutil:  color-mix(in srgb, var(--color-text) 8%,  transparent);
+  --trazo-medio:  color-mix(in srgb, var(--color-text) 12%, transparent);
+  --trazo-fuerte: color-mix(in srgb, var(--color-text) 20%, transparent);
+  --trazo-interactivo: color-mix(in srgb, var(--color-text) 55%, transparent);  /* borde de controles ≥3:1 sobre crema (3.59) — MCP/Ceci */
+}
+
+/* ── Tema oscuro: sección editorial sobre berenjena ─────────────── */
+[data-tema="oscuro"] {
+  --fondo:        var(--color-text);       /* berenjena */
+  --superficie:   color-mix(in srgb, var(--color-text) 88%, var(--color-bg));
+  --texto-1:      var(--color-bg);         /* crema */
+  --texto-2:      color-mix(in srgb, var(--color-bg) 78%, transparent);
+  --texto-3:      color-mix(in srgb, var(--color-bg) 58%, transparent);
+  --identidad:    var(--color-miriam-claro);
+  --anillo-foco:  var(--color-miriam-claro);
+  --cta-texto:    var(--color-cta);        /* coral pleno ≈5.6:1 sobre berenjena — AA */
+  --trazo-sutil:  color-mix(in srgb, var(--color-bg) 10%, transparent);
+  --trazo-medio:  color-mix(in srgb, var(--color-bg) 16%, transparent);
+  --trazo-fuerte: color-mix(in srgb, var(--color-bg) 26%, transparent);
+  --trazo-interactivo: color-mix(in srgb, var(--color-bg) 40%, transparent);  /* borde de controles ≥3:1 sobre berenjena (3.51) — MCP/Ceci */
+}
+
+/* Puente Tailwind: canales RGB para rgb(var(--x-rgb) / <alpha-value>) (Fase 0) */
+:root {
+  --color-bg-rgb: 250 246 240;
+  --color-bg-card-rgb: 245 239 230;
+  --color-text-rgb: 45 27 61;
+  --color-text-soft-rgb: 58 51 64;
+  --color-miriam-rgb: 157 68 171;
+  --color-miriam-soft-rgb: 232 212 237;
+  --color-miriam-claro-rgb: 199 125 210;
+  --color-cta-rgb: 255 107 71;
+  --color-cta-hover-rgb: 229 87 58;
+  --cielo-resplandor-rgb: 58 36 80;
+  --berenjena-2-rgb: 58 35 80;
+}

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -21,8 +21,8 @@
     left: 0;
     z-index: 9999;
     padding: 8px 16px;
-    background: #2d1b3d; /* berenjena */
-    color: #faf6f0;
+    background: var(--color-text); /* berenjena */
+    color: var(--color-bg);
     font-size: 0.875rem;
     font-weight: 600;
     text-decoration: none;
@@ -44,7 +44,7 @@
      crema lo hace visible también sobre las secciones oscuras (berenjena).
      Solo :focus-visible → no molesta al click de ratón, sí guía al teclado. */
   :where(a, button, summary, [role="button"], [tabindex]):focus-visible {
-    outline: 2px solid #9d44ab;
+    outline: 2px solid var(--color-miriam);
     outline-offset: 2px;
     border-radius: 4px;
     box-shadow: 0 0 0 4px rgba(250, 246, 240, 0.55);
@@ -136,7 +136,7 @@
   /* DS card — cream-card sobre cream */
   .card-base {
     @apply bg-cream-card rounded-card p-6 sm:p-8;
-    border: 1px solid rgba(45, 27, 61, 0.08);
+    border: 1px solid rgb(var(--color-text-rgb) / 0.08);
   }
 
   /* D8 · pulido desktop: lift sutil al pasar el cursor SOLO en tarjetas
@@ -151,7 +151,7 @@
     a.card-base:hover,
     button.card-base:hover {
       transform: translateY(-2px);
-      box-shadow: 0 14px 34px rgba(45, 27, 61, 0.1);
+      box-shadow: 0 14px 34px rgb(var(--color-text-rgb) / 0.1);
     }
   }
   @media (prefers-reduced-motion: reduce) {
@@ -167,7 +167,7 @@
     box-shadow: 0 0 0 0 transparent;
   }
   .btn-cta:hover {
-    box-shadow: 0 10px 22px -8px rgba(255, 107, 71, 0.55);
+    box-shadow: 0 10px 22px -8px rgb(var(--color-cta-rgb) / 0.55);
     transform: translateY(-2px);
   }
   @media (prefers-reduced-motion: reduce) {
@@ -177,7 +177,7 @@
   }
   .btn-secondary {
     @apply inline-flex items-center justify-center gap-2 px-5 py-3 rounded-btn font-semibold text-berenjena bg-transparent transition-colors;
-    border: 2px solid #2d1b3d;
+    border: 2px solid var(--color-text);
   }
   .btn-secondary:hover {
     @apply bg-berenjena text-cream;
@@ -223,15 +223,15 @@
      Sin movimiento (solo box-shadow), seguro siempre. */
   .badge-genomic:hover, .badge-genomic:focus-visible,
   .tag-gold:hover, .tag-gold:focus-visible {
-    box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.18);
+    box-shadow: 0 0 0 3px rgb(var(--color-miriam-rgb) / 0.18);
   }
 
   /* Ocean tag (legacy) → outlined berenjena */
   .tag-ocean {
     @apply inline-flex items-center px-2.5 py-0.5 rounded-full text-2xs font-medium tracking-wide uppercase;
-    background: rgba(45, 27, 61, 0.06);
-    color: #2d1b3d;
-    border: 1px solid rgba(45, 27, 61, 0.12);
+    background: rgb(var(--color-text-rgb) / 0.06);
+    color: var(--color-text);
+    border: 1px solid rgb(var(--color-text-rgb) / 0.12);
   }
 
   /* Stat number — Fraunces display */
@@ -267,20 +267,20 @@
     font-size: 12px;
     letter-spacing: 0.02em;
     padding: 14px 16px;
-    background: #f5efe6; /* cream-card */
-    border-bottom: 1px solid rgba(45, 27, 61, 0.08);
+    background: var(--color-bg-card); /* cream-card */
+    border-bottom: 1px solid rgb(var(--color-text-rgb) / 0.08);
   }
   .data-table thead th:first-child { border-top-left-radius: 12px; }
   .data-table thead th:last-child  { border-top-right-radius: 12px; }
   .data-table tbody td {
     padding: 14px 16px;
-    border-bottom: 1px solid rgba(45, 27, 61, 0.06);
+    border-bottom: 1px solid rgb(var(--color-text-rgb) / 0.06);
     vertical-align: middle;
-    color: #2d1b3d;
+    color: var(--color-text);
     font-variant-numeric: tabular-nums;
   }
   .data-table tbody tr:last-child td { border-bottom: 0; }
-  .data-table tbody tr:hover td { background: rgba(157, 68, 171, 0.04); }
+  .data-table tbody tr:hover td { background: rgb(var(--color-miriam-rgb) / 0.04); }
   .data-table .col-marker {
     @apply font-mono;
     font-size: 13px;
@@ -289,7 +289,7 @@
     word-break: normal;
   }
   .data-table .col-note {
-    color: #3a3340;
+    color: var(--color-text-soft);
     font-size: 13px;
     line-height: 1.5;
   }
@@ -311,7 +311,7 @@
   /* Card wrapper around a data table — keeps the rounded look from the mockups */
   .data-card {
     @apply bg-cream rounded-card overflow-hidden;
-    border: 1px solid rgba(45, 27, 61, 0.08);
+    border: 1px solid rgb(var(--color-text-rgb) / 0.08);
   }
 
   /* ────────────────────────────────────────────────────────────
@@ -333,7 +333,7 @@
     }
     .data-table--cards tr {
       padding: 14px 16px;
-      border-bottom: 1px solid rgba(45, 27, 61, 0.10);
+      border-bottom: 1px solid rgb(var(--color-text-rgb) / 0.10);
     }
     .data-table--cards tbody tr:last-child {
       border-bottom: 0;
@@ -361,7 +361,7 @@
       font-size: 10.5px;
       letter-spacing: 0.04em;
       text-transform: uppercase;
-      color: #3a3340;
+      color: var(--color-text-soft);
       font-weight: 500;
       line-height: 1.4;
     }
@@ -371,12 +371,12 @@
       text-align: left;
       padding: 2px 0 9px !important;
       margin-bottom: 4px;
-      border-bottom: 1px solid rgba(45, 27, 61, 0.06) !important;
+      border-bottom: 1px solid rgb(var(--color-text-rgb) / 0.06) !important;
       font-family: 'Fraunces', Georgia, serif;
       font-weight: 600;
       font-size: 16px;
       letter-spacing: -0.01em;
-      color: #2d1b3d;
+      color: var(--color-text);
     }
     .data-table--cards td.cell-head::before {
       display: none;
@@ -410,10 +410,10 @@
   .pill-data--info     { background: #e0ecf8; color: #1e4a6f; }
   .pill-data--warn     { background: #fde4cc; color: #8a4a1a; }
   .pill-data--positive { background: #d8ede0; color: #1f5a3a; }
-  .pill-data--neutral  { background: rgba(45,27,61,0.06); color: #3a3340; }
-  .pill-data--violet   { background: #e8d4ed; color: #5a2466; }
-  /* berenjena: pill de recuento (rima con la insignia de «N focos» del esqueleto, #2d1b3d). Tokens del DS; contraste ~13:1. */
-  .pill-data--berenjena { background: #2d1b3d; color: #faf6f0; }
+  .pill-data--neutral  { background: rgb(var(--color-text-rgb) / 0.06); color: var(--color-text-soft); }
+  .pill-data--violet   { background: var(--color-miriam-soft); color: #5a2466; }
+  /* berenjena: pill de recuento (rima con la insignia de «N focos» del esqueleto, var(--color-text)). Tokens del DS; contraste ~13:1. */
+  .pill-data--berenjena { background: var(--color-text); color: var(--color-bg); }
 
   /* Status badges (uppercase mono) — for clinical/trial status */
   .status-badge {
@@ -426,7 +426,7 @@
     white-space: nowrap;
   }
   .status-badge--active    { background: #d8ede0; color: #1f5a3a; }
-  .status-badge--complete  { background: rgba(45,27,61,0.06); color: #3a3340; }
+  .status-badge--complete  { background: rgb(var(--color-text-rgb) / 0.06); color: var(--color-text-soft); }
   .status-badge--candidate { background: #fde4cc; color: #8a4a1a; }
   .status-badge--reference {
     background: #e0ecf8;
@@ -439,7 +439,7 @@
     overflow-wrap: anywhere;
   }
   .status-badge--paused    { background: #f0d4cc; color: #7a3018; }
-  .status-badge--firma     { background: #e8d4ed; color: #5a2466; }
+  .status-badge--firma     { background: var(--color-miriam-soft); color: #5a2466; }
   /* shape: tag teal de morfología/factibilidad (forma del hueso); recurre en /mapa. */
   .status-badge--shape     { background: rgba(31,107,87,0.12); color: #1f6b57; }
 
@@ -449,7 +449,7 @@
      sits at the top, the value is pinned to the bottom (margin-top:auto). */
   .stat-readout {
     @apply bg-cream rounded-card flex flex-col;
-    border: 1px solid rgba(45, 27, 61, 0.08);
+    border: 1px solid rgb(var(--color-text-rgb) / 0.08);
     padding: 14px 16px;
     min-height: 108px;
   }
@@ -510,13 +510,13 @@
   /* Form controls — cream background, miriam focus ring */
   .form-input {
     @apply w-full px-4 py-2.5 bg-cream rounded-btn text-sm text-berenjena transition-all;
-    border: 1px solid rgba(45, 27, 61, 0.12);
+    border: 1px solid rgb(var(--color-text-rgb) / 0.12);
   }
-  .form-input::placeholder { color: rgba(58, 51, 64, 0.55); }
+  .form-input::placeholder { color: rgb(var(--color-text-soft-rgb) / 0.55); }
   .form-input:focus {
     outline: none;
-    border-color: #9d44ab;
-    box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.18);
+    border-color: var(--color-miriam);
+    box-shadow: 0 0 0 3px rgb(var(--color-miriam-rgb) / 0.18);
   }
   .form-label {
     @apply block text-sm font-medium text-berenjena mb-1.5;
@@ -538,10 +538,10 @@
   .link-underline {
     @apply text-miriam font-medium;
     text-decoration: underline;
-    text-decoration-color: rgba(157, 68, 171, 0.45);
+    text-decoration-color: rgb(var(--color-miriam-rgb) / 0.45);
     text-decoration-thickness: 1px;
     text-underline-offset: 3px;
-    background-image: linear-gradient(#e8d4ed, #e8d4ed);
+    background-image: linear-gradient(var(--color-miriam-soft), var(--color-miriam-soft));
     background-size: 0% 60%;
     background-position: 0 90%;
     background-repeat: no-repeat;
@@ -553,8 +553,8 @@
   .link-inline:focus-visible,
   .link-underline:hover,
   .link-underline:focus-visible {
-    color: #2d1b3d;
-    text-decoration-color: #9d44ab;
+    color: var(--color-text);
+    text-decoration-color: var(--color-miriam);
     background-size: 100% 60%;
   }
 
@@ -589,16 +589,16 @@
   }
   .link-logo:hover,
   .link-logo:focus-visible {
-    color: #9d44ab; /* miriam */
+    color: var(--color-miriam); /* miriam */
     transform: translateY(-1px);
   }
 
   /* Enlaces dentro de contenido (markdown/prose): el plugin typography ya
      los subraya; aquí solo les añadimos el mismo resaltado de marca. */
   .prose a {
-    text-decoration-color: rgba(157, 68, 171, 0.45);
+    text-decoration-color: rgb(var(--color-miriam-rgb) / 0.45);
     text-underline-offset: 3px;
-    background-image: linear-gradient(#e8d4ed, #e8d4ed);
+    background-image: linear-gradient(var(--color-miriam-soft), var(--color-miriam-soft));
     background-size: 0% 60%;
     background-position: 0 90%;
     background-repeat: no-repeat;
@@ -608,8 +608,8 @@
   }
   .prose a:hover,
   .prose a:focus-visible {
-    color: #2d1b3d;
-    text-decoration-color: #9d44ab;
+    color: var(--color-text);
+    text-decoration-color: var(--color-miriam);
     background-size: 100% 60%;
   }
 
@@ -621,7 +621,7 @@
      violeta de firma al pasar/enfocar, como el resto de pistas
      interactivas del sistema. */
   .notes-disclosure {
-    border-top: 1px solid rgba(45, 27, 61, 0.08);
+    border-top: 1px solid rgb(var(--color-text-rgb) / 0.08);
   }
   .notes-disclosure > summary {
     @apply font-mono uppercase tracking-[0.12em] text-tinta;
@@ -653,11 +653,11 @@
   }
   .notes-disclosure > summary:hover,
   .notes-disclosure > summary:focus-visible {
-    color: #9d44ab;
+    color: var(--color-miriam);
     outline: none;
   }
   .notes-disclosure[open] > summary {
-    color: #9d44ab;
+    color: var(--color-miriam);
     margin-bottom: 4px;
   }
   @media (prefers-reduced-motion: reduce) {
@@ -673,7 +673,7 @@
      competir con las bandas de color con significado (anomalía/objetivo). */
   .chapter-rule {
     border: 0;
-    border-top: 1px solid rgba(45, 27, 61, 0.08);
+    border-top: 1px solid rgb(var(--color-text-rgb) / 0.08);
     margin: 0 0 2.75rem;
   }
 }
@@ -728,8 +728,8 @@
    · soft-pulse → punto coral en el borde de avance de la barra (latido).
    · draw-in    → trazado de líneas SVG (ECG / sparkline ctDNA). */
 @keyframes soft-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 107, 71, 0.45); }
-  50% { box-shadow: 0 0 0 7px rgba(255, 107, 71, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgb(var(--color-cta-rgb) / 0.45); }
+  50% { box-shadow: 0 0 0 7px rgb(var(--color-cta-rgb) / 0); }
 }
 @keyframes draw-in {
   from { stroke-dashoffset: var(--len, 400); }
@@ -777,7 +777,7 @@
   height: 8px;
   margin: -4px -4px 0 0;
   border-radius: 9999px;
-  background: #ff6b47;
+  background: var(--color-cta);
 }
 
 /* ────────────────────────────────────────────────────────────
@@ -790,12 +790,12 @@
 .link-inline:active,
 .link-underline:active,
 .prose a:active {
-  color: #2d1b3d;
-  text-decoration-color: #9d44ab;
+  color: var(--color-text);
+  text-decoration-color: var(--color-miriam);
   background-size: 100% 60%;
 }
 .link-logo:active {
-  color: #9d44ab;
+  color: var(--color-miriam);
 }
 .link-action:active {
   text-decoration: underline;
@@ -958,13 +958,13 @@
     font-family: 'JetBrains Mono', monospace;
     font-size: 12px;
     line-height: 1.55;
-    color: rgba(58, 51, 64, 0.82);
+    color: rgb(var(--color-text-soft-rgb) / 0.82);
     margin-top: 0.25rem;
   }
   .pathway-comfort__icon {
     width: 14px;
     height: 14px;
-    color: #9d44ab;
+    color: var(--color-miriam);
     flex-shrink: 0;
     align-self: center;
   }
@@ -993,13 +993,13 @@
     height: 100%;
     padding: 1.25rem 1.35rem;
     border-radius: 16px;
-    background: #faf6f0;
-    border: 1px solid rgba(45, 27, 61, 0.08);
+    background: var(--color-bg);
+    border: 1px solid rgb(var(--color-text-rgb) / 0.08);
     transition: box-shadow 0.18s ease;
   }
   @media (hover: hover) {
     .pathway-card:hover {
-      box-shadow: 0 10px 28px rgba(45, 27, 61, 0.08);
+      box-shadow: 0 10px 28px rgb(var(--color-text-rgb) / 0.08);
     }
   }
   .pathway-card__head {
@@ -1015,15 +1015,15 @@
     width: 2.25rem;
     height: 2.25rem;
     border-radius: 10px;
-    background: rgba(157, 68, 171, 0.12);
-    color: #2d1b3d;
+    background: rgb(var(--color-miriam-rgb) / 0.12);
+    color: var(--color-text);
   }
   .pathway-card__time {
     font-family: 'JetBrains Mono', monospace;
     font-size: 10.5px;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: rgba(58, 51, 64, 0.72);
+    color: rgb(var(--color-text-soft-rgb) / 0.72);
     white-space: nowrap;
   }
   .pathway-card__title {
@@ -1031,13 +1031,13 @@
     font-weight: 600;
     font-size: 1.05rem;
     line-height: 1.25;
-    color: #2d1b3d;
+    color: var(--color-text);
     text-wrap: balance;
   }
   .pathway-card__desc {
     font-size: 0.875rem;
     line-height: 1.55;
-    color: #3a3340;
+    color: var(--color-text-soft);
     flex: 1;
   }
   .pathway-card__steps {
@@ -1049,7 +1049,7 @@
     gap: 0.35rem;
     font-size: 0.78rem;
     line-height: 1.45;
-    color: rgba(58, 51, 64, 0.88);
+    color: rgb(var(--color-text-soft-rgb) / 0.88);
   }
   .pathway-card__steps li {
     display: flex;
@@ -1060,7 +1060,7 @@
     content: '→';
     font-family: 'JetBrains Mono', monospace;
     font-size: 10px;
-    color: #9d44ab;
+    color: var(--color-miriam);
     flex-shrink: 0;
   }
   .pathway-card__cta {
@@ -1071,7 +1071,7 @@
     margin-top: 0.45rem;
     font-size: 0.72rem;
     line-height: 1.45;
-    color: rgba(58, 51, 64, 0.78);
+    color: rgb(var(--color-text-soft-rgb) / 0.78);
     min-height: 2rem;
   }
 
@@ -1086,17 +1086,17 @@
     gap: 0.45rem;
     padding: 0.55rem 0.85rem;
     border-radius: 999px;
-    border: 1px solid rgba(45, 27, 61, 0.12);
-    background: #faf6f0;
-    color: #2d1b3d;
+    border: 1px solid rgb(var(--color-text-rgb) / 0.12);
+    background: var(--color-bg);
+    color: var(--color-text);
     font-size: 0.82rem;
     font-weight: 600;
     text-decoration: none;
     transition: background 0.15s ease, border-color 0.15s ease;
   }
   .pathway-chip:hover {
-    background: rgba(157, 68, 171, 0.1);
-    border-color: rgba(157, 68, 171, 0.28);
+    background: rgb(var(--color-miriam-rgb) / 0.1);
+    border-color: rgb(var(--color-miriam-rgb) / 0.28);
   }
   .pathway-chip__label {
     white-space: nowrap;
@@ -1106,7 +1106,7 @@
     font-size: 10px;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: rgba(58, 51, 64, 0.65);
+    color: rgb(var(--color-text-soft-rgb) / 0.65);
     margin-left: 0.1rem;
   }
 
@@ -1119,7 +1119,7 @@
     font-family: 'JetBrains Mono', monospace;
     font-size: 0.82rem;
     font-weight: 600;
-    color: #2d1b3d;
+    color: var(--color-text);
     list-style: none;
     padding: 0.65rem 0;
   }
@@ -1128,7 +1128,7 @@
   }
   .pathway-brief__summary::before {
     content: '▸';
-    color: #9d44ab;
+    color: var(--color-miriam);
     transition: transform 0.15s ease;
   }
   .pathway-brief[open] .pathway-brief__summary::before {
@@ -1140,8 +1140,8 @@
     text-transform: uppercase;
     padding: 0.2rem 0.55rem;
     border-radius: 999px;
-    background: rgba(157, 68, 171, 0.12);
-    color: #2d1b3d;
+    background: rgb(var(--color-miriam-rgb) / 0.12);
+    color: var(--color-text);
   }
   .pathway-brief__list {
     margin: 0;
@@ -1157,7 +1157,7 @@
     align-items: flex-start;
     font-size: 0.9rem;
     line-height: 1.55;
-    color: #3a3340;
+    color: var(--color-text-soft);
   }
   .pathway-brief__num {
     display: inline-flex;
@@ -1166,11 +1166,11 @@
     width: 1.5rem;
     height: 1.5rem;
     border-radius: 6px;
-    background: rgba(157, 68, 171, 0.14);
+    background: rgb(var(--color-miriam-rgb) / 0.14);
     font-family: 'JetBrains Mono', monospace;
     font-size: 11px;
     font-weight: 700;
-    color: #2d1b3d;
+    color: var(--color-text);
     flex-shrink: 0;
   }
 
@@ -1179,12 +1179,12 @@
     .pathway-card,
     .pathway-chip,
     .card-base {
-      border-color: rgba(45, 27, 61, 0.22);
+      border-color: rgb(var(--color-text-rgb) / 0.22);
     }
     .pathway-card__desc,
     .pathway-comfort,
     .nota {
-      color: #2d1b3d;
+      color: var(--color-text);
     }
     .btn-secondary {
       border-width: 2.5px;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -24,6 +24,7 @@ export default defineNuxtConfig({
   fonts: {
     families: [
       { name: 'Fraunces', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal', 'italic'] },
+      { name: 'Hanken Grotesk', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal', 'italic'] },
       { name: 'Source Sans 3', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal', 'italic'] },
       { name: 'JetBrains Mono', provider: 'google', weights: [400, 500] },
       // Manuscrita para las anotaciones «de cuaderno de laboratorio»
@@ -148,7 +149,7 @@ export default defineNuxtConfig({
     },
   },
 
-  css: ['~/assets/css/main.css'],
+  css: ['~/assets/css/design-system-v2/btp-tokens.css', '~/assets/css/main.css'],
 
   // ── Enlaces cortos de marca (campañas) ───────────────────────────────────
   // Links cortos en NUESTRO dominio (helpmiriam.com/3d…) que redirigen al

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,33 +24,33 @@ export default {
       colors: {
         // Design system tokens — Caso Miriam
         // Base palette (5 colors): cream bg, berenjena text, miriam violet (accent), coral (CTA)
-        cream: '#faf6f0',         // var(--color-bg)
-        'cream-card': '#f5efe6',  // var(--color-bg-card)
-        berenjena: '#2d1b3d',     // var(--color-text)
-        tinta: '#3a3340',         // var(--color-text-soft)
+        cream: 'rgb(var(--color-bg-rgb) / <alpha-value>)',         // var(--color-bg)
+        'cream-card': 'rgb(var(--color-bg-card-rgb) / <alpha-value>)',  // var(--color-bg-card)
+        berenjena: 'rgb(var(--color-text-rgb) / <alpha-value>)',     // var(--color-text)
+        tinta: 'rgb(var(--color-text-soft-rgb) / <alpha-value>)',         // var(--color-text-soft)
         miriam: {
           // Firma / emphasis / links. Oscurecido de #a44db2 a #9d44ab para que el
           // texto pase WCAG AA (4.5:1) también sobre cream-card (4.77:1), no solo
           // sobre cream. El violeta sigue siendo prácticamente el mismo.
-          DEFAULT: '#9d44ab',
-          soft: '#e8d4ed',        // var(--color-miriam-soft) — badge genómico bg
+          DEFAULT: 'rgb(var(--color-miriam-rgb) / <alpha-value>)',
+          soft: 'rgb(var(--color-miriam-soft-rgb) / <alpha-value>)',        // var(--color-miriam-soft) — badge genómico bg
           // Violeta claro para ÉNFASIS sobre fondos oscuros (berenjena): el miriam
           // DEFAULT no contrasta sobre berenjena, este sí (5.46:1, pasa WCAG AA).
           // Usado en el dossier /marcas (titulares e identidad sobre bandas oscuras).
-          claro: '#c77dd2',
+          claro: 'rgb(var(--color-miriam-claro-rgb) / <alpha-value>)',
         },
         // Berenjena un punto más violácea para tarjetas elevadas SOBRE las bandas
         // oscuras (cajas «Carlos Roca» / LinkedIn en /marcas). Texto crema: 12.8:1.
-        'berenjena-2': '#3a2350',
+        'berenjena-2': 'rgb(var(--berenjena-2-rgb) / <alpha-value>)',
         coral: {
-          DEFAULT: '#ff6b47',     // var(--color-cta) — ÚNICO color de acción (fondos / decoración)
-          hover: '#e5573a',
+          DEFAULT: 'rgb(var(--color-cta-rgb) / <alpha-value>)',     // var(--color-cta) — ÚNICO color de acción (fondos / decoración)
+          hover: 'rgb(var(--color-cta-hover-rgb) / <alpha-value>)',
           // Coral accesible para TEXTO sobre fondos claros: pasa WCAG AA
           // (4.7:1 sobre cream-card, 5.0:1 sobre cream). El coral DEFAULT
           // solo cumple contraste como fondo o como texto sobre berenjena.
           deep: '#bb4128',
-          500: '#ff6b47',
-          600: '#e5573a',
+          500: 'rgb(var(--color-cta-rgb) / <alpha-value>)',
+          600: 'rgb(var(--color-cta-hover-rgb) / <alpha-value>)',
         },
 
         // Legacy palette aliases — remapped to DS tokens so existing classNames


### PR DESCRIPTION
## Qué es
**Fase 1** de la migración. Apilada sobre #156 (Fase 0). Todas las clases de `main.css` pasan a consumir los tokens, **sin cambio visual**.

## Cambios
- **47 hexes sólidos** de paleta → `var(--color-*)` (mismo valor exacto).
- **38 `rgba()`** de berenjena/violeta/coral → `rgb(var(--x-rgb) / alfa)` (mismo color, ahora tokenizado, vía el puente RGB de Fase 0).
- **Sin tocar:** los colores semánticos fuera de paleta (pill/status azul/naranja/verde) → Fase 5 (Ceci); el remapeo de roles en bandas oscuras → Fase 2/3.

## Neutro por construcción
Ningún valor de color cambia. **El preview debe verse idéntico.**

## Para revisar
- [ ] Preview Netlify verde y pixel-idéntico (index, prensa, colabora, marcas; móvil/desktop; ES/EN).
- [ ] Base de este PR = `feat/ds-v2-fase0-tokens` (#156). Al mergear #156, este se re-apunta a main solo.

**Mergeas tú** tras revisar el preview. Merge en orden: #156 primero, luego este.

🤖 Generated with [Claude Code](https://claude.com/claude-code)