### PR TITLE
feat(ds): cuerpo del sitio → Hanken Grotesk (Fase C)

### DIFF
--- a/app/components/Term.vue
+++ b/app/components/Term.vue
@@ -440,7 +440,7 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
   border-radius: 11px;
   background: #2d1b3d;
   color: #faf6f0;
-  font-family: 'Source Sans 3', system-ui, sans-serif;
+  font-family: 'Hanken Grotesk', system-ui, sans-serif;
   font-size: 13.5px;
   line-height: 1.5;
   white-space: normal;

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -267,7 +267,7 @@ const groups = computed(() => {
   border-radius: 9999px;
   border: 1px solid rgba(45, 27, 61, 0.16);
   background: #faf6f0;
-  font-family: 'Source Sans 3', system-ui, sans-serif;
+  font-family: 'Hanken Grotesk', system-ui, sans-serif;
   font-size: 13.5px;
   font-weight: 600;
   color: #3a3340;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -99,7 +99,9 @@ export default {
       },
       fontFamily: {
         display: ['Fraunces', 'Georgia', 'serif'],
-        body: ['Source Sans 3', 'system-ui', 'sans-serif'],
+        // Cuerpo/UI: Hanken Grotesk (elección del tipógrafo, 9-jul) — cálida, x-height
+        // generosa, quita el «tell» de Source Sans. Ya cargada por @nuxt/fonts.
+        body: ['Hanken Grotesk', 'system-ui', 'sans-serif'],
         mono: ['JetBrains Mono', 'monospace'],
       },
       fontSize: {


### PR DESCRIPTION
## Fase C del acabado — el cuerpo del sitio pasa a Hanken Grotesk

**Site-wide** (no solo el mapa). El cuerpo/UI deja **Source Sans 3** (la sans «Adobe por defecto», con leve tell-de-IA) y pasa a **Hanken Grotesk** — cálida, x-height generosa — alineando con la **decisión del tipógrafo (9-jul)** ya demostrada en el escaparate del DS (#151).

### Cambios (mínimos y contenidos)
- `tailwind.config.js`: token `body` → **Hanken Grotesk**. Voltea todo lo que usa `@apply font-body` (≈ todo el cuerpo del sitio). **Hanken ya estaba cargada** por `@nuxt/fonts` en `main` → **cero cambios de pipeline**; `@nuxt/fonts` genera el **fallback métrico-ajustado** (fontaine) → CLS controlado.
- `Term.vue`, `timeline.vue`: refs inline `font-family` → Hanken.

### Verificación
- `nuxt build` OK.
- `getComputedStyle` del cuerpo = **Hanken Grotesk** + cadena de fallback métrico.
- **Home**: render correcto en desktop; **sin overflow horizontal a 320px** (scrollW 321/320). Ver captura en el chat.
- **Pendiente tu vista en Netlify**: spot-check de un par de páginas más (timeline, ciencia, ayudar) — un swap de fuente conviene ojearlo ancho.

### Fuera de este PR (a propósito)
- **C1** Fraunces variable `opsz` — bespoke (self-host woff2 variable) y de bajo valor visual → **aparcado**.
- **C2** slashed-zero — redundante (JetBrains Mono ya tiene cero distinto; `tnum` ya aplicado) → **omitido**.
- OG image (takumi) y los labels SVG del mapa siguen en Source Sans (pipelines aparte) → follow-up trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)