### PR TITLE
Fase 2 · Migración DS: chrome (nav/footer) → tokens (neutral)

### DIFF
--- a/app/components/SiteFooter.vue
+++ b/app/components/SiteFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer :aria-label="$t('footer.site_footer')" class="bg-cream-card" style="border-top: 1px solid rgba(45,27,61,0.08)">
+  <footer :aria-label="$t('footer.site_footer')" class="bg-cream-card" style="border-top: 1px solid rgb(var(--color-text-rgb) / 0.08)">
     <!-- Con el apoyo de — muro de logos uniforme: todos en blanco monocromo, misma
          altura óptica, centrados en rejilla. Cada logo se aplana a silueta crema
          (logo-wall__mark) para que GitHub/Notion/Tahe/Never Surrender se lean como
@@ -107,7 +107,7 @@
       <nav
         :aria-label="$t('footer.legal_heading')"
         class="mt-8 pt-6 flex flex-wrap items-center gap-x-5 gap-y-2"
-        style="border-top: 1px solid rgba(45,27,61,0.08)"
+        style="border-top: 1px solid rgb(var(--color-text-rgb) / 0.08)"
       >
         <NuxtLink :to="localePath('aviso-legal')" class="text-[11px] font-mono text-tinta hover:text-miriam hover:underline underline-offset-2 transition-colors">
           {{ $t('footer.legal_notice') }}

--- a/app/components/SiteNav.vue
+++ b/app/components/SiteNav.vue
@@ -8,7 +8,7 @@
         ? 'bg-cream/95 backdrop-blur-lg shadow-sm'
         : 'bg-cream'
     "
-    style="border-bottom: 1px solid rgba(45,27,61,0.08)"
+    style="border-bottom: 1px solid rgb(var(--color-text-rgb) / 0.08)"
   >
     <div class="section-wide flex items-center justify-between h-16 sm:h-18">
       <!-- Logo -->
@@ -49,7 +49,7 @@
           role="group"
           :aria-label="$t('nav.language')"
           class="hidden sm:flex items-center rounded-md overflow-hidden font-mono text-[11px] font-semibold tracking-widest uppercase"
-          style="border: 1px solid rgba(45,27,61,0.10)"
+          style="border: 1px solid rgb(var(--color-text-rgb) / 0.1)"
         >
           <button
             type="button"
@@ -112,7 +112,7 @@
         v-if="mobileOpen"
         id="mobile-nav"
         class="lg:hidden bg-cream/95 backdrop-blur-lg"
-        style="border-top: 1px solid rgba(45,27,61,0.08)"
+        style="border-top: 1px solid rgb(var(--color-text-rgb) / 0.08)"
       >
         <nav
           :aria-label="$t('nav.mobile_label')"
@@ -143,7 +143,7 @@
           <!-- Language switch — vive aquí en móvil para descongestionar la cabecera -->
           <div
             class="mt-3 pt-3 flex items-center justify-between"
-            style="border-top: 1px solid rgba(45,27,61,0.08)"
+            style="border-top: 1px solid rgb(var(--color-text-rgb) / 0.08)"
           >
             <span class="font-mono text-[11px] uppercase tracking-widest text-tinta">
               {{ $t('nav.language') }}
@@ -152,7 +152,7 @@
               role="group"
               :aria-label="$t('nav.language')"
               class="flex items-center rounded-md overflow-hidden font-mono text-[11px] font-semibold tracking-widest uppercase"
-              style="border: 1px solid rgba(45,27,61,0.10)"
+              style="border: 1px solid rgb(var(--color-text-rgb) / 0.1)"
             >
               <button
                 type="button"


### PR DESCRIPTION
## Qué es
**Fase 2** (primera parte). Los bordes `rgba(45,27,61,X)` inline de `SiteNav` y `SiteFooter` → `rgb(var(--color-text-rgb)/X)`. Fase 1 solo tocó `main.css`; estos viven en los `.vue`.

**Neutro** — mismo color exacto. El preview debe verse idéntico.

Pendiente (aparte, es un arbitrary-value de Tailwind): la sombra coral del CTA de donación.

**Mergeas tú** tras revisar el preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)