### PR TITLE
feat(design-system): unifica en el cuadernillo v2 (limpio + a11y + SEO)

### DIFF
--- a/public/design-system/index.html
+++ b/public/design-system/index.html
@@ -1,6646 +1,832 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="es">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Sistema de diseño · Miriam</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=JetBrains+Mono:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-    <link rel="apple-touch-icon" href="apple-touch-icon.svg" />
-    <meta name="theme-color" content="#A44DB2" />
-    <link rel="stylesheet" href="tokens.css" />
-    <link rel="stylesheet" href="design-system.css" />
-  </head>
-  <body>
-    <header class="ds-hero">
-      <div class="eyebrow">
-        v1.1 · Mayo 2026 · Sub-marca de Beyond the Protocol
-      </div>
-      <h1>Sistema de diseño Caso Miriam .</h1>
-      <p
-        style="
-          max-width: 60ch;
-          font-size: 18px;
-          color: var(--color-text-soft);
-          line-height: 1.55;
-        "
-      >
-        El sistema visual y verbal con el que se comunica el caso de Miriam
-        González en helpmiriam.com, redes (@miriamgonp), GoFundMe y materiales
-        de prensa.
-      </p>
-      <div class="meta">
-        <div><b>Idea central</b>Ciencia → humanidad → acción</div>
-        <div>
-          <b>Identidad</b>Violeta
-          <code style="color: #a44db2">#A44DB2</code>
-        </div>
-        <div>
-          <b>Acción</b>Coral
-          <code style="color: #ff6b47">#FF6B47</code>
-        </div>
-        <div><b>Lectura</b>~18 min · si tienes prisa, 00 · 01 · 10</div>
-      </div>
-    </header>
-
-    <div class="ds-shell">
-      <nav class="ds-side">
-        <div class="brand">
-          <div class="mark" style="background: transparent">
-            <svg viewBox="0 0 240 240" width="34" height="34" aria-hidden="true">
-              <path d="M192.94 24.47 L199.74 37.67 L212.94 44.47 L199.74 51.27 L192.94 64.47 L186.14 51.27 L172.94 44.47 L186.14 37.67 Z" fill="#9D44AB" />
-              <path d="M48.33 173.84 L52.75 182.42 L61.33 186.84 L52.75 191.26 L48.33 199.84 L43.91 191.26 L35.33 186.84 L43.91 182.42 Z" fill="#9D44AB" />
-              <path d="M55.05 44.24 L57.94 49.85 L63.55 52.74 L57.94 55.63 L55.05 61.24 L52.16 55.63 L46.55 52.74 L52.16 49.85 Z" fill="#9D44AB" opacity="0.5" />
-              <circle cx="182.5" cy="184.7" r="3.4" fill="#9D44AB" />
-              <circle cx="212.8" cy="134.7" r="2.3" fill="#9D44AB" opacity="0.5" />
-              <circle cx="120" cy="120" r="76" fill="#2D1B3D" />
-              <text x="120" y="147" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-weight="600" font-style="italic" font-size="120" fill="#FAF6F0" letter-spacing="-0.02em">m</text>
-            </svg>
-          </div>
-          <div>
-            <strong>Miriam</strong>
-            <small>Design system</small>
-          </div>
-        </div>
-
-        <h2>Empezar aquí</h2>
-        <a href="#start">00 · Cómo usar este sistema</a>
-
-        <h2>Fundamentos</h2>
-        <a href="#idea">01 · Idea central</a>
-        <a href="#color">02 · Color</a>
-        <a href="#type">03 · Tipografía</a>
-        <a href="#space">04 · Espaciado &amp; radios</a>
-
-        <h2>Identidad</h2>
-        <a href="#icons">05 · Iconografía</a>
-        <a href="#avatar">06 · Avatar, logo &amp; favicon</a>
-
-        <h2>Componentes</h2>
-        <a href="#buttons">07 · Botones</a>
-        <a href="#data">08 · Cifras &amp; badges</a>
-        <a href="#card">09 · Cards &amp; tablas</a>
-
-        <h2>Lenguaje</h2>
-        <a href="#voice">10 · Voz por superficie</a>
-        <a href="#do">11 · Lo que sí / lo que no</a>
-
-        <h2>Inclusión</h2>
-        <a href="#a11y">13 · Accesibilidad &amp; neurodivergencia</a>
-
-        <h2>Producción</h2>
-        <a href="#ai">12 · Hablar con IAs</a>
-        <a href="#repo">14 · Repositorio</a>
-
-        <h2>Recursos</h2>
-        <a href="#brand">15 · Marca &amp; dominio</a>
-        <a href="#photo">16 · Fotografía</a>
-        <a href="#states">17 · Estados de UI</a>
-        <a href="#press">18 · Press kit</a>
-        <a href="#templates">19 · Plantillas de mensaje</a>
-        <a href="#instagram">20 · Publicaciones de Instagram</a>
-      </nav>
-
-      <main class="ds-main">
-        <!-- 00 CÓMO USAR -->
-        <section class="ds-section" id="start">
-          <div class="eyebrow">00 · Empezar</div>
-          <h2>Cómo usar este sistema.</h2>
-          <p class="lede">
-            Una sola fuente de verdad para diseñadores, redactores y devs. La
-            voz Miriam no se inventa cada vez — se hereda. Antes de añadir un
-            componente nuevo, busca el patrón aquí; si no está, llévalo a una
-            sección existente antes de improvisar.
-          </p>
-
-          <div
-            class="grid-3"
-            style="display: grid; gap: 20px; margin-top: 32px"
-          >
-            <div
-              style="
-                background: var(--color-bg-card);
-                border-radius: 14px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.1em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                  margin-bottom: 8px;
-                "
-              >
-                Si diseñas
-              </div>
-              <h3 style="margin: 0 0 12px; font-size: 20px">
-                Trabaja en Figma.
-              </h3>
-              <ul
-                style="
-                  font-size: 13px;
-                  line-height: 1.6;
-                  color: var(--color-text);
-                  padding-left: 18px;
-                  margin: 0;
-                "
-              >
-                <li>
-                  Importa los tokens de la sección 02 (color) y 04 (espacio +
-                  radios) como variables.
-                </li>
-                <li>
-                  Usa Fraunces y JetBrains Mono. Nada de Inter por defecto.
-                </li>
-                <li>
-                  Antes de un mock nuevo, mira si una card/badge/tabla de las
-                  secciones 07–09 ya resuelve.
-                </li>
-                <li>
-                  Para iconos pide siempre la
-                  <strong>plantilla D</strong> (sección 13). No mezcles estilos.
-                </li>
-              </ul>
-            </div>
-            <div
-              style="
-                background: var(--color-bg-card);
-                border-radius: 14px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.1em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                  margin-bottom: 8px;
-                "
-              >
-                Si programas
-              </div>
-              <h3 style="margin: 0 0 12px; font-size: 20px">
-                Importa
-                <code
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 13px;
-                    color: var(--color-text);
-                  "
-                  >tokens.css</code
-                >.
-              </h3>
-              <ul
-                style="
-                  font-size: 13px;
-                  line-height: 1.6;
-                  color: var(--color-text);
-                  padding-left: 18px;
-                  margin: 0;
-                "
-              >
-                <li>
-                  Todas las variables CSS canónicas (<code
-                    style="font-family: var(--font-mono); font-size: 12px"
-                    >--color-*</code
-                  >,
-                  <code style="font-family: var(--font-mono); font-size: 12px"
-                    >--space-*</code
-                  >,
-                  <code style="font-family: var(--font-mono); font-size: 12px"
-                    >--radius-*</code
-                  >).
-                </li>
-                <li>
-                  Usa
-                  <code style="font-family: var(--font-mono); font-size: 12px"
-                    >color-mix()</code
-                  >
-                  para opacidades — no hex con alpha en el token.
-                </li>
-                <li>
-                  Container queries en cards si vas a reusarlas en grid o
-                  sidebar.
-                </li>
-                <li>
-                  Respeta
-                  <code style="font-family: var(--font-mono); font-size: 12px"
-                    >prefers-reduced-motion</code
-                  >
-                  y
-                  <code style="font-family: var(--font-mono); font-size: 12px"
-                    >prefers-color-scheme</code
-                  >
-                  (ver sección 12).
-                </li>
-              </ul>
-            </div>
-            <div
-              style="
-                background: var(--color-bg-card);
-                border-radius: 14px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.1em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                  margin-bottom: 8px;
-                "
-              >
-                Si redactas o usas IA
-              </div>
-              <h3 style="margin: 0 0 12px; font-size: 20px">
-                Lee <a href="#voice" style="color: var(--color-text)">10</a>,
-                <a href="#do" style="color: var(--color-text)">11</a>,
-                <a href="#ai" style="color: var(--color-text)">13</a>.
-              </h3>
-              <ul
-                style="
-                  font-size: 13px;
-                  line-height: 1.6;
-                  color: var(--color-text);
-                  padding-left: 18px;
-                  margin: 0;
-                "
-              >
-                <li>
-                  Voz por superficie: dato seco / narrativa íntima / acción
-                  directa.
-                </li>
-                <li>
-                  Para hablar con IA, copia el prompt base (sección 13) — no
-                  improvises.
-                </li>
-                <li>
-                  Texto de imagen → siempre en inglés. Texto de UI → siempre en
-                  español.
-                </li>
-                <li>
-                  Prohibido: emojis, "empoderamiento", gradientes, "lucha
-                  valiente".
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 48px">Reglas no negociables</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 16px;
-            "
-          >
-            Estas siete cosas son lo que mantiene unido el sistema. Si rompes
-            una, rompes la marca.
-          </p>
-          <ol
-            style="
-              font-size: 14px;
-              line-height: 1.8;
-              color: var(--color-text);
-              max-width: 70ch;
-              padding-left: 20px;
-            "
-          >
-            <li>
-              <strong>Un acento por pieza.</strong> Violeta = identidad/Miriam.
-              Coral = acción. Nunca los dos juntos protagonistas.
-            </li>
-            <li>
-              <strong>Berenjena #2D1B3D para texto y trazo</strong>. Negro puro
-              nunca.
-            </li>
-            <li>
-              <strong>Fondo crema #FAF6F0</strong>, no blanco. El blanco quema
-              en pantallas con brillo alto y rompe la calidez.
-            </li>
-            <li>
-              <strong
-                >Fraunces para titulares y firma; JetBrains Mono para
-                datos</strong
-              >. Para texto largo, system-ui o Inter (sección 03) — nunca
-              Fraunces a 14 px.
-            </li>
-            <li>
-              <strong>Sin gradientes, sin glassmorphism, sin emojis</strong>. La
-              textura viene de la tinta y el grano del papel.
-            </li>
-            <li>
-              <strong>Datos siempre con cifra absoluta</strong> (PLX9 42%, XLR2
-              ×9). Nunca redondear, nunca "alto".
-            </li>
-            <li>
-              <strong>WCAG 2.2 AA mínimo</strong>. Toque mínimo 44 px. Foco
-              visible. Sin animación que pase de 200 ms en interfaz.
-            </li>
-          </ol>
-
-          <h3 style="margin-top: 48px">Cuándo este sistema NO aplica</h3>
-          <p
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              color: var(--color-text);
-              max-width: 64ch;
-            "
-          >
-            Documentos médicos oficiales (informes, consentimientos),
-            correspondencia legal, papelería hospitalaria. Esos contextos tienen
-            sus propios sistemas — no los toquemos. Aquí solo cubrimos lo que el
-            equipo de helpmiriam.com produce: web, redes, prensa, dossieres a
-            especialistas, materiales de campaña.
-          </p>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 32px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)">Versión.</strong> v1.1 ·
-            mayo 2026. Si añades una expresión, plantilla, componente o regla
-            nueva, anótala con fecha al final del archivo y avisa al equipo. El
-            sistema se afina con el uso.
-          </p>
-        </section>
-
-        <!-- 01 IDEA CENTRAL -->
-        <section class="ds-section" id="idea">
-          <div class="eyebrow">01 · Fundamento</div>
-          <h2>Idea central.</h2>
-          <p class="lede">
-            Datos científicos rigurosos como base. Capa de humanidad para
-            conectar. Acción al final del recorrido.
-          </p>
-
-          <div class="journey">
-            <div class="card step-1">
-              <div class="num">01 — Base</div>
-              <h4>Datos</h4>
-              <p>
-                BC-SCC, XLR2 ×9, escamoso ~35%, PLX9 42%. La ciencia se
-                cuenta sin diluir.
-              </p>
-              <div class="quote">"Esto es real y serio."</div>
-            </div>
-            <div class="card step-2">
-              <div class="num">02 — Capa</div>
-              <h4>Humanidad</h4>
-              <p>
-                Sobre los datos, una capa narrativa: incertidumbre, comunidad,
-                decisiones contadas con honestidad.
-              </p>
-              <div class="quote">"Esto le pasa a una persona."</div>
-            </div>
-            <div class="card step-3">
-              <div class="num">03 — Cierre</div>
-              <h4>Acción</h4>
-              <p>
-                El recorrido cierra con un único color de acción: coral. Donar,
-                compartir, contactar.
-              </p>
-              <div class="quote">"Yo puedo hacer algo."</div>
-            </div>
-          </div>
-
-          <h3>Ratio ciencia / humanidad por sección</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 60ch;
-            "
-          >
-            Antes de escribir o diseñar una pieza, pregunta:
-            <em>¿qué ratio pide esta superficie y a qué acción lleva?</em>
-            Las decisiones de tipografía, color y tono salen de ahí.
-          </p>
-          <table class="ratio-table">
-            <thead>
-              <tr>
-                <th>Sección</th>
-                <th>Ratio</th>
-                <th>Objetivo</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><b>Home</b></td>
-                <td>
-                  <div class="ratio-bar">
-                    <div class="sci" style="width: 50%"></div>
-                    <div class="hum" style="width: 50%"></div>
-                  </div>
-                  <div class="ratio-vals">50 / 50</div>
-                </td>
-                <td>
-                  Punto de entrada para los dos públicos. Dato firma + frase
-                  humana + CTA.
-                </td>
-              </tr>
-              <tr>
-                <td><b>La ciencia</b></td>
-                <td>
-                  <div class="ratio-bar">
-                    <div class="sci" style="width: 90%"></div>
-                    <div class="hum" style="width: 10%"></div>
-                  </div>
-                  <div class="ratio-vals">90 / 10</div>
-                </td>
-                <td>
-                  Médicos, investigadores. Marcadores, vías, ensayos. Mínima
-                  narrativa.
-                </td>
-              </tr>
-              <tr>
-                <td><b>Timeline / Historia</b></td>
-                <td>
-                  <div class="ratio-bar">
-                    <div class="sci" style="width: 20%"></div>
-                    <div class="hum" style="width: 80%"></div>
-                  </div>
-                  <div class="ratio-vals">20 / 80</div>
-                </td>
-                <td>
-                  Conexión emocional. Narrativa cálida, fechas humanizadas,
-                  incertidumbre real.
-                </td>
-              </tr>
-              <tr>
-                <td><b>Cómo ayudar / Donar</b></td>
-                <td>
-                  <div class="ratio-bar">
-                    <div class="sci" style="width: 30%"></div>
-                    <div class="hum" style="width: 70%"></div>
-                  </div>
-                  <div class="ratio-vals">30 / 70</div>
-                </td>
-                <td>
-                  Justificación científica breve + voz directa + CTA coral.
-                </td>
-              </tr>
-              <tr>
-                <td><b>Equipo</b></td>
-                <td>
-                  <div class="ratio-bar">
-                    <div class="sci" style="width: 40%"></div>
-                    <div class="hum" style="width: 60%"></div>
-                  </div>
-                  <div class="ratio-vals">40 / 60</div>
-                </td>
-                <td>
-                  Profesionales detrás del caso, especialidades + por qué se han
-                  unido.
-                </td>
-              </tr>
-              <tr>
-                <td><b>Prensa / Recursos</b></td>
-                <td>
-                  <div class="ratio-bar">
-                    <div class="sci" style="width: 70%"></div>
-                    <div class="hum" style="width: 30%"></div>
-                  </div>
-                  <div class="ratio-vals">70 / 30</div>
-                </td>
-                <td>Datos verificables, dossier descargable, contactos.</td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-
-        <!-- 02 COLOR -->
-        <section class="ds-section" id="color">
-          <div class="eyebrow">02 · Fundamento</div>
-          <h2>Color.</h2>
-          <p class="lede">
-            Cinco colores totales.
-            <strong style="color: var(--color-text); font-weight: 600"
-              >Violeta = identidad.</strong
-            >
-            <strong style="color: #2d1b3d; font-weight: 600"
-              >Coral = acción.</strong
-            >
-            Esa distinción es lo que hace que el sistema funcione.
-          </p>
-
-          <h3>Paleta principal</h3>
-          <div class="swatch-grid">
-            <div class="swatch">
-              <div
-                class="chip"
-                style="
-                  background: #faf6f0;
-                  border-bottom: 1px solid rgba(45, 27, 61, 0.08);
-                "
-              ></div>
-              <div class="body">
-                <span class="role">Fondo</span>
-                <h4>Crema</h4>
-                <div class="hex">
-                  <span>#FAF6F0</span><span>250 · 246 · 240</span>
-                </div>
-                <p>
-                  Background de todo. Heredado del paraguas. Nunca blanco puro.
-                </p>
-              </div>
-            </div>
-            <div class="swatch">
-              <div class="chip" style="background: #2d1b3d"></div>
-              <div class="body">
-                <span class="role">Texto / trazo</span>
-                <h4>Berenjena</h4>
-                <div class="hex">
-                  <span>#2D1B3D</span><span>45 · 27 · 61</span>
-                </div>
-                <p>
-                  H1, H2, H3, body, líneas de ilustración. WCAG AA sobre crema.
-                </p>
-              </div>
-            </div>
-            <div class="swatch">
-              <div class="chip" style="background: #a44db2"></div>
-              <div class="body">
-                <span class="role" style="background: #e8d4ed; color: #2d1b3d"
-                  >Firma</span
-                >
-                <h4>Violeta Miriam</h4>
-                <div class="hex">
-                  <span>#A44DB2</span><span>164 · 77 · 178</span>
-                </div>
-                <p>
-                  Identifica AL CASO. El pelo del avatar, badges, anotaciones,
-                  énfasis.
-                </p>
-              </div>
-            </div>
-            <div class="swatch">
-              <div class="chip" style="background: #ff6b47"></div>
-              <div class="body">
-                <span
-                  class="role"
-                  style="background: rgba(255, 107, 71, 0.15); color: #2d1b3d"
-                  >Acción</span
-                >
-                <h4>Coral</h4>
-                <div class="hex">
-                  <span>#FF6B47</span><span>255 · 107 · 71</span>
-                </div>
-                <p>
-                  SOLO CTAs. Donar, apoyar, barra de progreso. Único color de
-                  acción.
-                </p>
-              </div>
-            </div>
-            <div class="swatch">
-              <div class="chip" style="background: #3a3340"></div>
-              <div class="body">
-                <span class="role">Texto secundario</span>
-                <h4>Tinta</h4>
-                <div class="hex">
-                  <span>#3A3340</span><span>58 · 51 · 64</span>
-                </div>
-                <p>Captions, notas clínicas, descripciones, metadatos.</p>
-              </div>
-            </div>
-          </div>
-
-          <h3>Superficie auxiliar</h3>
-          <div class="swatch-grid">
-            <div class="swatch">
-              <div
-                class="chip"
-                style="
-                  background: #f5efe6;
-                  border-bottom: 1px solid rgba(45, 27, 61, 0.08);
-                "
-              ></div>
-              <div class="body">
-                <span class="role">Cards</span>
-                <h4>Crema profunda</h4>
-                <div class="hex">
-                  <span>#F5EFE6</span><span>245 · 239 · 230</span>
-                </div>
-                <p>Cards, bloques destacados, separadores tonales suaves.</p>
-              </div>
-            </div>
-            <div class="swatch">
-              <div class="chip" style="background: #e8d4ed"></div>
-              <div class="body">
-                <span class="role" style="background: #e8d4ed; color: #2d1b3d"
-                  >Badges</span
-                >
-                <h4>Violeta soft</h4>
-                <div class="hex">
-                  <span>#E8D4ED</span><span>232 · 212 · 237</span>
-                </div>
-                <p>
-                  Badges con marcadores genómicos (XLR2 ×9), callouts
-                  identitarios.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <h3>Reglas críticas</h3>
-          <div class="rules">
-            <div class="rule do">
-              <b>Crema siempre de fondo</b>
-              Nunca blanco puro <code>#FFFFFF</code> ni gris. Heredado del
-              paraguas Beyond the Protocol.
-            </div>
-            <div class="rule do">
-              <b>Violeta = identidad. Coral = acción.</b>
-              No los mezcles ni los confundas. Identidad y acción no compiten.
-            </div>
-            <div class="rule do">
-              <b>Berenjena para texto largo</b>
-              Mejor legibilidad y contraste que violeta. WCAG AA garantizado.
-            </div>
-            <div class="rule dont">
-              <b>Sin gradientes ni sombras pronunciadas</b>
-              Sin texturas digitales, sin glassmorphism, sin glows.
-            </div>
-            <div class="rule dont">
-              <b>Sin rosa pastel ni lazos</b>
-              Sin estética de "lucha guerrera contra el cáncer". Sin azules
-              clínicos.
-            </div>
-            <div class="rule dont">
-              <b>Sin más de un color destacado por bloque</b>
-              Una cifra firma en violeta o una en coral. El resto en berenjena.
-            </div>
-          </div>
-
-          <h3>Variables CSS</h3>
-          <pre class="code">
-<span class="c-com">/* Heredadas del paraguas Beyond the Protocol */</span>
-<span class="c-key">--color-bg</span>:        <span class="c-val">#FAF6F0</span>;
-<span class="c-key">--color-bg-card</span>:   <span class="c-val">#F5EFE6</span>;
-<span class="c-key">--color-text</span>:      <span class="c-val">#2D1B3D</span>;
-<span class="c-key">--color-text-soft</span>: <span class="c-val">#3A3340</span>;
-<span class="c-key">--color-cta</span>:       <span class="c-val">#FF6B47</span>;
-<span class="c-key">--color-cta-hover</span>: <span class="c-val">#E5573A</span>;
-
-<span class="c-com">/* Específicas del Caso Miriam */</span>
-<span class="c-key">--color-miriam</span>:      <span class="c-val">#A44DB2</span>;
-<span class="c-key">--color-miriam-soft</span>: <span class="c-val">#E8D4ED</span>;</pre>
-
-          <h3 style="margin-top: 40px">Notas modernas (2026)</h3>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              color: var(--color-text);
-              max-width: 70ch;
-              padding-left: 20px;
-            "
-          >
-            <li>
-              Para opacidades usa
-              <code
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 12px;
-                  color: var(--color-text);
-                "
-                >color-mix(in oklab, var(--color-miriam) 20%, transparent)</code
-              >
-              en lugar de hex con alpha. Mejor mezcla perceptual y respeta el
-              token original.
-            </li>
-            <li>
-              Si añades dark mode, deriva los tokens con
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >@media (prefers-color-scheme: dark)</code
-              >: berenjena pasa a fondo, crema a texto. Violeta firma se
-              mantiene; coral sube a #FF8266 para contraste AA.
-            </li>
-            <li>
-              <strong>No uses</strong> oklch para definir los tokens canónicos —
-              los hex actuales son la fuente de verdad y se replican en Figma
-              sin pérdida. Reserva oklch para mezclas e interpolaciones en
-              código.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Combinaciones permitidas</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Reglas rápidas para números sobre tarjetas, badges y datos clínicos.
-            Solo estos pares cumplen contraste AA y respetan la jerarquía del
-            sistema.
-          </p>
-
-          <div
-            class="grid-3"
-            style="display: grid; gap: 16px; margin-top: 16px"
-          >
-            <div
-              style="
-                background: #faf6f0;
-                border-radius: 10px;
-                padding: 24px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 40px;
-                  color: #2d1b3d;
-                  line-height: 1;
-                "
-              >
-                ×9
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: #3a3340;
-                  margin-top: 8px;
-                "
-              >
-                XLR2 amplificación
-              </div>
-              <div
-                style="
-                  margin-top: 16px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: var(--color-text-soft);
-                "
-              >
-                Berenjena s/ crema · dato neutro
-              </div>
-            </div>
-            <div
-              style="
-                background: #faf6f0;
-                border-radius: 10px;
-                padding: 24px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 40px;
-                  color: #a44db2;
-                  line-height: 1;
-                "
-              >
-                42%
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: #a44db2;
-                  margin-top: 8px;
-                "
-              >
-                PLX9 proliferación
-              </div>
-              <div
-                style="
-                  margin-top: 16px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: var(--color-text-soft);
-                "
-              >
-                Violeta s/ crema · AA cualquier tamaño · no sobre crema-card
-              </div>
-            </div>
-            <div
-              style="background: #ff6b47; border-radius: 10px; padding: 24px"
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 40px;
-                  color: #2d1b3d;
-                  line-height: 1;
-                "
-              >
-                87k
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: #2d1b3d;
-                  margin-top: 8px;
-                "
-              >
-                Recaudado · €
-              </div>
-              <div
-                style="
-                  margin-top: 16px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: #2d1b3d;
-                "
-              >
-                Berenjena s/ coral · surface CTA
-              </div>
-            </div>
-            <div
-              style="background: #2d1b3d; border-radius: 10px; padding: 24px"
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 40px;
-                  color: #faf6f0;
-                  line-height: 1;
-                "
-              >
-                12
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: rgba(250, 246, 240, 0.6);
-                  margin-top: 8px;
-                "
-              >
-                Especialistas en el equipo
-              </div>
-              <div
-                style="
-                  margin-top: 16px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(250, 246, 240, 0.5);
-                "
-              >
-                Crema s/ berenjena · dato sobre fondo
-              </div>
-            </div>
-            <div
-              style="background: #2d1b3d; border-radius: 10px; padding: 24px"
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 40px;
-                  color: #e8d4ed;
-                  line-height: 1;
-                "
-              >
-                4
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: rgba(250, 246, 240, 0.6);
-                  margin-top: 8px;
-                "
-              >
-                Países involucrados
-              </div>
-              <div
-                style="
-                  margin-top: 16px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(250, 246, 240, 0.5);
-                "
-              >
-                Violeta-soft s/ berenjena · firma sobre fondo
-              </div>
-            </div>
-            <div
-              style="background: #2d1b3d; border-radius: 10px; padding: 24px"
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 40px;
-                  color: #ff6b47;
-                  line-height: 1;
-                "
-              >
-                €10
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: rgba(250, 246, 240, 0.6);
-                  margin-top: 8px;
-                "
-              >
-                Donación mínima
-              </div>
-              <div
-                style="
-                  margin-top: 16px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(250, 246, 240, 0.5);
-                "
-              >
-                Coral s/ berenjena · máximo énfasis
-              </div>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Combinaciones prohibidas</h3>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              color: var(--color-text);
-              max-width: 70ch;
-              padding-left: 20px;
-            "
-          >
-            <li>
-              <strong>Coral sobre crema para texto.</strong> Falla incluso para
-              texto grande. El coral solo es legible sobre berenjena o tinta.
-              El botón primario debe llevar texto berenjena, no crema.
-            </li>
-            <li>
-              <strong>Violeta firma sobre berenjena en texto pequeño.</strong>
-              Pasa solo en titulares grandes (≥24px / ≥18.67px bold). Para
-              texto de cuerpo o eyebrow sobre berenjena, usa
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >--color-miriam-soft</code
-              >
-              (#E8D4ED) que sí pasa.
-            </li>
-            <li>
-              <strong>Violeta firma sobre tinta #3A3340.</strong> No pasa
-              contraste. No usar en ningún tamaño.
-            </li>
-            <li>
-              <strong>Coral sobre violeta firma.</strong> Vibra y cansa la
-              vista. El coral solo respira sobre berenjena o tinta.
-            </li>
-            <li>
-              <strong>Dos acentos en la misma tarjeta.</strong> Violeta y coral
-              compiten. Una tarjeta = una historia = un acento.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 48px">
-            Tarjetas con texto — combinaciones probadas
-          </h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Lo mismo aplicado a cards con titular + cuerpo + etiqueta. Cada
-            tarjeta lleva en su pie el ratio de contraste real (calculado WCAG
-            2.2). Las que están aquí <strong>pasan AA</strong> en el texto
-            principal y AAA en titulares grandes — son las que puedes usar sin
-            pensar.
-          </p>
-
-          <div
-            class="grid-2"
-            style="display: grid; gap: 16px; margin-top: 16px"
-          >
-            <!-- Card 1: berenjena s/ crema -->
-            <div
-              style="
-                background: #faf6f0;
-                border-radius: 12px;
-                padding: 28px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: #3a3340;
-                  text-transform: uppercase;
-                "
-              >
-                Diagnóstico
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #2d1b3d;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Tumor refractario, perfil único.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(45, 27, 61, 0.85);
-                  margin: 0;
-                "
-              >
-                El informe AP confirma BC-SCC con amplificación XLR2 ×9. Un
-                perfil molecular poco frecuente en la literatura.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.1);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: var(--color-text-soft);
-                "
-              >
-                crema #FAF6F0 + berenjena #2D1B3D &middot;
-                <strong style="color: #2d1b3d">14.6:1</strong> &middot; AAA
-              </div>
-            </div>
-
-            <!-- Card 2: berenjena, contenido principal -->
-            <div
-              style="background: #2d1b3d; border-radius: 12px; padding: 28px"
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: rgba(250, 246, 240, 0.55);
-                  text-transform: uppercase;
-                "
-              >
-                Llamada a la acción
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #faf6f0;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Necesitamos 12.345 € más.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(250, 246, 240, 0.88);
-                  margin: 0;
-                "
-              >
-                Para la siguiente prueba molecular. Plazo de ventana clínica: 6
-                semanas.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(250, 246, 240, 0.15);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(250, 246, 240, 0.5);
-                "
-              >
-                berenjena #2D1B3D + crema #FAF6F0 &middot;
-                <strong style="color: #faf6f0">14.6:1</strong> &middot; AAA
-              </div>
-            </div>
-
-            <!-- Card 3: violeta-soft s/ berenjena -->
-            <div
-              style="background: #2d1b3d; border-radius: 12px; padding: 28px"
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: #e8d4ed;
-                  text-transform: uppercase;
-                "
-              >
-                Identidad del caso
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #faf6f0;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Miriam · 35 años · Murcia
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(250, 246, 240, 0.85);
-                  margin: 0;
-                "
-              >
-                Eyebrow en violeta-soft funciona como firma sin competir con el
-                titular. El cuerpo principal sigue siendo crema.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(250, 246, 240, 0.15);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(250, 246, 240, 0.5);
-                "
-              >
-                berenjena + violeta-soft
-                <strong style="color: #e8d4ed">11.28:1</strong> + crema
-                <strong style="color: #faf6f0">14.6:1</strong> &middot; AAA
-              </div>
-            </div>
-
-            <!-- Card 4: coral CTA s/ crema -->
-            <div
-              style="
-                background: #faf6f0;
-                border-radius: 12px;
-                padding: 28px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: #3a3340;
-                  text-transform: uppercase;
-                "
-              >
-                Acción
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #2d1b3d;
-                  margin: 8px 0 16px;
-                  line-height: 1.15;
-                "
-              >
-                Ayuda al ensayo.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(45, 27, 61, 0.85);
-                  margin: 0 0 20px;
-                "
-              >
-                Texto en berenjena. El acento coral va <strong>solo</strong> en
-                el botón — nunca en el cuerpo o titular.
-              </p>
-              <button
-                style="
-                  background: #ff6b47;
-                  color: #2d1b3d;
-                  border: none;
-                  padding: 12px 20px;
-                  border-radius: 8px;
-                  font-family: var(--font-body);
-                  font-size: 14px;
-                  font-weight: 600;
-                  cursor: pointer;
-                "
-              >
-                Donar →
-              </button>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.1);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: var(--color-text-soft);
-                "
-              >
-                crema + berenjena · botón: coral + berenjena — coral +
-                crema falla
-              </div>
-            </div>
-
-            <!-- Card 5: violeta-soft tinte fondo s/ crema base -->
-            <div
-              style="background: #e8d4ed; border-radius: 12px; padding: 28px"
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: #2d1b3d;
-                  text-transform: uppercase;
-                "
-              >
-                Cita / quote
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-style: italic;
-                  font-size: 24px;
-                  color: #2d1b3d;
-                  margin: 8px 0 0;
-                  line-height: 1.25;
-                "
-              >
-                "No estoy aquí para pedir ayuda sin explicarte exactamente por
-                qué."
-              </h4>
-              <p
-                style="
-                  font-size: 13px;
-                  line-height: 1.5;
-                  color: rgba(45, 27, 61, 0.7);
-                  margin: 16px 0 0;
-                "
-              >
-                — Miriam González, marzo 2026
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.15);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: #2d1b3d;
-                "
-              >
-                violeta-soft #E8D4ED + berenjena
-                <strong style="color: #2d1b3d">11.28:1</strong> · AAA
-              </div>
-            </div>
-
-            <!-- Card 6: cream-card #F5EFE6 s/ crema base -->
-            <div
-              style="background: #f5efe6; border-radius: 12px; padding: 28px"
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: #3a3340;
-                  text-transform: uppercase;
-                "
-              >
-                Card neutra
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 24px;
-                  color: #2d1b3d;
-                  margin: 8px 0 12px;
-                  line-height: 1.2;
-                "
-              >
-                Cards "panel" sin acento.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(45, 27, 61, 0.85);
-                  margin: 0;
-                "
-              >
-                Crema-card #F5EFE6 sobre crema base #FAF6F0 — diferencia tonal
-                sutil suficiente para separar bloques sin gritar. Ideal para
-                listas de FAQ, tablas, contenido secundario.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.1);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: #3a3340;
-                "
-              >
-                crema-card #F5EFE6 + berenjena
-                <strong style="color: #2d1b3d">13.75:1</strong> · AAA
-              </div>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 48px">
-            Lo que NO se debe hacer — antiejemplos
-          </h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Mismas cards, combinaciones rotas. Si te sale alguna de estas,
-            descártala. El ratio en el pie te dice por qué.
-          </p>
-
-          <div
-            class="grid-2"
-            style="display: grid; gap: 16px; margin-top: 16px"
-          >
-            <!-- Bad 1: violeta firma s/ berenjena -->
-            <div
-              style="
-                background: #2d1b3d;
-                border-radius: 12px;
-                padding: 28px;
-                position: relative;
-              "
-            >
-              <div
-                style="
-                  position: absolute;
-                  top: 14px;
-                  right: 14px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  letter-spacing: 0.06em;
-                  padding: 4px 8px;
-                  background: #ff6b47;
-                  color: #faf6f0;
-                  border-radius: 4px;
-                  text-transform: uppercase;
-                "
-              >
-                Falla en texto pequeño
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: rgba(250, 246, 240, 0.55);
-                  text-transform: uppercase;
-                "
-              >
-                Violeta firma s/ berenjena en body
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #a44db2;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Caso refractario único.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: #a44db2;
-                  margin: 0;
-                "
-              >
-                Este cuerpo de texto (14px) con violeta sobre berenjena falla
-                AA para texto normal (necesita ≥4.5:1). Solo es válido en
-                titulares ≥24px. Para texto corrido sobre berenjena, usa
-                crema.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(250, 246, 240, 0.15);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(250, 246, 240, 0.5);
-                "
-              >
-                berenjena + violeta firma · ✗ texto normal · ✓ solo titular ≥24px
-              </div>
-            </div>
-
-            <!-- Bad 2: coral en cuerpo de texto -->
-            <div
-              style="
-                background: #faf6f0;
-                border-radius: 12px;
-                padding: 28px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                position: relative;
-              "
-            >
-              <div
-                style="
-                  position: absolute;
-                  top: 14px;
-                  right: 14px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  letter-spacing: 0.06em;
-                  padding: 4px 8px;
-                  background: #ff6b47;
-                  color: #faf6f0;
-                  border-radius: 4px;
-                  text-transform: uppercase;
-                "
-              >
-                Falla
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: rgba(45, 27, 61, 0.55);
-                  text-transform: uppercase;
-                "
-              >
-                Coral como color de cuerpo
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #ff6b47;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Donar para salvar a Miriam.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: #ff6b47;
-                  margin: 0;
-                "
-              >
-                El coral tiñe titular y cuerpo. Tono telethon. Contraste
-                2.62:1 — falla incluso para texto grande (necesita ≥3:1). Y
-                agota la vista en 5 segundos.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.1);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(45, 27, 61, 0.6);
-                "
-              >
-                coral en cuerpo <strong style="color: #ff6b47">2.62:1</strong> ·
-                ✗ falla en todo tamaño · ✗ slop visual
-              </div>
-            </div>
-
-            <!-- Bad 3: dos acentos -->
-            <div
-              style="
-                background: #faf6f0;
-                border-radius: 12px;
-                padding: 28px;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                position: relative;
-              "
-            >
-              <div
-                style="
-                  position: absolute;
-                  top: 14px;
-                  right: 14px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  letter-spacing: 0.06em;
-                  padding: 4px 8px;
-                  background: #ff6b47;
-                  color: #faf6f0;
-                  border-radius: 4px;
-                  text-transform: uppercase;
-                "
-              >
-                Falla
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: #a44db2;
-                  text-transform: uppercase;
-                "
-              >
-                Dos acentos compitiendo
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #2d1b3d;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Caso <span style="color: #a44db2">único</span> · ayuda
-                <span style="color: #ff6b47">urgente</span>.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(45, 27, 61, 0.85);
-                  margin: 0;
-                "
-              >
-                Violeta firma + coral en la misma card. Las dos historias gritan
-                a la vez y ninguna se entiende. Una card = una historia = un
-                acento.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.1);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(45, 27, 61, 0.6);
-                "
-              >
-                contraste OK · ✗ jerarquía rota
-              </div>
-            </div>
-
-            <!-- Bad 4: coral s/ violeta-soft -->
-            <div
-              style="
-                background: #e8d4ed;
-                border-radius: 12px;
-                padding: 28px;
-                position: relative;
-              "
-            >
-              <div
-                style="
-                  position: absolute;
-                  top: 14px;
-                  right: 14px;
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  letter-spacing: 0.06em;
-                  padding: 4px 8px;
-                  background: #ff6b47;
-                  color: #faf6f0;
-                  border-radius: 4px;
-                  text-transform: uppercase;
-                "
-              >
-                Falla
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  color: rgba(45, 27, 61, 0.55);
-                  text-transform: uppercase;
-                "
-              >
-                Coral s/ violeta-soft
-              </div>
-              <h4
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 28px;
-                  color: #ff6b47;
-                  margin: 8px 0 12px;
-                  line-height: 1.15;
-                "
-              >
-                Vibración cromática.
-              </h4>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.55;
-                  color: rgba(45, 27, 61, 0.85);
-                  margin: 0;
-                "
-              >
-                Coral sobre violeta-soft vibra en el ojo. Dos pigmentos
-                cálido-fríos forzados juntos. El coral solo respira sobre crema
-                o berenjena.
-              </p>
-              <div
-                style="
-                  margin-top: 20px;
-                  padding-top: 16px;
-                  border-top: 1px solid rgba(45, 27, 61, 0.15);
-                  font-family: var(--font-mono);
-                  font-size: 10px;
-                  color: rgba(45, 27, 61, 0.55);
-                "
-              >
-                violeta-soft + coral
-                <strong style="color: #ff6b47">2.02:1</strong> · ✗ AA falla y
-                vibra
-              </div>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 48px">
-            Cheat sheet — qué pones encima de qué
-          </h3>
-          <div style="overflow-x: auto; margin-top: 16px">
-            <table
-              style="
-                width: 100%;
-                max-width: 76ch;
-                border-collapse: collapse;
-                font-size: 13.5px;
-                font-family: var(--font-body);
-              "
-            >
-              <thead>
-                <tr style="border-bottom: 2px solid #2d1b3d">
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Fondo
-                  </th>
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Texto cualquier tamaño (≥4.5:1)
-                  </th>
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Solo titular ≥24px (≥3:1)
-                  </th>
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Nota
-                  </th>
-                </tr>
-              </thead>
-              <tbody style="color: var(--color-text)">
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #faf6f0;
-                        border: 1px solid rgba(45, 27, 61, 0.2);
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Crema #FAF6F0
-                  </td>
-                  <td style="padding: 12px">
-                    berenjena #2D1B3D<br />
-                    tinta #3A3340<br />
-                    violeta #A44DB2
-                  </td>
-                  <td style="padding: 12px">
-                    <em style="color: var(--color-text-soft); font-size: 12px">—</em>
-                  </td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Fondo universal. Coral aquí falla.
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #f5efe6;
-                        border: 1px solid rgba(45, 27, 61, 0.2);
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Crema profunda #F5EFE6
-                  </td>
-                  <td style="padding: 12px">
-                    berenjena #2D1B3D<br />
-                    tinta #3A3340
-                  </td>
-                  <td style="padding: 12px">violeta #A44DB2</td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Cards y bloques. Mismas reglas que crema.
-                  </td>
-                </tr>
-                <tr
-                  style="
-                    border-bottom: 1px solid rgba(45, 27, 61, 0.08);
-                    background: rgba(45, 27, 61, 0.025);
-                  "
-                >
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #2d1b3d;
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Berenjena #2D1B3D
-                  </td>
-                  <td style="padding: 12px">
-                    crema #FAF6F0<br />
-                    coral #FF6B47
-                  </td>
-                  <td style="padding: 12px">violeta #A44DB2</td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Énfasis oscuro. Eyebrow: usar violeta-soft.
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #a44db2;
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Violeta #A44DB2
-                  </td>
-                  <td style="padding: 12px">
-                    <em style="color: var(--color-text-soft); font-size: 12px"
-                      >ninguno pasa para texto normal</em
-                    >
-                  </td>
-                  <td style="padding: 12px">
-                    crema #FAF6F0<br />
-                    berenjena #2D1B3D
-                  </td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Solo surface de firma. TODO el texto ≥24px.
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #e8d4ed;
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Violeta soft #E8D4ED
-                  </td>
-                  <td style="padding: 12px">
-                    berenjena #2D1B3D<br />
-                    tinta #3A3340
-                  </td>
-                  <td style="padding: 12px">violeta #A44DB2</td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Badges, callouts. No usar coral aquí.
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #ff6b47;
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Coral #FF6B47
-                  </td>
-                  <td style="padding: 12px">berenjena #2D1B3D</td>
-                  <td style="padding: 12px">tinta #3A3340</td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Solo botón CTA. Texto: berenjena. Crema falla.
-                  </td>
-                </tr>
-                <tr>
-                  <td style="padding: 12px">
-                    <span
-                      style="
-                        display: inline-block;
-                        width: 14px;
-                        height: 14px;
-                        background: #3a3340;
-                        border-radius: 3px;
-                        vertical-align: middle;
-                        margin-right: 8px;
-                      "
-                    ></span
-                    >Tinta #3A3340
-                  </td>
-                  <td style="padding: 12px">crema #FAF6F0</td>
-                  <td style="padding: 12px">coral #FF6B47</td>
-                  <td style="padding: 12px; font-size: 12px; color: var(--color-text-soft)">
-                    Captions y metadatos elevados a fondo.
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 24px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)"
-              >Regla de los tres colores por tarjeta.</strong
-            >
-            Cuenta los colores que ves en una card antes de aprobarla: fondo +
-            texto + acento ≤ 3. Si pasa de 3 (eyebrow violeta + titular
-            berenjena + body berenjena soft + botón coral + borde violeta-soft =
-            5), simplifica. La emoción la lleva la jerarquía tipográfica, no la
-            suma de colores.
-          </p>
-        </section>
-
-        <!-- 03 TIPOGRAFÍA -->
-        <section class="ds-section" id="type">
-          <div class="eyebrow">03 · Fundamento</div>
-          <h2>Tipografía.</h2>
-          <p class="lede">
-            Tres roles. <strong>Fraunces</strong> para titulares editoriales,
-            <strong>system sans</strong> para body y UI,
-            <strong>JetBrains Mono</strong> para datos científicos.
-          </p>
-
-          <div class="specimen h1">
-            <div class="meta">
-              <span>Display</span><b>Fraunces 600</b
-              ><span>96 / -0.05em / 1.05</span>
-            </div>
-            <div class="glyph">XLR2 ×9.</div>
-          </div>
-          <div class="specimen h2">
-            <div class="meta">
-              <span>H2 sección</span><b>Fraunces 600</b
-              ><span>60 / -0.04em / 1.1</span>
-            </div>
-            <div class="glyph">Una alteración rara, una oportunidad real.</div>
-          </div>
-          <div class="specimen h3">
-            <div class="meta">
-              <span>H3 bloque</span><b>Fraunces 600</b
-              ><span>32 / -0.03em / 1.15</span>
-            </div>
-            <div class="glyph">Perfil molecular del tumor</div>
-          </div>
-          <div class="specimen body">
-            <div class="meta">
-              <span>Body</span><b>system-ui 400</b><span>18 / 0 / 1.55</span>
-            </div>
-            <div class="glyph">
-              Miriam tiene 35 años y un cáncer de mama metastásico con
-              diferenciación escamosa atípica ~35% y amplificación XLR2 ×9. Su
-              tumor no responde a los tratamientos estándar. Un equipo
-              internacional busca, con ayuda de IA, una terapia que la oncología
-              convencional no contempla.
-            </div>
-          </div>
-          <div class="specimen caption">
-            <div class="meta">
-              <span>Caption</span><b>system-ui 400</b><span>13 / 0 / 1.5</span>
-            </div>
-            <div class="glyph">
-              Datos del informe AP-2024-0312 · Hospital Clínico San Carlos · 12
-              marzo 2024
-            </div>
-          </div>
-          <div class="specimen mono">
-            <div class="meta">
-              <span>Datos científicos</span><b>JetBrains Mono 500</b
-              ><span>22 / 0 / 1.5</span>
-            </div>
-            <div class="glyph">XLR2 ×9 · PPB6 ×6 · PLX9 42% · BC-SCC</div>
-          </div>
-          <div class="specimen stat">
-            <div class="meta">
-              <span>Cifra firma</span><b>Fraunces 600</b
-              ><span>120 / -0.06em / 0.95</span>
-            </div>
-            <div class="glyph" style="color: var(--color-miriam)">×9</div>
-          </div>
-
-          <h3>Por qué esta combinación</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 16px;
-            "
-          >
-            <strong style="color: var(--color-text)">Fraunces</strong> da aire
-            editorial / artículo de ciencia.
-            <strong style="color: var(--color-text)">System sans</strong> para
-            body es eficiente: carga instantánea, nativa en cualquier
-            dispositivo.
-            <strong style="color: var(--color-text)">JetBrains Mono</strong>
-            identifica a Miriam al instante: cualquier dato científico aparece
-            monoespaciado, evocando consola de programadora / cuaderno de
-            laboratorio.
-          </p>
-        </section>
-
-        <!-- 04 ESPACIADO -->
-        <section class="ds-section" id="space">
-          <div class="eyebrow">04 · Fundamento</div>
-          <h2>Espaciado &amp; radios.</h2>
-          <p class="lede">
-            Sistema en múltiplos de 8. Mucho whitespace: la página respira.
-            Densidad de información clínica con aire visual editorial.
-          </p>
-
-          <h3>Escala (×8)</h3>
-          <div class="space-list">
-            <div class="space-row">
-              <span class="label">space-1</span><span class="px">8 px</span>
-              <div class="bar" style="width: 8px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-2</span><span class="px">16 px</span>
-              <div class="bar" style="width: 16px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-3</span><span class="px">24 px</span>
-              <div class="bar" style="width: 24px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-4</span><span class="px">32 px</span>
-              <div class="bar" style="width: 32px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-6</span><span class="px">48 px</span>
-              <div class="bar" style="width: 48px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-8</span><span class="px">64 px</span>
-              <div class="bar" style="width: 64px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-12</span><span class="px">96 px</span>
-              <div class="bar" style="width: 96px"></div>
-            </div>
-            <div class="space-row">
-              <span class="label">space-16</span><span class="px">128 px</span>
-              <div class="bar" style="width: 128px"></div>
-            </div>
-          </div>
-
-          <h3>Radios</h3>
-          <div class="radius-row">
-            <div class="radius-card" style="border-radius: 6px">
-              <span>6 px<br />inputs</span>
-            </div>
-            <div class="radius-card" style="border-radius: 8px">
-              <span>8 px<br />base</span>
-            </div>
-            <div class="radius-card" style="border-radius: 12px">
-              <span>12 px<br />botones</span>
-            </div>
-            <div class="radius-card" style="border-radius: 16px">
-              <span>16 px<br />cards</span>
-            </div>
-            <div class="radius-card" style="border-radius: 9999px">
-              <span>pill<br />badges</span>
-            </div>
-          </div>
-
-          <h3>Lectura</h3>
-          <p style="font-size: 14px; color: var(--color-text-soft)">
-            Ancho de columna óptimo:
-            <code
-              style="font-family: var(--font-mono); color: var(--color-text)"
-              >65–75ch</code
-            >
-            (~65–75 caracteres por línea para texto corrido).
-          </p>
-        </section>
-
-        <!-- 05 ICONOGRAFÍA -->
-        <section class="ds-section" id="icons">
-          <div class="eyebrow">05 · Identidad</div>
-          <h2>Iconografía.</h2>
-          <p class="lede">
-            Heredados de
-            <strong style="color: var(--color-text)"
-              >Beyond the Protocol</strong
-            >
-            — la marca paraguas. Vocabulario fijo: 1024×1024, formas chunky de
-            relleno (no outline),
-            <strong style="color: var(--color-text)">berenjena #2D1B3D</strong>
-            como masa principal y
-            <strong style="color: #2d1b3d">coral #FF6B47</strong> como
-            único acento por icono. En Miriam el acento alterna coral (acción) o
-            <strong style="color: var(--color-text)">violeta #A44DB2</strong>
-            (firma).
-          </p>
-
-          <h3>Set Miriam — set operativo</h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin: 8px 0 12px;
-              padding: 14px 16px;
-              background: rgba(255, 107, 71, 0.06);
-              border-left: 2px solid var(--color-cta);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            Disclaimer. Este set lo monté yo rápido como SVGs vectoriales para
-            tener algo funcional en la web mientras se trabaja la pieza
-            definitiva. No son la versión final. Lo correcto sería encargar o
-            diseñar con IA un set propio que parta del lenguaje del set Beyond
-            the Protocol que listo más abajo — mismo trazo a mano, misma masa de
-            tinta, misma textura de papel — pero con el inventario y los
-            conceptos específicos del Caso Miriam (caso, equipo, historia,
-            donar…). Hasta que exista, estos cumplen.
-          </p>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Diez iconos que mapean uno a uno con las secciones del sitio.
-            Mantienen el ADN BTP en lo conceptual (cuerpos rellenos, un solo
-            acento por pieza) aunque la línea aún es vectorial limpia, no la
-            tinta a mano del set original.
-          </p>
-          <div class="icon-grid" style="margin-top: 16px">
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/caso.svg"
-                alt="caso"
-                style="width: 100%; display: block"
-              /><span class="name">caso</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/equipo.svg"
-                alt="equipo"
-                style="width: 100%; display: block"
-              /><span class="name">equipo</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/historia.svg"
-                alt="historia"
-                style="width: 100%; display: block"
-              /><span class="name">historia</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/ia.svg"
-                alt="ia"
-                style="width: 100%; display: block"
-              /><span class="name">ia</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/datos.svg"
-                alt="datos"
-                style="width: 100%; display: block"
-              /><span class="name">datos</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/ayudar.svg"
-                alt="ayudar"
-                style="width: 100%; display: block"
-              /><span class="name">ayudar</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/donar.svg"
-                alt="donar"
-                style="width: 100%; display: block"
-              /><span class="name">donar</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/compartir.svg"
-                alt="compartir"
-                style="width: 100%; display: block"
-              /><span class="name">compartir</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/prensa.svg"
-                alt="prensa"
-                style="width: 100%; display: block"
-              /><span class="name">prensa</span>
-            </div>
-            <div class="icon-tile" style="background: transparent">
-              <img
-                src="assets/icons-web/contacto.svg"
-                alt="contacto"
-                style="width: 100%; display: block"
-              /><span class="name">contacto</span>
-            </div>
-          </div>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 16px;
-              max-width: 64ch;
-            "
-          >
-            <strong style="color: var(--color-text)">Mapa de uso.</strong>
-            <em>caso, equipo, historia, ia, datos, prensa</em> usan acento
-            <strong style="color: var(--color-text)">violeta firma</strong>
-            (identidad, contenido).
-            <em>ayudar, donar, compartir, contacto</em> usan acento
-            <strong style="color: #2d1b3d">coral</strong> (acción,
-            conversión). Formato SVG vectorial, escalable de 24 a 256 px sin
-            pérdida.
-          </p>
-
-          <h3 id="linaje-btp" style="margin-top: 40px">
-            Set Beyond the Protocol — linaje
-          </h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            El set original de la marca paraguas.
-            <strong style="color: var(--color-text)"
-              >No es inventario activo del caso</strong
-            >
-            — se incluye solo como referencia de la sintaxis visual de la que
-            hereda el set Caso Miriam (mismo trazo, mismas masas, mismo uso de
-            un acento). Si necesitas un icono que no existe en el set operativo,
-            amplíalo siguiendo este lenguaje, no copiando del BTP.
-          </p>
-          <div class="icon-grid">
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/01_comunidad.png"
-                alt="comunidad"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">comunidad</span>
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/02_anuncios.png"
-                alt="anuncios"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">anuncios</span>
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/03_general.png"
-                alt="general"
-                style="width: 100%; display: block; background: #2d1b3d"
-              /><span class="name" style="padding: 8px 12px"
-                >general · logo BTP</span
-              >
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/04_tratamiento.png"
-                alt="tratamiento"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">tratamiento</span>
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/05_ia.png"
-                alt="ia"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">ia</span>
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/06_web.png"
-                alt="web"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">web</span>
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/07_onco360.png"
-                alt="onco360"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">onco360</span>
-            </div>
-            <div class="icon-tile" style="padding: 0; overflow: hidden">
-              <img
-                src="assets/icons/08_fundadoras.png"
-                alt="fundadoras"
-                style="width: 100%; display: block"
-              /><span class="name" style="padding: 8px 12px">fundadoras</span>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Reglas para iconos de Miriam</h3>
-          <ul class="checklist" style="max-width: 64ch">
-            <li>
-              <strong>Mismo lenguaje BTP</strong>: formas geométricas chunky de
-              relleno, no outline. Bordes redondeados. Sin trama, sin sombra.
-            </li>
-            <li>
-              Berenjena #2D1B3D como masa principal sobre crema #FAF6F0. Un solo
-              acento de color por icono.
-            </li>
-            <li>
-              Acento <strong style="color: #2d1b3d">coral</strong> =
-              acción (donar, compartir, contactar). Acento
-              <strong style="color: var(--color-text)">violeta</strong> =
-              identidad/firma del caso.
-            </li>
-            <li>
-              Variante invertida disponible: berenjena de fondo, formas en
-              crema, acento coral. Solo para hero / favicon / RRSS.
-            </li>
-            <li>
-              Composición centrada, padding interno generoso (~20% por lado). El
-              icono respira.
-            </li>
-          </ul>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 32px;
-              padding: 14px 16px;
-              background: rgba(255, 107, 71, 0.06);
-              border-left: 2px solid var(--color-cta);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: #2d1b3d"
-              >Sin set de iconos lineales propios.</strong
-            >
-            Miriam usa <strong>solo</strong> el set BTP (sección anterior) —
-            tinta a mano, no SVG geométrico. Si una sección parece pedir un
-            icono y no existe en BTP, hay tres salidas válidas, en orden: (1)
-            replantear la sección sin icono — la mayoría de las veces, sobra;
-            (2) usar un dato tipográfico grande en lugar del icono; (3) encargar
-            la pieza nueva al ilustrador BTP o generarla con la plantilla D
-            (sec. 12). <strong>Nunca</strong> reemplazar con Heroicons / Lucide
-            / Material / vector lineal genérico — es justo el slop que la sec.
-            12 prohíbe.
-          </p>
-
-          <h3 style="margin-top: 48px">
-            Extender el set — partir de un icono BTP existente
-          </h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Cuando hace falta un icono nuevo (concepto que no está cubierto),
-            generarlo desde cero con un prompt de texto plano
-            <strong>siempre</strong> da una pieza con línea distinta — no encaja
-            en el set y se nota. La forma fiable de extenderlo es con una
-            herramienta que acepte <em>image reference</em>: pasarle 1–3 iconos
-            BTP existentes como referencia plástica, no como inspiración
-            temática. Así el modelo replica grosor de línea, sombreado por
-            hatching y textura del papel.
-          </p>
-
-          <div
-            class="grid-2"
-            style="
-              display: grid;
-              gap: 16px;
-              margin-bottom: 16px;
-              max-width: 76ch;
-            "
-          >
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Herramientas con <em>image reference</em>
-              </div>
-              <ul
-                style="
-                  margin: 8px 0 0;
-                  padding-left: 18px;
-                  font-size: 13px;
-                  color: var(--color-text);
-                  line-height: 1.7;
-                "
-              >
-                <li>
-                  <strong>Midjourney</strong> — flag
-                  <code style="font-family: var(--font-mono); font-size: 11px"
-                    >--sref</code
-                  >
-                  (style reference) con 2–3 BTP existentes.
-                </li>
-                <li>
-                  <strong>Flux</strong> / <strong>Stable Diffusion</strong> con
-                  IP-Adapter o Style Transfer.
-                </li>
-                <li>
-                  <strong>Recraft</strong> — entrenar un <em>style</em> con 5–10
-                  piezas BTP y reutilizarlo.
-                </li>
-                <li>
-                  <strong>nano-banana</strong> (Gemini 2.5 Flash Image) — útil
-                  para edits puntuales sobre un BTP existente.
-                </li>
-              </ul>
-            </div>
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Lo que no funciona
-              </div>
-              <ul
-                style="
-                  margin: 8px 0 0;
-                  padding-left: 18px;
-                  font-size: 13px;
-                  color: var(--color-text);
-                  line-height: 1.7;
-                "
-              >
-                <li>
-                  Solo prompt de texto, sin referencia visual — sale línea
-                  genérica de IA.
-                </li>
-                <li>
-                  Pasar como referencia ilustraciones de Internet en estilo
-                  similar pero no del set — drift al primer icono.
-                </li>
-                <li>
-                  Mezclar en la misma referencia BTP + cualquier otro estilo —
-                  el modelo promedia y pierde la voz.
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <h4 style="margin-top: 28px; font-size: 15px">
-            Workflow recomendado
-          </h4>
-          <ol
-            style="
-              font-size: 14px;
-              line-height: 1.85;
-              max-width: 64ch;
-              padding-left: 20px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              Elige <strong>2–3 iconos BTP existentes</strong> con la línea más
-              cercana al concepto que quieres generar (no por tema, por
-              <em>peso de línea</em> y densidad de hatching).
-            </li>
-            <li>
-              Súbelos como image reference en la herramienta. En Midjourney:
-              <code style="font-family: var(--font-mono); font-size: 11px"
-                >--sref [url1] [url2] [url3] --sw 800</code
-              >
-              (style weight alto).
-            </li>
-            <li>
-              Prompt de texto: <strong>solo</strong> el concepto concreto +
-              plantilla D (sec. 12). Nada de adjetivos plásticos — el estilo lo
-              lleva la referencia, no el texto.
-            </li>
-            <li>
-              Genera <strong>4 variantes</strong>. Si ninguna encaja al ponerla
-              junto a un BTP existente, descarta todo y reformula — no escojas
-              "la menos mala".
-            </li>
-            <li>
-              Antes de aceptar la pieza nueva, pásala por el
-              <strong>test de coherencia</strong> (sec. 12): ponla al lado de 3
-              BTP existentes. Si parece de otro proyecto, fuera.
-            </li>
-          </ol>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 24px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)"
-              >Honestidad de proceso.</strong
-            >
-            Estas herramientas evolucionan rápido — lo que hoy funciona con
-            <code style="font-family: var(--font-mono); font-size: 11px"
-              >--sref</code
-            >
-            mañana puede tener un endpoint mejor. La regla no es "usa
-            Midjourney", es:
-            <em
-              >nunca generes una pieza sin pasarle ejemplos del set como
-              referencia visual</em
-            >. La consistencia plástica es el activo del caso — si se rompe, se
-            rompe la voz visual entera.
-          </p>
-
-          <h3 style="margin-top: 48px">Plantilla SVG base</h3>
-          <pre class="code">
-&lt;<span class="c-key">svg</span> xmlns=<span class="c-val">"http://www.w3.org/2000/svg"</span> viewBox=<span class="c-val">"0 0 1024 1024"</span> width=<span class="c-val">"1024"</span> height=<span class="c-val">"1024"</span>&gt;
-  &lt;<span class="c-key">rect</span> width=<span class="c-val">"1024"</span> height=<span class="c-val">"1024"</span> fill=<span class="c-val">"#FAF6F0"</span>/&gt;
-  &lt;<span class="c-key">g</span> fill=<span class="c-val">"none"</span> stroke=<span class="c-val">"#2D1B3D"</span> stroke-width=<span class="c-val">"48"</span>
-     stroke-linecap=<span class="c-val">"round"</span> stroke-linejoin=<span class="c-val">"round"</span>&gt;
-    <span class="c-com">&lt;!-- contenido del icono --&gt;</span>
-    <span class="c-com">&lt;!-- acento: violeta #A44DB2 (firma) o coral #FF6B47 (acción) --&gt;</span>
-  &lt;/<span class="c-key">g</span>&gt;
-&lt;/<span class="c-key">svg</span>&gt;</pre>
-        </section>
-
-        <!-- 06 AVATAR -->
-        <section class="ds-section" id="avatar">
-          <div class="eyebrow">06 · Identidad</div>
-          <h2>Avatar.</h2>
-          <p class="lede">
-            El avatar a tinta — pelo violeta rizado, gafas redondas, anotaciones
-            científicas manuscritas — es el activo emocional del caso. Vive en
-            RRSS, campaña y secciones narrativas de la web.
-            <strong style="color: var(--color-text)"
-              >Esta es la pieza de referencia canónica.</strong
-            >
-          </p>
-
-          <div class="avatar-row">
-            <div
-              class="avatar-card"
-              style="padding: 0; overflow: hidden; background: #faf6f0"
-            >
-              <img
-                src="assets/miriam-avatar.png"
-                alt="Avatar Miriam — ilustración a tinta con pelo violeta, gafas redondas, anotaciones científicas XLR2×9 y squamous cell cluster"
-                style="display: block; width: 100%; height: auto"
-              />
-            </div>
-            <div style="display: none">
-              <svg viewBox="0 0 320 380" xmlns="http://www.w3.org/2000/svg">
-                <!-- Hair (violet) -->
-                <path
-                  d="M 60 130 C 60 80, 100 50, 160 50 C 220 50, 260 80, 260 130 C 268 145, 270 165, 262 185 C 274 195, 274 215, 262 230 C 270 240, 264 256, 252 260 C 252 280, 240 290, 232 290 L 88 290 C 80 290, 68 280, 68 260 C 56 256, 50 240, 58 230 C 46 215, 46 195, 58 185 C 50 165, 52 145, 60 130 Z"
-                  fill="#A44DB2"
-                />
-                <!-- Curl details on hair -->
-                <path
-                  d="M 95 110 C 100 100, 110 100, 115 110"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  opacity="0.4"
-                />
-                <path
-                  d="M 200 95 C 205 85, 220 85, 225 100"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  opacity="0.4"
-                />
-                <path
-                  d="M 240 145 C 250 140, 260 150, 255 165"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                  opacity="0.4"
-                />
-                <!-- Face -->
-                <ellipse cx="160" cy="200" rx="72" ry="84" fill="#FAF6F0" />
-                <!-- Glasses -->
-                <circle
-                  cx="135"
-                  cy="195"
-                  r="20"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="3"
-                />
-                <circle
-                  cx="185"
-                  cy="195"
-                  r="20"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="3"
-                />
-                <line
-                  x1="155"
-                  y1="195"
-                  x2="165"
-                  y2="195"
-                  stroke="#2D1B3D"
-                  stroke-width="3"
-                />
-                <!-- Freckles -->
-                <circle
-                  cx="125"
-                  cy="225"
-                  r="1.5"
-                  fill="#2D1B3D"
-                  opacity="0.7"
-                />
-                <circle
-                  cx="135"
-                  cy="232"
-                  r="1.5"
-                  fill="#2D1B3D"
-                  opacity="0.7"
-                />
-                <circle
-                  cx="185"
-                  cy="232"
-                  r="1.5"
-                  fill="#2D1B3D"
-                  opacity="0.7"
-                />
-                <circle
-                  cx="195"
-                  cy="225"
-                  r="1.5"
-                  fill="#2D1B3D"
-                  opacity="0.7"
-                />
-                <!-- Smile -->
-                <path
-                  d="M 140 252 C 150 262, 170 262, 180 252"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="3"
-                  stroke-linecap="round"
-                />
-                <!-- Body -->
-                <path
-                  d="M 75 380 C 75 330, 110 295, 160 295 C 210 295, 245 330, 245 380"
-                  fill="none"
-                  stroke="#2D1B3D"
-                  stroke-width="3"
-                />
-                <!-- Annotations -->
-                <g
-                  font-family="Caveat, 'Comic Sans MS', cursive"
-                  fill="#2D1B3D"
-                  font-size="14"
-                >
-                  <text x="20" y="155" transform="rotate(-8 20 155)">
-                    XLR2 ×9
-                  </text>
-                  <path
-                    d="M 65 155 Q 50 175, 60 195"
-                    fill="none"
-                    stroke="#2D1B3D"
-                    stroke-width="1.5"
-                    marker-end="url(#a)"
-                  />
-                  <text x="240" y="180" transform="rotate(6 240 180)">
-                    BC-SCC
-                  </text>
-                  <path
-                    d="M 240 185 Q 230 200, 220 195"
-                    fill="none"
-                    stroke="#2D1B3D"
-                    stroke-width="1.5"
-                  />
-                </g>
-                <defs>
-                  <marker
-                    id="a"
-                    markerWidth="6"
-                    markerHeight="6"
-                    refX="5"
-                    refY="3"
-                    orient="auto"
-                  >
-                    <path d="M 0 0 L 6 3 L 0 6 Z" fill="#2D1B3D" />
-                  </marker>
-                </defs>
-              </svg>
-            </div>
-            <div>
-              <h3 style="margin-top: 0">Reglas para generar nuevas piezas</h3>
-              <ul class="checklist">
-                <li>
-                  Pelo violeta rizado abundante + gafas redondas + sonrisa suave
-                  + pecas + camiseta negra sólida — siempre.
-                </li>
-                <li>
-                  Solo el pelo lleva color (violeta Miriam #A44DB2). Todo lo
-                  demás es tinta negra sobre crema.
-                </li>
-                <li>
-                  Trazo a pluma, suelto, ligeramente imperfecto. Estilo
-                  editorial / New Yorker. No comic, no anime, no realista.
-                </li>
-                <li>
-                  Las anotaciones científicas son siempre
-                  <em>handwritten en mayúsculas</em>, en negro tinta, con
-                  flechas curvas finas apuntando a elementos genómicos /
-                  celulares.
-                </li>
-                <li>
-                  Las manos sostienen o señalan elementos científicos (hélice de
-                  DNA, cluster celular, micrografía). Composición busto
-                  centrado.
-                </li>
-                <li>
-                  Fondo crema con grano sutil — nunca blanco puro, nunca
-                  degradados.
-                </li>
-              </ul>
-              <p
-                style="
-                  font-size: 13px;
-                  color: var(--color-text-soft);
-                  margin-top: 20px;
-                  padding: 12px 14px;
-                  background: rgba(168, 85, 181, 0.06);
-                  border-left: 2px solid var(--color-miriam);
-                  border-radius: 0 6px 6px 0;
-                "
-              >
-                <strong style="color: var(--color-text)"
-                  >Referencia canónica.</strong
-                >
-                Para nuevas piezas, mantén el estilo: tinta + pelo violeta +
-                anotaciones manuscritas con flechas curvas. Generar con
-                Midjourney/Procreate manteniendo el lenguaje visual exacto.
-              </p>
-            </div>
-          </div>
-
-          <hr
-            style="
-              border: 0;
-              border-top: 1px solid rgba(45, 27, 61, 0.08);
-              margin: 64px 0 40px;
-            "
-          />
-
-          <h2 id="logo" style="margin-top: 0">Logo oficial.</h2>
-          <p class="lede">
-            Monograma circular + constelación + wordmark con <em>miriam</em> en lila
-            como firma. El coral se reserva para el CTA y nunca aparece en el logo.
-          </p>
-          <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 20px">
-            <div style="border: 1px solid rgba(45,27,61,.1); border-radius: 16px; padding: 36px; display: grid; place-items: center; background: var(--color-bg)">
-              <svg width="150" height="158" viewBox="0 0 360 380" role="img" aria-label="helpmiriam.com vertical">
-                <g transform="translate(60,0)">
-                  <path d="M192.94 24.47 L199.74 37.67 L212.94 44.47 L199.74 51.27 L192.94 64.47 L186.14 51.27 L172.94 44.47 L186.14 37.67 Z" fill="#9D44AB"/>
-                  <path d="M48.33 173.84 L52.75 182.42 L61.33 186.84 L52.75 191.26 L48.33 199.84 L43.91 191.26 L35.33 186.84 L43.91 182.42 Z" fill="#9D44AB"/>
-                  <circle cx="182.5" cy="184.7" r="3.4" fill="#9D44AB"/>
-                  <circle cx="120" cy="120" r="76" fill="#2D1B3D"/>
-                  <text x="120" y="147" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-style="italic" font-weight="600" font-size="120" fill="#FAF6F0">m</text>
-                </g>
-                <text x="180" y="356" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-weight="500" font-size="44" letter-spacing="-1"><tspan fill="#2D1B3D">help</tspan><tspan fill="#9D44AB">miriam</tspan><tspan fill="#3A3340">.com</tspan></text>
-              </svg>
-            </div>
-            <div style="border-color: transparent; border-radius: 16px; padding: 36px; display: grid; place-items: center; background: #2D1B3D">
-              <svg width="150" height="158" viewBox="0 0 360 380" role="img" aria-label="helpmiriam.com inverso">
-                <g transform="translate(60,0)">
-                  <path d="M192.94 24.47 L199.74 37.67 L212.94 44.47 L199.74 51.27 L192.94 64.47 L186.14 51.27 L172.94 44.47 L186.14 37.67 Z" fill="#9D44AB"/>
-                  <circle cx="120" cy="120" r="76" fill="#FAF6F0"/>
-                  <text x="120" y="147" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-style="italic" font-weight="600" font-size="120" fill="#2D1B3D">m</text>
-                </g>
-                <text x="180" y="356" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-weight="500" font-size="44" letter-spacing="-1"><tspan fill="#FAF6F0">help</tspan><tspan fill="#C77DD2">miriam</tspan><tspan fill="#9B8FA6">.com</tspan></text>
-              </svg>
-            </div>
-            <div style="border: 1px solid rgba(45,27,61,.1); border-radius: 16px; padding: 36px; display: grid; place-items: center; background: var(--color-bg)">
-              <svg width="200" height="40" viewBox="0 0 520 80" role="img" aria-label="helpmiriam.com wordmark">
-                <text x="260" y="58" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-weight="500" font-size="62" letter-spacing="-1.4"><tspan fill="#2D1B3D">help</tspan><tspan fill="#9D44AB">miriam</tspan><tspan fill="#3A3340">.com</tspan></text>
-              </svg>
-            </div>
-          </div>
-          <p style="font-size: 13px; color: var(--color-text-soft); margin-top: 12px; font-family: var(--font-mono)">
-            Vertical (principal) · inverso (fondo berenjena) · wordmark (cuando el monograma ya está presente). En el header de la web: monograma + nombre + dominio.
-          </p>
-
-          <hr
-            style="
-              border: 0;
-              border-top: 1px solid rgba(45, 27, 61, 0.08);
-              margin: 56px 0 40px;
-            "
-          />
-
-          <h2 id="favicon" style="margin-top: 0">Favicon.</h2>
-          <p class="lede">
-            La marca a 16 px. Una <em>m</em> minúscula en cursiva Fraunces sobre
-            violeta firma, rodeada de una constelación mínima de destellos. Es
-            la única superficie del sistema donde la inicial sustituye al
-            retrato — a ese tamaño, la ilustración se pierde.
-          </p>
-
-          <div
-            class="grid-2"
-            style="display: grid; gap: 24px; margin-top: 32px"
-          >
-            <div
-              style="
-                background: var(--color-bg-card);
-                border-radius: 14px;
-                padding: 32px;
-                text-align: center;
-              "
-            >
-              <img
-                src="favicon.svg"
-                alt=""
-                style="
-                  width: 200px;
-                  height: 200px;
-                  display: block;
-                  margin: 0 auto;
-                "
-              />
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.1em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                  margin-top: 16px;
-                "
-              >
-                favicon.svg · principal
-              </div>
-            </div>
-            <div
-              style="
-                background: var(--color-bg-card);
-                border-radius: 14px;
-                padding: 32px;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                justify-content: center;
-                gap: 24px;
-              "
-            >
-              <div style="display: flex; gap: 20px; align-items: flex-end">
-                <div style="text-align: center">
-                  <img
-                    src="favicon.svg"
-                    width="16"
-                    height="16"
-                    alt=""
-                    style="
-                      image-rendering: -webkit-optimize-contrast;
-                      display: block;
-                    "
-                  />
-                  <div
-                    style="
-                      font-family: var(--font-mono);
-                      font-size: 10px;
-                      color: var(--color-text-soft);
-                      margin-top: 8px;
-                    "
-                  >
-                    16
-                  </div>
-                </div>
-                <div style="text-align: center">
-                  <img
-                    src="favicon.svg"
-                    width="32"
-                    height="32"
-                    alt=""
-                    style="
-                      image-rendering: -webkit-optimize-contrast;
-                      display: block;
-                    "
-                  />
-                  <div
-                    style="
-                      font-family: var(--font-mono);
-                      font-size: 10px;
-                      color: var(--color-text-soft);
-                      margin-top: 8px;
-                    "
-                  >
-                    32
-                  </div>
-                </div>
-                <div style="text-align: center">
-                  <img
-                    src="favicon.svg"
-                    width="64"
-                    height="64"
-                    alt=""
-                    style="display: block"
-                  />
-                  <div
-                    style="
-                      font-family: var(--font-mono);
-                      font-size: 10px;
-                      color: var(--color-text-soft);
-                      margin-top: 8px;
-                    "
-                  >
-                    64
-                  </div>
-                </div>
-                <div style="text-align: center">
-                  <img
-                    src="favicon.svg"
-                    width="96"
-                    height="96"
-                    alt=""
-                    style="display: block"
-                  />
-                  <div
-                    style="
-                      font-family: var(--font-mono);
-                      font-size: 10px;
-                      color: var(--color-text-soft);
-                      margin-top: 8px;
-                    "
-                  >
-                    180
-                  </div>
-                </div>
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.1em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                "
-              >
-                Pruebas de tamaño
-              </div>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Construcción</h3>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              color: var(--color-text);
-              max-width: 64ch;
-              padding-left: 20px;
-            "
-          >
-            <li>
-              Lienzo <strong>64 × 64</strong> con radio
-              <strong>14 / 64 ≈ 22%</strong> (iOS rounded square que no se
-              recorta en Android).
-            </li>
-            <li>
-              Fondo <strong>berenjena #2D1B3D</strong>. Nunca crema — a 16 px se
-              pierde el contorno.
-            </li>
-            <li>
-              Letra <strong>m minúscula itálica Fraunces 600</strong>, color
-              crema #FAF6F0, font-size 40, centrada.
-            </li>
-            <li>
-              Decoración: <strong>3 estrellas + 2 puntos</strong>. Dos estrellas
-              violeta firma, una crema, dos puntos crema en opacidad 0.5–0.7.
-            </li>
-            <li>
-              Las estrellas <strong>no tocan el bounding box de la m</strong> —
-              se distribuyen en las esquinas y el aire libre lateral.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Por qué m minúscula</h3>
-          <p
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              color: var(--color-text);
-              max-width: 64ch;
-            "
-          >
-            La web usa exclusivamente minúsculas en su marca verbal:
-            <em>helpmiriam.com</em>, <em>@miriamgonp</em>, los titulares
-            ("ayudar a miriam"). Mayúscula M sería logo corporativo; minúscula
-            es firma personal. La cursiva refuerza la idea de "escrito a mano".
-          </p>
-
-          <h3 style="margin-top: 40px">Por qué constelación</h3>
-          <p
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              color: var(--color-text);
-              max-width: 64ch;
-            "
-          >
-            El caso entero descansa entre dos polos — la ciencia (XLR2, PLX9,
-            biopsias) y la persona (sus rizos, sus gatos, su humor). El favicon
-            necesitaba el guiño personal sin caer en literalidad. Una
-            constelación mínima resuelve ambas: cosmos = esperanza sin ser
-            cursi, y los destellos violeta cuentan que esto va de
-            <em>su</em> universo, no del logo de una ONG.
-          </p>
-
-          <h3 style="margin-top: 40px">Set</h3>
-          <table class="tokens">
-            <thead>
-              <tr>
-                <th>Archivo</th>
-                <th>Tamaño</th>
-                <th>Uso</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>favicon.svg</code></td>
-                <td>vectorial</td>
-                <td>
-                  Pestaña en navegadores modernos. Escala a cualquier tamaño sin
-                  pérdida.
-                </td>
-              </tr>
-              <tr>
-                <td><code>favicon-32.png</code></td>
-                <td>32 × 32</td>
-                <td>Pestaña Safari/Firefox legacy. Bookmark bar.</td>
-              </tr>
-              <tr>
-                <td><code>favicon-16.png</code></td>
-                <td>16 × 16</td>
-                <td>Bookmark drawer. Tabs muy comprimidas.</td>
-              </tr>
-              <tr>
-                <td><code>favicon-180.png</code></td>
-                <td>180 × 180</td>
-                <td>Apple Touch Icon — añadir a pantalla de inicio en iOS.</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <h3 style="margin-top: 40px">Snippet HTML</h3>
-          <pre class="code">
-<span class="c-com">&lt;!-- En el &lt;head&gt; de cada página --&gt;</span>
-<span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"icon"</span> <span class="c-val">type</span>=<span class="c-val">"image/svg+xml"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon.svg"</span><span class="c-key">&gt;</span>
-<span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"icon"</span> <span class="c-val">type</span>=<span class="c-val">"image/png"</span> <span class="c-val">sizes</span>=<span class="c-val">"32x32"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon-32.png"</span><span class="c-key">&gt;</span>
-<span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"icon"</span> <span class="c-val">type</span>=<span class="c-val">"image/png"</span> <span class="c-val">sizes</span>=<span class="c-val">"16x16"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon-16.png"</span><span class="c-key">&gt;</span>
-<span class="c-key">&lt;link</span> <span class="c-val">rel</span>=<span class="c-val">"apple-touch-icon"</span> <span class="c-val">href</span>=<span class="c-val">"/favicon-180.png"</span><span class="c-key">&gt;</span>
-<span class="c-key">&lt;meta</span> <span class="c-val">name</span>=<span class="c-val">"theme-color"</span> <span class="c-val">content</span>=<span class="c-val">"#A44DB2"</span><span class="c-key">&gt;</span></pre>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 24px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)"
-              >Cuando regenerar.</strong
-            >
-            Si cambias la m, el peso de Fraunces o la disposición de las
-            estrellas en el SVG, regenera los tres PNG desde el SVG actualizado.
-            PNG y SVG <em>desincronizados</em> es el bug más visible del sistema
-            — el favicon parece cambiar de color al cambiar de tamaño.
-          </p>
-        </section>
-
-        <!-- 07 BOTONES -->
-        <section class="ds-section" id="buttons">
-          <div class="eyebrow">07 · Componentes</div>
-          <h2>Botones.</h2>
-          <p class="lede">
-            Tres niveles. <strong>Primario coral</strong> solo para acciones
-            (donar, apoyar). Secundario y ghost para todo lo demás.
-          </p>
-
-          <div class="show">
-            <div class="show-meta" style="width: 100%">
-              Primario · CTA único
-            </div>
-            <button class="btn btn-primary">Donar ahora</button>
-            <button class="btn btn-primary">
-              Donar ahora
-              <svg
-                width="16"
-                height="16"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <path d="M3 8h10M9 3l5 5-5 5" />
-              </svg>
-            </button>
-            <button
-              class="btn btn-primary"
-              style="box-shadow: 0 0 0 2px var(--color-text); transform: translateY(-1px)"
-            >
-              Hover state
-            </button>
-          </div>
-          <div class="show">
-            <div class="show-meta" style="width: 100%">
-              Primario · estados loading / disabled
-            </div>
-            <button
-              disabled
-              aria-busy="true"
-              aria-label="Procesando donación"
-              class="btn btn-primary"
-              style="cursor: wait; opacity: 1"
-            >
-              <span
-                style="
-                  display: inline-block;
-                  width: 14px;
-                  height: 14px;
-                  border: 2px solid rgba(45, 27, 61, 0.25);
-                  border-top-color: #2d1b3d;
-                  border-radius: 50%;
-                  animation: ds-spin 700ms linear infinite;
-                  flex-shrink: 0;
-                "
-                aria-hidden="true"
-              ></span>
-              Procesando…
-            </button>
-            <button
-              disabled
-              class="btn btn-primary"
-              style="
-                background: rgba(45, 27, 61, 0.12);
-                color: rgba(45, 27, 61, 0.4);
-                cursor: not-allowed;
-              "
-            >
-              Donar ahora
-            </button>
-          </div>
-          <div class="show">
-            <div class="show-meta" style="width: 100%">
-              Secundario · navegación / acción no urgente
-            </div>
-            <button class="btn btn-secondary">Ver la ciencia</button>
-            <button class="btn btn-secondary">Leer la historia</button>
-          </div>
-          <div class="show">
-            <div class="show-meta" style="width: 100%">
-              Ghost · navegación menor
-            </div>
-            <button class="btn btn-ghost">La ciencia</button>
-            <button class="btn btn-ghost">Equipo</button>
-            <button class="btn btn-ghost">Prensa</button>
-          </div>
-        </section>
-
-        <!-- 08 CIFRAS Y BADGES -->
-        <section class="ds-section" id="data">
-          <div class="eyebrow">08 · Componentes</div>
-          <h2>Cifras &amp; badges.</h2>
-          <p class="lede">
-            Una cifra firma en violeta. Una cifra de campaña en coral. El resto
-            en berenjena.
-            <strong>Nunca más de un color destacado por bloque.</strong>
-          </p>
-
-          <div class="show" style="gap: 64px; align-items: flex-end">
-            <div>
-              <div class="show-meta">Cifra firma · violeta</div>
-              <div class="stat-number stat-number--firma">×9</div>
-              <div class="stat-label">
-                Amplificación XLR2 detectada en biopsia
-              </div>
-            </div>
-            <div
-              style="
-                background: #2d1b3d;
-                border-radius: 12px;
-                padding: 20px 24px;
-              "
-            >
-              <div class="show-meta" style="color: #faf6f0">Cifra de campaña · coral sobre berenjena</div>
-              <div class="stat-number stat-number--cta">12.345&nbsp;€</div>
-              <div class="stat-label" style="color: #faf6f0">Recaudado · 850 personas</div>
-            </div>
-            <div>
-              <div class="show-meta">Cifra neutra · berenjena</div>
-              <div class="stat-number">~35%</div>
-              <div class="stat-label">Diferenciación escamosa atípica</div>
-            </div>
-          </div>
-
-          <div class="show" style="gap: 8px">
-            <div class="show-meta" style="width: 100%">
-              Badge marcador genómico · JetBrains Mono
-            </div>
-            <span class="badge-genomic">XLR2 ×9</span>
-            <span class="badge-genomic">PPB6 ×6</span>
-            <span class="badge-genomic">XLRL1/2/5</span>
-            <span class="badge-genomic">PLX9 42%</span>
-            <span class="badge-genomic">BC-SCC</span>
-          </div>
-
-          <h3>Snippet</h3>
-          <pre class="code">
-.<span class="c-key">badge-genomic</span> {
-  background: <span class="c-val">#E8D4ED</span>;
-  color:      <span class="c-val">#A44DB2</span>;
-  border-radius: <span class="c-val">9999px</span>;
-  padding: <span class="c-val">4px 12px</span>;
-  font-family: <span class="c-val">JetBrains Mono</span>, monospace;
-  font-size: <span class="c-val">14px</span>; font-weight: <span class="c-val">600</span>;
-}</pre>
-        </section>
-
-        <!-- 09 CARDS Y TABLAS -->
-        <section class="ds-section" id="card">
-          <div class="eyebrow">09 · Componentes</div>
-          <h2>Cards &amp; tablas.</h2>
-          <p class="lede">
-            Cards sobre crema profunda, radio 16 px. Tablas científicas limpias,
-            sin filas alternas, marcadores en violeta + JetBrains Mono.
-          </p>
-
-          <div class="show col">
-            <div class="show-meta">Card básica · datos científicos</div>
-            <div class="card" style="max-width: 480px">
-              <div class="eyebrow" style="margin-bottom: 12px">Diagnóstico</div>
-              <h3 style="border: 0; padding: 0; margin: 0 0 12px">
-                Cáncer de mama metastásico con diferenciación escamosa atípica
-              </h3>
-              <p
-                style="
-                  font-size: 14px;
-                  color: var(--color-text-soft);
-                  margin-bottom: 16px;
-                "
-              >
-                Subtipo raro caracterizado por
-                <span
-                  class="badge-genomic"
-                  style="font-size: 12px; padding: 2px 8px"
-                  >BC-SCC</span
-                >
-                y amplificación múltiple del receptor XLR2.
-              </p>
-              <div style="display: flex; gap: 8px; flex-wrap: wrap">
-                <span class="badge-genomic">XLR2 ×9</span>
-                <span class="badge-genomic">PLX9 42%</span>
-              </div>
-            </div>
-          </div>
-
-          <div class="show col">
-            <div class="show-meta">Tabla científica · perfil molecular</div>
-            <table
-              class="mol-table"
-              style="
-                background: var(--color-bg);
-                border-radius: 12px;
-                overflow: hidden;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <thead>
-                <tr>
-                  <th>Marcador</th>
-                  <th>Valor</th>
-                  <th>Interpretación</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><span class="marker">XLR2</span></td>
-                  <td><span class="marker">×9</span></td>
-                  <td>
-                    Amplificación de alto nivel · diana terapéutica candidata
-                  </td>
-                </tr>
-                <tr>
-                  <td><span class="marker">PPB6</span></td>
-                  <td><span class="marker">×6</span></td>
-                  <td>Co-amplificación 7p21 · proliferación elevada</td>
-                </tr>
-                <tr>
-                  <td><span class="marker">XLRL1 / XLRL2 / XLRL5</span></td>
-                  <td><span class="marker">amp</span></td>
-                  <td>Ligandos del eje XLR · activación autocrina</td>
-                </tr>
-                <tr>
-                  <td><span class="marker">Dif. escamosa atípica</span></td>
-                  <td><span class="marker">~35%</span></td>
-                  <td>Subtipo BC-SCC · sin protocolo estándar</td>
-                </tr>
-                <tr>
-                  <td><span class="marker">PLX9</span></td>
-                  <td><span class="marker">42%</span></td>
-                  <td>Proliferación alta</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        <!-- 10 VOZ -->
-        <section class="ds-section" id="voice">
-          <div class="eyebrow">10 · Lenguaje</div>
-          <h2>Voz por superficie.</h2>
-          <p class="lede">
-            Miriam usa <strong>dos voces distintas según el canal</strong>. Es
-            un punto clave del sistema: la web es periodística (3ª persona), las
-            RRSS son de Miriam (1ª persona).
-          </p>
-
-          <div class="voice-grid">
-            <div class="voice">
-              <div class="surf">🌐 helpmiriam.com</div>
-              <h4>Tercera persona</h4>
-              <div class="sample">
-                "Miriam tiene cáncer de mama metastásico con diferenciación
-                escamosa atípica."
-              </div>
-              <div class="sample">
-                "Su tumor no responde a los tratamientos estándar."
-              </div>
-              <p
-                style="
-                  font-size: 13px;
-                  color: var(--color-text-soft);
-                  margin-top: 12px;
-                "
-              >
-                Voz periodística / editorial. Cuenta el caso desde fuera,
-                mantenida por el equipo de apoyo.
-              </p>
-            </div>
-            <div class="voice first">
-              <div class="surf">📱 @miriamgonp · GoFundMe</div>
-              <h4>Primera persona — yo / nosotros</h4>
-              <div class="sample">
-                "Soy Miriam. Tengo 35 años, vivo en Murcia."
-              </div>
-              <div class="sample">
-                "Mañana me hacen la biopsia. Estoy un poco nerviosa."
-              </div>
-              <div
-                class="sample"
-                style="border-left-color: var(--color-miriam)"
-              >
-                "<strong>Hemos conseguido</strong> los 50.000€ del primer hito.
-                Gracias a las 1.200 personas que han donado."
-              </div>
-              <div
-                class="sample"
-                style="border-left-color: var(--color-miriam)"
-              >
-                "<strong>Necesitamos</strong> 12.345 € más para la siguiente
-                prueba molecular."
-              </div>
-              <p
-                style="
-                  font-size: 13px;
-                  color: var(--color-text-soft);
-                  margin-top: 12px;
-                "
-              >
-                <strong>Yo</strong> para lo personal — pruebas, sentimientos,
-                día a día, agradecimientos íntimos.
-                <strong>Nosotros</strong> para hitos colectivos — recaudación,
-                necesidades, decisiones de equipo, llamadas a la acción. La
-                regla: si el sujeto del verbo es el equipo (donantes,
-                especialistas, gente que difunde), va en plural. Si soy yo
-                entrando al hospital, va en singular.
-              </p>
-            </div>
-            <div class="voice">
-              <div class="surf">🩺 Documentos clínicos</div>
-              <h4>Tercera persona técnica</h4>
-              <div class="sample">
-                "La paciente presenta amplificación XLR2 ×9."
-              </div>
-              <div class="sample">
-                "Se confirma progresión ósea en estudio de mayo."
-              </div>
-              <p
-                style="
-                  font-size: 13px;
-                  color: var(--color-text-soft);
-                  margin-top: 12px;
-                "
-              >
-                Voz médica neutra y precisa. Sin adjetivos, sin narrativa.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        <!-- 11 DO / DONT -->
-        <section class="ds-section" id="do">
-          <div class="eyebrow">11 · Lenguaje</div>
-          <h2>Lo que sí, lo que no.</h2>
-          <p class="lede">
-            Honestidad sin paternalismos. Rigor científico real. Calidez sin
-            victimismo. Comunidad sin individualismo. Transparencia sobre
-            fracasos clínicos.
-          </p>
-
-          <div class="grid-2" style="display: grid; gap: 32px">
-            <div>
-              <h3
-                style="
-                  color: var(--color-miriam);
-                  border-bottom-color: rgba(168, 85, 181, 0.2);
-                "
-              >
-                Lo que SÍ es
-              </h3>
-              <ul class="checklist">
-                <li>Honestidad sin paternalismos</li>
-                <li>
-                  Rigor científico: nombres de marcadores, dosis, fechas reales
-                </li>
-                <li>
-                  Calidez sin victimismo: hay urgencia y esperanza, sin
-                  lastimero
-                </li>
-                <li>
-                  Comunidad: "el equipo", "los especialistas que se han unido"
-                </li>
-                <li>
-                  Transparencia: presupuestos públicos, gastos documentados,
-                  fracasos contados sin maquillar
-                </li>
-                <li>Datos reales sin simplificar de más</li>
-              </ul>
-            </div>
-            <div>
-              <h3
-                style="
-                  color: #2d1b3d;
-                  border-bottom-color: rgba(255, 107, 71, 0.2);
-                "
-              >
-                Lo que NO es
-              </h3>
-              <ul class="checklist dont">
-                <li>
-                  Lazos rosas, corazones rosas, estética de "lucha guerrera"
-                </li>
-                <li>
-                  Lenguaje victimista, lastimero o de "ángel en la tierra"
-                </li>
-                <li>Lenguaje médico inaccesible</li>
-                <li>
-                  Estética hospitalaria (azules clínicos, blancos sanitarios,
-                  batas)
-                </li>
-                <li>Stock photos genéricas</li>
-                <li>Alarmismo o titulares clickbait</li>
-              </ul>
-            </div>
-          </div>
-
-          <!-- Diccionario de marcadores de lista: cada símbolo tiene una semántica
-               fija. No mezclar. Documentado tras detectar usos inconsistentes
-               (dots neutros en listas que pedían afirmación o contraste). -->
-          <h3 style="margin-top: 56px">Marcadores de lista — cuándo usar cada uno</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 68ch;
-            "
-          >
-            Cuatro marcadores, cuatro significados distintos. El símbolo — no solo
-            el color — comunica la intención. Elegir por significado, nunca por
-            estética.
-          </p>
-
-          <div
-            style="
-              display: grid;
-              gap: 0;
-              margin-top: 20px;
-              border: 1px solid rgba(45, 27, 61, 0.1);
-              border-radius: 12px;
-              overflow: hidden;
-              max-width: 760px;
-            "
-          >
-            <!-- ✓ círculo relleno -->
-            <div
-              style="
-                display: flex;
-                align-items: flex-start;
-                gap: 16px;
-                padding: 18px 20px;
-                background: #faf6f0;
-              "
-            >
-              <span
-                style="
-                  flex-shrink: 0;
-                  width: 22px;
-                  height: 22px;
-                  border-radius: 999px;
-                  background: var(--color-miriam-soft);
-                  color: #2d1b3d;
-                  display: inline-flex;
-                  align-items: center;
-                  justify-content: center;
-                  font-size: 13px;
-                  font-weight: 700;
-                "
-                >✓</span
-              >
-              <div>
-                <strong style="color: #2d1b3d">Círculo relleno · logrado / incluido</strong>
-                <p style="font-size: 13px; color: var(--color-text-soft); margin: 4px 0 0">
-                  Afirmaciones cumplidas o cosas que entran. Listas de gastos cubiertos,
-                  ventajas del ensayo N-of-1. <em>En la web: icono <code>ph:check-circle-fill</code> / <code>ph:check-bold</code>.</em>
-                </p>
-              </div>
-            </div>
-            <!-- ○ círculo hueco -->
-            <div
-              style="
-                display: flex;
-                align-items: flex-start;
-                gap: 16px;
-                padding: 18px 20px;
-                background: #fff;
-                border-top: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <span
-                style="
-                  flex-shrink: 0;
-                  width: 22px;
-                  height: 22px;
-                  border-radius: 999px;
-                  border: 1.5px dashed var(--color-cta);
-                  color: var(--color-cta);
-                  display: inline-flex;
-                  align-items: center;
-                  justify-content: center;
-                "
-                aria-hidden="true"
-              ></span>
-              <div>
-                <strong style="color: #2d1b3d">Círculo hueco · pendiente / falta</strong>
-                <p style="font-size: 13px; color: var(--color-text-soft); margin: 4px 0 0">
-                  Algo deseado que todavía no está. La columna "lo que falta" de la home.
-                  Dice "aún no", no "rechazado". <em>En la web: icono <code>ph:circle-dashed-bold</code>.</em>
-                </p>
-              </div>
-            </div>
-            <!-- ✗ suelta -->
-            <div
-              style="
-                display: flex;
-                align-items: flex-start;
-                gap: 16px;
-                padding: 18px 20px;
-                background: #faf6f0;
-                border-top: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <span
-                style="
-                  flex-shrink: 0;
-                  width: 22px;
-                  height: 22px;
-                  border-radius: 6px;
-                  background: rgba(255, 107, 71, 0.18);
-                  color: var(--color-cta);
-                  display: inline-flex;
-                  align-items: center;
-                  justify-content: center;
-                  font-size: 13px;
-                  font-weight: 700;
-                "
-                >✕</span
-              >
-              <div>
-                <strong style="color: #2d1b3d">Aspa · rechazo / posicionamiento</strong>
-                <p style="font-size: 13px; color: var(--color-text-soft); margin: 4px 0 0">
-                  Lo que conscientemente NO se es o NO se hace. "Lo que NO somos" en colabora.
-                  <em>En la web: icono <code>ph:x-bold</code> en recuadro coral.</em>
-                </p>
-              </div>
-            </div>
-            <!-- ▣ cuadrito checklist -->
-            <div
-              style="
-                display: flex;
-                align-items: flex-start;
-                gap: 16px;
-                padding: 18px 20px;
-                background: #fff;
-                border-top: 1px solid rgba(45, 27, 61, 0.08);
-              "
-            >
-              <span
-                style="
-                  flex-shrink: 0;
-                  width: 22px;
-                  height: 22px;
-                  border-radius: 5px;
-                  background: var(--color-miriam-soft);
-                  background-image: linear-gradient(
-                    135deg,
-                    transparent 40%,
-                    var(--color-miriam) 40% 60%,
-                    transparent 60%
-                  );
-                "
-                aria-hidden="true"
-              ></span>
-              <div>
-                <strong style="color: #2d1b3d">Cuadrito ✓/✗ (<code>ul.checklist</code>) · directriz sí/no</strong>
-                <p style="font-size: 13px; color: var(--color-text-soft); margin: 4px 0 0">
-                  Reservado para guías de buenas-vs-malas prácticas emparejadas (do/don't),
-                  como la guía de lenguaje de arriba. <strong>No usar</strong> para afirmaciones
-                  simples, pendientes ni rechazos: para eso están los tres de arriba.
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <!-- 12 HABLAR CON IAs -->
-        <section class="ds-section" id="ai">
-          <div class="eyebrow">12 · Producción</div>
-          <h2>Hablar con IAs.</h2>
-          <p class="lede">
-            Buena parte de los textos, mocks y código del caso pasarán por una
-            IA. Si le hablas mal, te devuelve <em>slop</em>: gradientes, emojis,
-            copys vacíos, "empoderamiento", iconos genéricos. Esta sección es el
-            manual para que cualquier IA — Claude, GPT, asistente de diseño —
-            escriba y diseñe
-            <strong style="color: var(--color-text)">como Miriam</strong>, no
-            como un blog corporativo.
-          </p>
-
-          <h3 style="margin-top: 40px">
-            El prompt base — pega esto siempre primero
-          </h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Toda interacción empieza estableciendo el contexto. Sin esto, la IA
-            defaultea a tono motivacional genérico de ONG.
-          </p>
-          <pre class="code">
-<span class="c-com">Contexto: caso Miriam González — paciente real con cáncer de mama metastásico</span>
-<span class="c-com">refractario y un perfil molecular único (XLR2 ×9, BC-SCC). Web personal,</span>
-<span class="c-com">no es ONG ni campaña corporativa. Pide ayuda concreta para acceder a un</span>
-<span class="c-com">tratamiento experimental. Audiencia: lectores adultos, posiblemente</span>
-<span class="c-com">pacientes oncológicos o familiares.</span>
-
-<span class="c-key">Voz</span>: directa, científica, primera persona singular cuando habla Miriam.
-       Plural ("nosotros") solo cuando habla el equipo. Nunca corporativo.
-<span class="c-key">Registro</span>: ES neutro peninsular. Tuteo. Sin diminutivos. Sin exclamaciones.
-<span class="c-key">Tono</span>: lúcido, sin autocompasión, sin victimismo. La urgencia se nota,
-       no se grita.
-<span class="c-key">Prohibido</span>: "luchadora", "guerrera", "guerrera contra el cáncer",
-            "valiente", "inspiración", "viaje", "empoderamiento",
-            "juntos podemos", emojis, exclamaciones.
-<span class="c-key">Permitido</span>: cifras crudas, términos clínicos exactos (XLR2, PLX9,
-            BC-SCC), fechas concretas, nombres propios.</pre>
-
-          <h3 style="margin-top: 40px">Reglas duras de léxico</h3>
-          <div
-            class="grid-2"
-            style="display: grid; gap: 16px; margin-bottom: 32px"
-          >
-            <div class="rule do">
-              <div class="rule-h">Sí — palabras del caso</div>
-              <ul
-                style="
-                  margin: 8px 0 0;
-                  padding-left: 18px;
-                  font-size: 14px;
-                  color: var(--color-text);
-                  line-height: 1.8;
-                "
-              >
-                <li>amplificación · expresión · refractario</li>
-                <li>biopsia · informe AP · perfil molecular</li>
-                <li>XLR2, PLX9, BC-SCC, XLR</li>
-                <li>cifras: "×9", "42%", "5 meses"</li>
-                <li>nombres: Miriam, y los de su equipo, médicos y hospital</li>
-                <li>"acceso a tratamiento", "ensayo clínico"</li>
-              </ul>
-            </div>
-            <div class="rule dont">
-              <div class="rule-h">No — slop universal</div>
-              <ul
-                style="
-                  margin: 8px 0 0;
-                  padding-left: 18px;
-                  font-size: 14px;
-                  color: var(--color-text);
-                  line-height: 1.8;
-                "
-              >
-                <li>"luchadora" / "guerrera" / "valiente"</li>
-                <li>"viaje" / "camino" / "travesía"</li>
-                <li>"juntos podemos" / "unidos venceremos"</li>
-                <li>"empoderar" / "inspirar" / "transformar"</li>
-                <li>"héroes" / "ángeles" / "estrellas"</li>
-                <li>signos de exclamación, emojis, hashtags</li>
-              </ul>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Reglas duras de visual</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Cuando le pidas a la IA que genere mocks, código HTML/CSS o
-            variantes de diseño, añade explícitamente estas restricciones — son
-            las que evitan los reflejos de "diseño bonito" tipo SaaS.
-          </p>
-          <pre class="code">
-<span class="c-key">Paleta</span>: <span class="c-val">#FAF6F0</span> crema (fondo), <span class="c-val">#2D1B3D</span> berenjena (texto),
-        <span class="c-val">#A44DB2</span> violeta (firma — solo para "Miriam"),
-        <span class="c-val">#FF6B47</span> coral (CTA — solo botones de donar),
-        <span class="c-val">#E8D4ED</span> violeta soft (badges genómicos).
-        <span class="c-com">// No inventar colores. No degradados. No glassmorphism.</span>
-
-<span class="c-key">Tipografía</span>: Fraunces (display, italic para énfasis emocional),
-            Inter (cuerpo), JetBrains Mono (datos clínicos, eyebrows).
-            <span class="c-com">// Nunca Roboto, nunca system-ui en titulares.</span>
-
-<span class="c-key">Layout</span>: editorial, no SaaS. Márgenes amplios. Una idea por sección.
-        Datos clínicos como cifras grandes (display 80–120px), no como
-        tarjetas de dashboard. Nada de "stats grid 4 columnas con icono".
-
-<span class="c-key">Iconografía</span>: ilustración a tinta tipo "Beyond the Protocol".
-             Nunca iconos lineales genéricos (Heroicons, Lucide).
-             Si no hay icono real disponible, usar un placeholder
-             — mejor vacío que stock.</pre>
-
-          <h3 style="margin-top: 40px">
-            Plantillas de prompt — copiar &amp; pegar
-          </h3>
-
-          <p
-            style="
-              font-family: var(--font-mono);
-              font-size: 11px;
-              letter-spacing: 0.08em;
-              text-transform: uppercase;
-              color: var(--color-text-soft);
-              margin: 24px 0 8px;
-            "
-          >
-            A · Escribir un texto nuevo
-          </p>
-          <pre class="code">
-[<span class="c-com">prompt base</span>]
-
-Necesito el copy para [<span class="c-val">sección X</span>].
-Objetivo concreto: [<span class="c-val">qué tiene que hacer el lector después de leer</span>].
-Longitud: [<span class="c-val">N caracteres / N párrafos</span>].
-Quien habla: [<span class="c-val">Miriam / equipo / tercera persona del informe</span>].
-
-Devuelve 3 versiones — una más clínica, una más íntima, una intermedia.
-Sin titular sensacionalista. Sin call-to-action explícito al final
-(eso lo lleva el botón).</pre>
-
-          <p
-            style="
-              font-family: var(--font-mono);
-              font-size: 11px;
-              letter-spacing: 0.08em;
-              text-transform: uppercase;
-              color: var(--color-text-soft);
-              margin: 24px 0 8px;
-            "
-          >
-            B · Generar un componente / mock
-          </p>
-          <pre class="code">
-[<span class="c-com">prompt base</span>] + [<span class="c-com">reglas duras de visual</span>]
-
-Diseña [<span class="c-val">componente X</span>] para la página [<span class="c-val">Y</span>].
-Función: [<span class="c-val">qué hace el usuario aquí</span>].
-Datos reales que debe mostrar: [<span class="c-val">pegar cifras/textos del caso</span>].
-
-Restricciones:
-— Mobile-first, hit-targets ≥ 44px.
-— Foco visible coral 2px, offset 3px.
-— Texto base 17px, line-height 1.55.
-— Si propones animación, debe respetar prefers-reduced-motion.
-— Si propones un icono, marca su origen (BTP, placeholder, etc).</pre>
-
-          <p
-            style="
-              font-family: var(--font-mono);
-              font-size: 11px;
-              letter-spacing: 0.08em;
-              text-transform: uppercase;
-              color: var(--color-text-soft);
-              margin: 24px 0 8px;
-            "
-          >
-            C · Revisar / corregir un texto existente
-          </p>
-          <pre class="code">
-[<span class="c-com">prompt base</span>]
-
-Revisa este texto buscando:
-1. Slop oncológico ("luchadora", "viaje", "valiente"…).
-2. Frases vacías que se podrían borrar sin perder información.
-3. Cifras o términos clínicos que se pueden hacer más concretos.
-4. Adjetivos sentimentales que podrían sustituirse por hechos.
-
-Devuelve el texto corregido + una lista de cambios y por qué.
-No reescribas la voz — corrige sin reformular.</pre>
-
-          <h3 style="margin-top: 40px">
-            Antipatrones — qué hace una IA cuando no le hablas bien
-          </h3>
-          <div style="display: grid; gap: 10px; max-width: 76ch">
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                "Miriam es una luchadora incansable que cada día demuestra…"
-              </div>
-              <p style="font-size: 13px">
-                Tono ONG. Cero información. Reescribe con cifras: qué pasó,
-                cuándo, qué se necesita.
-              </p>
-            </div>
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Stats grid 4 columnas con iconos lineales
-              </div>
-              <p style="font-size: 13px">
-                Reflejo SaaS. La cifra clínica es la noticia — debe ser
-                tipográfica, grande, sin icono que la decore.
-              </p>
-            </div>
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Hero con gradiente violeta → coral y glassmorphism
-              </div>
-              <p style="font-size: 13px">
-                Slop visual. La paleta es plana sobre crema. La emoción la lleva
-                la tipografía y el retrato, no el degradado.
-              </p>
-            </div>
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                "💜 Apoya a Miriam en su lucha 💜"
-              </div>
-              <p style="font-size: 13px">
-                Emojis nunca. Corazones violeta nunca. CTA literal: "Donar" o
-                "Ayudar a financiar el ensayo".
-              </p>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Test de los 3 segundos</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Antes de aceptar lo que te devuelva la IA, pásalo por estos tres
-            filtros:
-          </p>
-          <ol
-            style="
-              font-size: 14px;
-              line-height: 1.9;
-              max-width: 64ch;
-              padding-left: 20px;
-            "
-          >
-            <li>
-              <strong
-                >¿Podría aparecer en cualquier web de cualquier
-                paciente?</strong
-              >
-              Si la respuesta es sí, no es del caso. Pídele especificidad — un
-              dato, un nombre, una fecha.
-            </li>
-            <li>
-              <strong>¿Qué dato concreto se llevaría el lector?</strong> Si no
-              sabes responderlo en una frase, sobra texto.
-            </li>
-            <li>
-              <strong>¿Lo firmaría Miriam?</strong> Si no lo diría ella en
-              persona, lo elimina o lo reescribe en su voz.
-            </li>
-          </ol>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 32px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)">Regla de oro.</strong>
-            Una IA es buena reescribiendo dentro de un sistema, mala
-            inventándolo. Tu trabajo no es delegar la decisión — es darle el
-            sistema completo y validar que no se desvíe.
-          </p>
-
-          <h3 style="margin-top: 56px">Generar imágenes — el lenguaje BTP</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 16px;
-            "
-          >
-            Toda la iconografía e ilustración del caso vive en un único lenguaje
-            visual: <strong>"Beyond the Protocol"</strong> — tinta negra a mano
-            alzada sobre crema, con un único acento de color (violeta Miriam o
-            coral) por pieza. Si encargas a una IA generativa una imagen, este
-            es el ADN que tienes que describir. Sin esto, defaultea a flat
-            illustration tipo Notion / Linear / SaaS — limpio, vacío,
-            intercambiable.
-          </p>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 8px;
-              padding: 14px 16px;
-              background: rgba(255, 107, 71, 0.06);
-              border-left: 2px solid var(--color-cta);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: #2d1b3d"
-              >Idioma del prompt — regla práctica.</strong
-            >
-            Plantillas <strong>A, B, C</strong> (texto y mocks de UI) →
-            <strong>en español</strong>. El modelo se queda en "modo español" y
-            la voz Miriam sale natural; en inglés se cuelan anglicismos
-            prohibidos. Plantillas <strong>D, E, F</strong> (generación de
-            imagen — Midjourney, DALL-E, Flux, Stable Diffusion) →
-            <strong>en inglés</strong>. El vocabulario plástico
-            ("cross-hatching", "fine-tip ink", "warm cream paper grain") tiene
-            mejor fidelidad. En español la calidad cae notablemente.
-          </p>
-
-          <h3 style="margin-top: 32px; font-size: 18px">
-            ADN visual — pegar en cada prompt
-          </h3>
-          <pre class="code">
-<span class="c-com">// Identidad gráfica común a TODA la iconografía e ilustración</span>
-<span class="c-key">style</span>: hand-drawn ink illustration, fine-tip pen on cream paper.
-<span class="c-key">line</span>: black ink, varied weight (0.5–2pt), confident strokes,
-      visible imperfection. Not vector-clean. Not symmetrical.
-<span class="c-key">shading</span>: cross-hatching for shadows, never gradients.
-         Dot stippling for soft volume.
-<span class="c-key">paper</span>: warm cream <span class="c-val">#FAF6F0</span> background, slightly off-white.
-       Subtle paper grain visible. No drop shadows.
-<span class="c-key">color</span>: monochrome black ink + ONE accent per piece —
-       <span class="c-val">#A44DB2</span> violet (concept of Miriam, the patient, identity),
-       <span class="c-val">#FF6B47</span> coral (action, urgency, donate, click),
-       never both in same piece, never any other accent.
-<span class="c-key">composition</span>: a single object/scene centered with breathing room.
-             Annotation labels in handwritten cursive allowed
-             (English or Spanish), connected by thin arrow lines.
-<span class="c-key">no</span>: gradients, glassmorphism, neon, isometric perspective,
-    flat 2D vector "corporate Memphis" people, emoji, 3D render,
-    photorealism, stock-illustration style.</pre>
-
-          <h3 style="margin-top: 40px">Plantilla D · Icono individual</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Para iconos puntuales — dato clínico, sección de la web, badge.
-            Salida: PNG transparente o SVG monocromo. <em>Prompt en inglés.</em>
-          </p>
-          <pre class="code">
-[<span class="c-com">visual DNA block above</span>]
-
-Generate ONE icon depicting: [<span class="c-val">concrete concept, e.g. "tumor</span>
-<span class="c-val">tissue sample on a biopsy slide"</span>].
-Framing: square, object centered, 30% inner padding.
-Output: 512×512 px on cream background <span class="c-val">#FAF6F0</span>.
-
-Constraints:
-— Black ink only. No color accent (accent is added in CSS).
-— Recognizable at 32×32 px. Detail reduced to the minimum needed.
-— Optional small handwritten label naming the concept.
-— If the concept is abstract (e.g. "hope"), <strong style="color: #faf6f0">reject and ask for a concrete one</strong>.
-
-Return 4 variants with distinct compositions — not 4 cosmetic
-versions of the same idea.</pre>
-
-          <h3 style="margin-top: 40px">Plantilla E · Ilustración de sección</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Para piezas grandes que acompañan un titular — hero, separadores,
-            openers de página. Más densas, con anotaciones, narrativas.
-            <em>Prompt en inglés.</em>
-          </p>
-          <pre class="code">
-[<span class="c-com">visual DNA block above</span>]
-
-Generate an illustration for: [<span class="c-val">describe the scene —</span>
-<span class="c-val">"a microscope with a tissue sample labeled XLR2, handwritten</span>
-<span class="c-val">annotations around it explaining ×9 amplification"</span>].
-Framing: 3:2 horizontal or 4:5 vertical depending on use.
-Output: 2000 px long edge, cream background <span class="c-val">#FAF6F0</span>.
-
-Allowed in this format:
-— Handwritten annotations with thin arrows pointing to parts.
-— Color accent: ONE subtle area in violet <span class="c-val">#A44DB2</span> OR coral <span class="c-val">#FF6B47</span>.
-— Small diluted watercolor / wash patches if they add texture.
-— Maximum 2–3 elements in the scene. Do not crowd.
-
-NOT allowed:
-— Stylized "vector flat people". If a human figure appears,
-  it must follow the team-portraits style (ink + hatching,
-  identifiable face, not generic).
-— Any decorative element without narrative function.</pre>
-
-          <h3 style="margin-top: 40px">Plantilla F · Retrato de persona</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 12px;
-            "
-          >
-            Para añadir un nuevo miembro al equipo o representar un colaborador
-            externo. Coherencia con el set existente es
-            <strong>crítica</strong>. <em>Prompt en inglés.</em>
-          </p>
-          <pre class="code">
-[<span class="c-com">visual DNA block above</span>]
-
-Editorial portrait of [<span class="c-val">name, role, 2–3 key physical traits —</span>
-<span class="c-val">"Dr. Suárez, oncologist, 50s, round glasses, short grey hair, white coat"</span>].
-
-Framing: 1:1 square, bust shot, looking at camera or slightly off.
-Background: flat cream <span class="c-val">#FAF6F0</span>. No context, no objects behind.
-
-Style (aligned with existing team set):
-— Black ink, parallel-hatching shading.
-— Identifiable, specific face — not "a type of person", THIS person.
-— One subtle color patch somewhere (hair streak, accessory, shirt
-  collar) — violet <span class="c-val">#A44DB2</span> if patient/family,
-  coral <span class="c-val">#FF6B47</span> if medical/operations team.
-— Optional small handwritten role label below the portrait.
-
-Mandatory reference: see existing portraits of Miriam and her team. Same level of detail. Same line work.</pre>
-
-          <h3 style="margin-top: 40px">
-            Cuándo NO generar — pedir o dibujar a mano
-          </h3>
-          <div style="display: grid; gap: 10px; max-width: 76ch">
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Anatomía clínica precisa (mama, células, cromosomas)
-              </div>
-              <p style="font-size: 13px">
-                La IA inventa estructuras. Para esto se pide a un ilustrador
-                científico o se referencia atlas médico. Riesgo de comunicar mal
-                el caso = no asumible.
-              </p>
-            </div>
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Logos, escudos institucionales (hospitales, universidades)
-              </div>
-              <p style="font-size: 13px">
-                Pedir el oficial. Nunca recrear con IA. Problemas legales y de
-                identidad.
-              </p>
-            </div>
-            <div class="rule dont" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Fotos de personas reales que no han posado
-              </div>
-              <p style="font-size: 13px">
-                Solo retratos en estilo BTP, claramente ilustrados. Nunca foto
-                sintética que pueda confundirse con real.
-              </p>
-            </div>
-          </div>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 24px;
-              padding: 14px 16px;
-              background: rgba(255, 107, 71, 0.06);
-              border-left: 2px solid var(--color-cta);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: #2d1b3d">Test de coherencia.</strong>
-            Pon la imagen nueva al lado de un icono BTP existente o un retrato
-            del equipo. Si parece de otro proyecto — descartar. El sistema solo
-            funciona si <em>todas</em> las piezas se reconocen como hermanas.
-          </p>
-        </section>
-
-        <!-- 13 ACCESIBILIDAD & NEURODIVERGENCIA -->
-        <section class="ds-section" id="a11y">
-          <div class="eyebrow">13 · Inclusión</div>
-          <h2>Accesibilidad &amp; neurodivergencia.</h2>
-          <p class="lede">
-            Una paciente oncológica leyendo su web bajo el efecto de
-            quimioterapia. Una madre con TDAH escaneando para decidir si dona.
-            Un revisor con baja visión. Un lector con dislexia.
-            <strong style="color: var(--color-text)"
-              >Todos son nuestra audiencia real.</strong
-            >
-            Estas reglas son obligatorias, no opcionales — y la mayoría hacen
-            mejor el diseño para todo el mundo.
-          </p>
-
-          <h3>Principios — neurodivergencia friendly</h3>
-          <div
-            class="grid-2"
-            style="display: grid; gap: 24px; margin-top: 16px"
-          >
-            <div class="rule do">
-              <div class="rule-h">Información escaneable</div>
-              <p>
-                Eyebrows, h2 corto, lede de 1–2 frases, párrafos &lt;4 líneas.
-                Cifras destacadas como ancla visual. La página se entiende
-                leyendo solo titulares.
-              </p>
-            </div>
-            <div class="rule do">
-              <div class="rule-h">Una idea por bloque</div>
-              <p>
-                Ningún bloque combina dos asuntos. Si hace falta, se parte en
-                dos. Reduce la carga cognitiva y permite saltar lo que no
-                aplica.
-              </p>
-            </div>
-            <div class="rule do">
-              <div class="rule-h">Lenguaje literal y concreto</div>
-              <p>
-                Cifras antes que adjetivos. Fechas reales antes que
-                "recientemente". Sin metáforas bélicas, sin ironía, sin dobles
-                sentidos.
-              </p>
-            </div>
-            <div class="rule do">
-              <div class="rule-h">Movimiento opcional</div>
-              <p>
-                Animaciones suaves, &lt;300 ms, ningún parallax.
-                <code
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 12px;
-                    color: var(--color-text);
-                  "
-                  >prefers-reduced-motion</code
-                >
-                respetado: cero animación si el usuario lo pide.
-              </p>
-            </div>
-            <div class="rule do">
-              <div class="rule-h">Predictibilidad</div>
-              <p>
-                Misma sección = misma estructura. Eyebrow + h2 + lede +
-                contenido. El usuario aprende el patrón una vez y lo reutiliza.
-              </p>
-            </div>
-            <div class="rule do">
-              <div class="rule-h">Sin trampas atencionales</div>
-              <p>
-                Cero pop-ups, cero auto-play, cero modales que interrumpan. Cero
-                scroll hijacking. La donación no se persigue al usuario; está
-                donde el usuario la busca.
-              </p>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Reglas WCAG 2.2 AA — obligatorias</h3>
-          <ul class="checklist" style="max-width: 70ch">
-            <li>
-              <strong>Contraste ≥ 4.5:1</strong> para texto, ≥ 3:1 para texto
-              grande (≥24 px) y elementos UI. Berenjena #2D1B3D sobre crema
-              #FAF6F0 =
-              <strong style="color: var(--color-text)">14.6:1</strong> ✓.
-            </li>
-            <li>
-              <strong>Tamaño base 16 px mínimo</strong>; 17 px en cuerpo de la
-              landing. Nunca por debajo de 14 px (badges, captions). El usuario
-              debe poder hacer zoom hasta 200% sin perder contenido.
-            </li>
-            <li>
-              <strong>Foco visible siempre</strong>: outline 2 px coral con
-              offset 3 px en cualquier elemento interactivo. Nunca
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >outline:none</code
-              >
-              sin reemplazo.
-            </li>
-            <li>
-              <strong>Áreas táctiles ≥ 44×44 px</strong>. Botones, links,
-              inputs. Móvil incluido.
-            </li>
-            <li>
-              <strong>Color nunca es la única señal</strong>. Si una cifra es
-              positiva, además de violeta lleva un símbolo o etiqueta.
-              Daltónicos incluidos.
-            </li>
-            <li>
-              <strong>Skip link</strong> al inicio de cada página: "Saltar al
-              contenido". Visible al hacer Tab.
-            </li>
-            <li>
-              <strong>HTML semántico</strong>:
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >&lt;main&gt;</code
-              >,
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >&lt;nav&gt;</code
-              >,
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >&lt;section aria-labelledby&gt;</code
-              >. Los lectores de pantalla son ciudadanos de primera.
-            </li>
-            <li>
-              <strong>Imágenes con alt descriptivo</strong>: el avatar de una
-              investigadora no es "imagen 1", es "investigadora molecular,
-              sosteniendo viales con DNA y Cas9".
-            </li>
-            <li>
-              <strong>Cifras con contexto leíble</strong>: "XLR2 ×9" se lee
-              como "XLR2 amplificado nueve veces". Añadir
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >aria-label</code
-              >
-              donde haga falta.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Lectura — dislexia &amp; baja visión</h3>
-          <ul class="checklist" style="max-width: 70ch">
-            <li>Línea de 65–75 caracteres. Nada de medidas anchas.</li>
-            <li>
-              Interlineado <strong>1.55–1.65</strong> en cuerpo. Espacio entre
-              letras +0.005em.
-            </li>
-            <li>Sin justificar. Solo alineación a izquierda.</li>
-            <li>
-              Listas con bullets, no comas concatenadas. Cada idea es su propia
-              línea.
-            </li>
-            <li>
-              Negrita selectiva — 1–2 conceptos por párrafo. Nunca subrayar lo
-              que no es link.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">
-            Para pacientes oncológicos — chemo brain
-          </h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 16px;
-            "
-          >
-            Quimioterapia + radio + ansiedad reducen capacidad atencional y
-            memoria de trabajo. Esta web la lee Miriam y otras pacientes en su
-            misma situación. Diseñar para ese estado <em>no es opcional</em>.
-          </p>
-          <ul class="checklist" style="max-width: 70ch">
-            <li>
-              Información crítica nunca depende de recordar lo leído antes. Cada
-              sección es autosuficiente.
-            </li>
-            <li>
-              Acción principal repetida en hero, en sección de donar, en footer.
-              Tres oportunidades, mismo botón.
-            </li>
-            <li>
-              Resúmenes al inicio. "TL;DR científico" antes de detalles
-              moleculares.
-            </li>
-            <li>
-              Glosario de términos al alcance — hover/tap revela definición sin
-              sacar al usuario de la página.
-            </li>
-            <li>
-              Idioma simple para datos clínicos. La complejidad va en notas a
-              pie, no en titulares.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Reduced motion — snippet obligatorio</h3>
-          <pre class="code">
-@media (<span class="c-key">prefers-reduced-motion</span>: reduce) {
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BTP Design System · Cuadernillo de especímenes</title>
+<meta name="description" content="Sistema de diseño de Beyond the Protocol: color, tipografía y componentes reunidos en un cuadernillo de especímenes.">
+<link rel="canonical" href="https://helpmiriam.com/design-system/">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://helpmiriam.com/design-system/">
+<meta property="og:title" content="Sistema de diseño — Caso Miriam">
+<meta property="og:description" content="Sistema de diseño de Beyond the Protocol: color, tipografía y componentes reunidos en un cuadernillo de especímenes.">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Sistema de diseño — Caso Miriam">
+<meta name="twitter:description" content="Sistema de diseño de Beyond the Protocol: color, tipografía y componentes reunidos en un cuadernillo de especímenes.">
+<style>
+/* Fraunces variable EMBEBIDA y SUBSETEADA (latin, glifos usados; ejes ital+opsz+wght+SOFT+WONK).
+   OFL, Undercase Type. Generada por build: la galeria no depende de ninguna CDN.
+   Subset con fonttools: 270 KB de woff2 -> 184 KB (-32%), ejes variables intactos. */
+@font-face {
+  font-family: 'Fraunces'; font-style: normal; font-weight: 100 900; font-display: swap;
+  src: url(data:font/woff2;base64,d09GMgABAAAAAT2gABMAAAAB+EwAAT0uAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGoYmG7NKHIIIP0hWQVKOTgZgP1NUQVSDBidsAIMGL4FkEQgKgY4k8ncwhfsUATYCJAOEHguCEgAEIAWIcgcgWz7oUSPbnNzi6SZSALtV1WhM9/xiFapbOrjqudkEL0FxJht34HZEyvb8jsj+//OOyhiasqcpAKKgejfQFU4wO42bwnSmrc1N54cluWEkBvaj+gzjQXIJsuuc0cF8IZS4L+k5l5Qd/32fs/SHhfChctlrHQ6FCX8hFES7DNHUWwURsVZCnF+v1bOw7zs7womKemAjFPARHWEodHOAfrSzOhhtS3K6GT9kPwbxE6bGT++1WvNFlUWTYxNGUijUC8eJwXMcZeDc4MYfM5/zi3pOK2KjFYc+pOXf3rgNbywl+PXkf/bUDqaKSwnJbUlscOzQhbrcMFxsQrgR0dXMIvS+phN7ffHSvmbicGTHAGesAuwW+ShF5qFPeJ5wrv9z78wkaRrSFmhazLqse9nliTlPxCnlqzj/qQnDw9Na6BtaOsAUEF2Ajahujb2frVFVmoSqtBn/a4z1UN+ymOePWNfFSsBDYWiimbwzNLLdzkVCe6eO/fJP/Xid9j2SBWSZFdlRZAgAjXPA3V11RUVN42cvAIZ4Nwj+SPz/67Kvdx+BuKQqtrv9AbAXKQo2pHQsuf8sRHMmSBYhHCJqYEOhSvCyQMEeWrj9VBYaB6YWnMR/jNHeicabS467RPHE0DwkmmWxToiUjv8dXNOIjJrwc/OsxkrCPwtfpuSw5WCZchnRAG5aqU871RPTptTu/E0FCOYJ4kkISQiB4F5KW1pfO/O7205tgzk16Y7tIgTvbIdaTtMBgWSFBpiVMKCP802+bUdlGiAbRjA826p/s9dbtxWzO9M75YwTRlOiiIiK2AioGBiF0Xfnj4xcBmhuXa3jFsVgGxsjpcTnmD5WYYKZGIkYY7QZgJHYKFjY2JiYgEGP7t0AbbPTntMpSoaECiglFkiGICoimIHOyJVi5DZr5fLnwnW7fSz7/7f+ZXzrIC6tLLJsHoJM0qRMu9zdeyTqOE9AB8Ddg+JtU0oh4WGbZUuC58nuv241+I0aQCulu0mwSapT1Qsgmo0gRoCGelB3JaCQPw/f18n/dzvpSFd+APK+RtRs1KfyzSE4s7yX9ey3vnpoECmFUsyyeMN36iyEolcK7+AfqDmbhJroqesmGeianGouiGhUgRDy/jzvTPvXECaZTJMSLgDOAtLffYxnG7WLUAhxkwG0eUwgW5ZsgSULLbQtIw/Qpn0/iI2owgDDoIFA4jVb8xOT7Zx+sVPxv2+frGtl26RtGoHhv8v6rw440AoX8txHfwL4g3bqwp6FM8pEnU7DRZ6yWoO59D/JNBho0ub1E+AeEe5728tlx84ynImw770CpcmgPWOUJQvY/75U37Z9QIF6kFXlhiTbD149ODYdAavK68l5tSaapIRGkxIEKiBI80FQcjUAhyY5rAIBByqUi0pOMd5uSP8/kD88QqlFTaCkH/i/Jkd9TYhpFdJy9rsY9rNY7mbWc5Wq9Z0GBImUtbek7L0FLw4v8rLD40OFzfF76fFJwEBDEICoAEorkJB2SToorV0Q5UhfoBgkkgpOcUPMoLSBDlXncCm/7vPM8fmwn/fbutdC/899qplckL9QLLUCaJZ1+k68r5vXy6VQFQJe+94yS7fenkVZ1Tpf7ZnY8/WeH3sYjlyLDc5EoIFhqLs5o8AxVFSjlxsF9B4FNDmqLnD8ifXkyVTIlHVZkvWqilx9gGTsB5qUik0dpaYDUhdHt3mc7o6lkCWt4fk6IwGeeG9AB77n+zgAHNyyLAgooXxZe6P3EpD2H9exTpehNgJ6uO1pj7H5v4BtLyItaBkecCL6w/8NK+cpm/QK6xCmskgaRKxrrZWPWFfc+4YK0Gkzewil8V476YRmoc/Lb/nH5lLxTD/7RBTZQAIrFT3GtHIw7P9d51vd1q8krhRRFLog2TdCUHDNW5EBXocBdgfYy0i/y4jUoA1DWMKK9iOihWjAANZqP0AxtEa2ieawUWZipjVpmtNP2d8oj6zVWbdK24Tk+H6PJ3j33uNztY9cfH2LzCJXw4mK6pdKeXffbHFgpD8UiWeKteY57z149PjF6/MLNWTcRPFV86ROh1Lu85BHKsJAVP6A0pFFibNHMzxjPeVx57md16u316Hct37nFO7MqxBZnBbN/0WKSSpMAx2FYI2U+NsZgzwrjBaaxqBZVS4dag9kcTNX+I+hd2o4Z/St98l7VeRHBv+bV3OL1zsTVqo/F2Gf+r7fhp2FCwqxUHjoR8GcpZhC1BnMaP6990WQdRmDZs6+nWuBLLcFvqDRIGfbiLROFLHN5ZLZ0dL5UkjpkhflltAOaiTaRcQz6ZLuY3S/LUGnQk38/qwUVAAETPQKBgpOCkz8WXgZ8LTCeyBVGHQBUxVPwjUMadC5E2KCdcBWQweFoKirM/SQ+DmPvi8fwbsYN4yRjer055p9jqye/6rGEccxw3jNOb6tNwRmnXSEUgWzTtvInWuceHSzCnx3vYIdHHFi2bVwDzKkXMImQpXrZNN9LE+r+OKfuhQN6B+9ISSlhAgxKIEMZKoMDm4yDFQ7AYLc8J/c7ZW3hl9WLumIAJzThQH6gdTJTI1eCUA7vjvWH1HJfyZxDWfdlt4UcEGpLuHTrCFPQHyxKbSDmoq1cXUAiFJsFmxOO8jdndCyYcDe/cW4MHk2TUwlceR0AGuIWG38HzMAjJvp0UxIOVtgc2zSaqZ5AIii2noLfc+/9bV1BoyiQHRX/j0XT67Hss7yH1ny9y7ZfLApsZt4sR3lDFurrliyxQkOxZzwQb9nNGD62PBUV4poy47+v+YIkt6pkRWS7yURyt8ElZRtM7unfHItvcJFCu251fK2LO7NXCk9CbKmpsR0dNUy7ultU6gqPVYlqTrHUb778kYUkp2YsJI6PVm3G7MLW8sywJ7jJYifbZf3r2mZbVE+1JbsZ6G6s/ICCyZT1Suv6ccVWevGBVVaoyQHGbAzqpY+GVncx5Sso7TrqovSuRNK9JayXo0puAc8C4WjfM64i6u+GgNyyU7hSe2eS7ZcyOWL3jrlKdguqlyT+s4sfzxV+OyJwradHYOJ73XbW/6yHv2xp/zNVpa9fqXY/IJwZU0ty1zuX+paX4S+hKI3tkExF54wqYf0xCwvKV/ul7eL24x6heR99Hm9fEsrX65EdZxw154PKOYof7p4f+6Xkgv3lSj1vW/SgmSd3JrH9CJH9u1zzYJr8d/8U1OZ3I6zI0tr2DI7j25plrApvlhSNUl0WRZMi9yK+/gVX3NB9STOBc56aTpNyLaZrWrNgdYoLqXCGRrcgWzJSZwLnK2i0OJAQUDRaEKe/aWL8hR1JIr08lurLzCYkGXz7MAlZBcfU8oyTcSPXh0E5TTPH5Gdp75g3gxM92E5lfbeEAS5KlrKMD6x4vPjyRKkGmr8h32b7KBO3aziPrFvKjjSMhyc0vk5dbpUL+ZYTonqiBR99frJd9oyQg906lOzWCrPuAle98Dt4WMO4OOECZLylL+zic3h+PeSrWQf1KfsGtKWEVhOtxZuksmT9o5K++aVzjYSwp8cLKyZCxeoUstcC9cgdM28qf5NSTM2nUt1VG53E8+29Ha2uPAFKkppQk5391YcSmXKwdm7y6fkFh5n0px5oCfdRYEtobPOoqnNZZH17LrY096J/PoX6dtbSX/fTetbz+E1y7xldSlT3YxuKVMppMxl3yUOmDOcZbkrXhtXAjN+2UlOKkvdpEN3bF65b1n4iJrkKdg+7frKa3ZfSmervLN5Zfb1qn3bCRVvZI8z9tCie6YsNX+ih+w92TarK6wALRmmVucfqTiU9Qeqk4pjpixC1moqD9yiyxg3lI/qpR8GI46BRTPbaC9ciAqDG7bBRgSZTpnNCQ4oJBR78RpPH3yeBEnQA01Js6LqrSGA4s0AiZU5vFcXWpz/dsrObAC6zzjQF+ASUSKOhj5A8uPKEIvEqgqjZITknPOA3L0KuCTzyIQiZNrGuVAYtEMgh268rTDJdeWbJeMHtNJN2CXmukBIfkfWjzISpIgqsbvjUuFdyFBQBrdWfBLQWA2xvXh2gGST6TdYzUqVUjtyZou6FI1A1Hngyaclhp6OEIYbITaHctxEaTk6J4QJVU+JiF+hBYfwSFt0hxRWpkh72ijodNHZAUEnxKvEjoChMY/OMcpwJRdiKwaFkx9bgHgLqMSBwRcNcNBFGGhoVXSXxkVros4T8zgD0DrnCa85HLKRDvraYqBTuAopDgpoERRZ1RooFGHIjUpFZbJrRwl2roIJS0BLhYG1LKE1JLIXdsECUqY4G7BiG0dVx4qiNN6lTKktAOYAsQCSbkF0IaEZaCuSSaYBaeeAa2EHEKWVfM3Dgn/55RU5S32EnnR8XgSzzjin6V/Bq1PL/g7YkScu0eQq+T9HQjsyNOjZxoMBnNm+edKzhfslehhG2LrREURuoDvBlj0awoARTwKxySGQjI697MymcWcepGTrXkB0UV/KczuOGzKz+7jHyNUMRb+FHYQPF9vrS3vDr0UqQu46HLRTEjpaUZZNsBX2hYvh8/BX9IRTFX4CN6GnnGYU/dhpgX70ntNVoQ7T5L/CZ16Y9T/BJ8V/i0GkaAtj3o7PRA+iP2biIc+sHF/wJjJuvqXp2qpPMI6vhY0kWF8dbVPoPANB8LAeeur1x7qzCPn8HRtP5tWN5RUb7ONLPnjq2tSu/LF3nO5VO+7k9jCQxOc/6gdP4+ICzWYkLcf/XydZ5MfV+9/hlYgn7eKbEY9Abd4NXVwg9czPustG/X9HIsViv+dZ62vT+q9dXnjjNOs7zHP/QAnetlvD+QkG8a9z4vrU8e5z9qOjtlFH+c0Vp0lUjj5brMoKY9ijF0E4P110eZSZF1hJvxmvhKOcduNnFeU/hXksR92ivjV4yvurCLVg464uvq5BXfK9FcUiVtB/Hnw5HrP5dpJpYY+Madw/FjfoB4l3TBenzr+fQhclURp9+9fxaVFtHfJZnoLj/HXT09FyX5ySLuZH1/oZsr4e9gnOTep3lxnsa17vHmxh+l8UagtXuxive63+CN3fjslh/M1QP32fGw9gvVxG3Lxp5B2Gayyyn6uT3ouxveKngwm/BT/+//Xm3PsV83vQD8tvjK6O4e81NDqg+CcR9YUvTIM+XEPKm26Nqy+Xlr7+8/p07Kc/xH8vurRZ1gemtTvzX8z9cf+a4e1+nU+dC46PfyPfsVibGOdOOJ/lnGb9XsR/9JXOJ9O/T+Oz/z+c2vv/3L7W8FqvO6zoQbz5zfx3i3VTACXsFwQFCHjpKQTFXvv98//zOEnNSv0K/kPPVrxXcmuO3+++8WxvOm67F18QGHi9dP6a+QWUgdDOHP7lLxUyKu89hZPfWFmfTr8BL/zYNCUM3gBAZA17No1fkNV/gned/uxPKwXsdeO9+9BOgVL+W6f669sbF4xf8rvw6J24z98n59DZuXeM+B/VZ999OzV2v+3mmXde78iP7q5HFH63dQ0Q+98/4LGv/u2an8998M3Fb8+6hhRwY/75/58fo5GObvxXm8H3sa6bT/iXFmyoy1l6TxkncF/7/BV9bI4aK09Rifz6+Ff33/jJeCgT3b1+so8fOxEX26celX47lZsTaz2nF1WujZ8stOW4bXx3fI+EPqlDmS4ttty3aDA91/7JHyTHjaKnfpakUwAocFL3ggW6oeOxMkv/0Wl7D4AGID3wqfze7fcBO67D/7HnaLk18Pe77+MulzmkYktxOQjlu49OAhdcdpmXlw6/7P8PAwkWXN3l+cNbwzcDKbPOln8SRvX5DRADky76EW8C1rjT1fP4zOywEbUbP43G8/syIFJypgyYvpU0+2d2syvfVY9jtfnLe/UCpl+Yjfod8FZ3XZPfYhFuBgDzun2r+EzhTtqTXXQ3xs+ARyWjJ8dkRg88/n358PwLgEoi4IdLx/rO+F2nmwP4YsFP5Gz4JAB0Wkk8kkQ6Sy7TQPmZGCVOrbJDBUqQnwggCwWUprxUkFxUoo7JhFyVa+IqMaIXLbOzpywSlWgkVtzFJN4KqsqAOKlNnMWqdI1kjtKkJmcV1lhz2kpp7gQiynF6RjzFQ7zE52j7W7qGF3JocSKGMBXLY23THZzLeawFpjDUlHhuh8PyRrJpdT6dkXVyRlVyWs7LOUnX03JFQkSiYE2QV3JKA+Qa+Vkm1Ucuk45E0j8dZcrWuSpSQA/XHAlnHgmJVeYCYl81sfSAa7cZ3M5XR4P+m/vVMot8NmCPZkNxn0ehMen6Vf1gn/OzBCA3rHMqz7i5wjWu6dDgIXsBLBYTNwCdelprMAeYT/mLmHNHzj22oMy52bLfbj5yzgNznb+XZA4GQi9ehLJxamPCKJhn1yNMGRRfoCykCAXzfM/oJC/vKTHseZw0CHtb2Qe2fH6Z05dLG2cjHelxSDteaetOsKfMfLAnAAo7CFuvgd2BLIAdciiUVCLTgUO3vvE+u2PdP+3ST6bdif4bdpl+KKZmGlLsmYY5PPtrmPA4FYOknACwI9WdOpf26f46sCW2Cq5WS7+x58HrKU2MjAgNbV3r2F61kcYWOQIC7rq5y0Zkwve6xS8+/H8PBX89A+y/fwSC5SYjY/IbDmExRLZtsl2CERlF5IzSFqIzgNUh3AnItu3mQVeiWIu51vELScoqKnvnozzf/FLojxLV6jUTwCj6Q9P/y2qqMx4EEuK+PkdJD/OpyyBois7DADmbfj5+afzi+F8ZMP15/N05et8Kepu32GqzDcb1eR5WWWOZUUNja7++H0FfAoBsKbGdBxJrDrXmEp/ri7QKm5ilUNEFKJdHSSVZNjEDET0JqXx5CiQwARkXdOhPYl+4G2bc8cATb3wYgC9++BPASCVkSskprxaBsNJ7jRLJ6k2uktbP/1lSczrIL6yWWaQq9SjvaxNrqSYlgLDSZ8T6gQmqXyZOAs3ZZcFpoUT+n1+Qk/jsuv9peUn8/72gRdKzm2mlQCyegkjt43tKUdAvlGxy9Ny/mTwXB60oRQQ0cNELZ1pWoIFBGqgdq5oFKBjNGOmWApS6BaB7MzFoXgRUGu9COL1IrV1YtVAHTsFmDMlIsX/0+fIRX6FuydU1vqdijdkhe+7OSmw6Ihf07vVeoIfrkalj9oTlmC1YrrN8i12KRFGNLI7ppIbC0QO27frwGfgAx/muaTdiiOF4qMaeDbbdm7W9ZtdM+XjLrjE4fY5LeC7EaayyI8qnN1AXjM+dsfMNd3XBOqZvTLqzq07UuRnXGA4fEl07xB6LhApbsQyXP+P8vbVIxkkeiTIJOYRisZA6oecii0Z1iDKbKwOicsM+fVi5w1/RQBOXHUMyYIgsDvWHbizk44BKHwnFt692UjmmQB9QcPVa/0ifChAhM021lPoEGOu9BiFVJvLEYj8E6aYYLfz6CPF8UtiuGKvkWrRBes/JCne+Z1BNULEeBP2gPFEyRfgRQOQEP0T94bt6oQYhEj3+KXtKjM9JH2F1x9OjcsMt++xIZZJ5h47+s6teLf1JIBTR+kQxG3K6z19I69z9lbTX3lPGOnsabz9ilZk9J6lz+JhE1glE49eOOCmjgupMiZrTVT3l1Bnj6OXNH23gBE2lzfpF1vA4VJzqgybbngT3VEeKi79VKbBIBZEkAb6iq4RUs/PQGWbi0OTM2KScpA+GXxBejAHDNGhzLzwPaEMX1o3qDQ2LZasHA++0sy7hZyb9I1MLOlLPZdTqC1TNIN6VqgG6waL9EuCdfBUh970edizXIHP9igsanaLazviJaGcXmwLfcMbUeNsewFdoYFQmjeuGJCQ/Z9i6W/bWu6dB0AbCCBkpybqRDmUEF7Vsp2rhhg23M+H/tU4s1+rQRaBInDT3DbqFYfR3NLNJeGr+qx5ylyvAEbbhGT/L115EYFmE/CVVN/JPKNA3k79DZfdw9AkaUpxENSpVLpMiufJxRyEASsJoXJhvJPZGKy8xvfK+o3/taQOA+HJQt2CoUlyb6L78Lr6ITHQvsnh6/HI7HWo85JkAv1PDU7zZ2UlvXl1sEyyZLUNu8J4yLJe6hQooT1UcZIVAEBKaRo/pJGuXdkF8lhCpgybvaHtUKQcvHeLpRA2ttUHTHeFixugbKndbmwr1DtZcZTv3VAp1ch3Z7BlgKjlLCKlRjew7DV0uWaMqT3LGUjn+fg0CiU8Gu8FxpbAi1B8C8BHiswbyIr26IODI/tOcsZA+jOg5uUkYhRSHTjSt9RgKXfEV2l1nkrCVbl8H5yAshGc8F/OZ30GH5KKSE/FnHTMG7ZFTUMbmCDGuW+gRA7ciQhiL/R0LLj8eqxEfvh7mM2PjV1l8bf6umO6PzEKBg3pIPqYK1czJRbLOLygjRm+XtCb+hkDGKSRe1PvYDvVhNZrUtdQhw0Fxgu/UEgqcmYfZUl9LAxRc8M5ECRgGKIVNDFhAiCnZx52z4nYJRfUil/FotDCEBM7v5+MoDaOnBIchDEHQVCrJmKKHRFYtQJMiMJ30UlBxYiGEtklmM7ZPKXNIqy3DeK8062++wyDgz0w3nSWGXXBfL4zRWh4pW9RTVTn9mZkqzXG9skHSeByVrTjPRwxoX41FWI8phI1bMMrv1iWkDRiARmqFDCh3gFEA5GKiU3CSq5yWPCGHHXrRSvu5L5idp6P++O6P1L1Yu8cqm7kRyGRzW4GORC05Sq35kYIVec3wSBVV9Rz9R3Jn8ujOJbfvDEL/CHTtcjilx9PTWwRLNtizOL0G7+Ds0W0NVl86sMyHNqa/T9IW9I/OcpNG7S4x5jxCwi0SGkkeCIya78dYLU+itiwCdKqsJu1A34FB4FrE5ase76mpZ1LVNfdldDhQdRJfqabkTORuRV46sPKxlPLO/bzd7VjaMPP59Or88ybqWOXk7udxW+eu8ZkpctenJdJC3wGy9Ff40n2uM53nxXh2c1Cg8djU3SmpoKmTHnZrFbE0E5onihyutOB3ckJwPOGrqDIY4N8kUIFbTyHrA5KFda2hTFwReLpOjYHgkxPBp69GejwQ4oZx0Qgu3AJrIkN9WgoIYRFoEAejljG0EY1NgPifrK2m5BypcVosNNCrnhQAQRrVTFiLXxMOcqvfD6qHmkb53FzgADGh9wBMRLt9nCATqcUOSk9a/6syvS91LD617oPJ0xqjoupemCU6nGs+HpUzsQftK5LbYQiTPD1UQf5p0cJZtjdjheo7a8WVp8oiMdDJhMTxlEGhOkbmc3SLGoyuW3xRO6diuTTWVgewzTPDfkpfDn7Nf7to985yoYxA6NfhyuBsbo9IbklBqa97LCPqjsxi+1oR/RVD+K/y7r5z0uWiicsTdGyJGEh6cVzYw7hUo8fEsl5dvSAU6TxREgPqJbLFNXhgdqxAX4aEUd3om3UZXTafvhUgZjj+/QniSVR/MveP90CKx66zZw8rPrHyYVRsF4ei9KWgFibyVFL34a8tsNTDA3VWNMPYR4nXt1ycVjr8jjK4foNZI8xHBx5JQ0dmLDZN91YsjGL70bsb2iaRm/sN894e8XbkGXWY/BiOKUP5rYSUTKWH0/KSGuySiJH0/YciAtSvwofaJijMifBl6LG8h4mMAi1qzaLz91OG/L+9vb+UCldPcuCj7BRS5A8/zTtVXm/XSMgMo/eLX+UNFk8VMzt9OfO1DqjYwqUn/RkdBftVabPtqtwXfdaIZmOwIKjvFxQWPOPPGb+6mR9peM7WArmeGpy+rrEVkdZI4ohRtAZ1CZGr8WRA1epCV0ZRqnQo7t4jwIgbvZkX14sXTItNT9Xiuftw+blHsYhsfKK4ZDsUjF+geU2Ma3IuKNMnUw5VmIK1D8wplTLHGKejCSb9kOXHZvkYsEubC4/EtdOffnqdGBv8Iet9k2tt20hoSU/R95l/6yf4CPAGDK5V1PwStEAltFejjFmB3oiYdHI21qlk24EfJJSFtopdhIW6+jSy3FF1rIUKktVVs4NTFTu09X1xRUb3/yYQjX/O+QghhBB5R3YqLRaTPCqH5PJEzal1XxzVYYiWjhyX4kzEgdsbEAm8Sd7KqDNZEIYbo2+Eob76dNx2m+RQUwczBv2wMrhsrPioefH30igwXiFGmuKnBHBSrKRDJ4ArXFCfWsa4UdkR9BOWQ1NFrF59LAEej7B0JehrnpAxBU5eaRCZu3q1kGhrWXrC6dqqFilFPnFShA81ni8YL8lU3WAymxUPTPjExdeKmZ2abmAT+W3TOx2jdxEtlVFNGu6BZSt5f4NO1BrLzp+EGgXT4IqLYKF+AAccq5K5sfSs50yDW54TE9L+y+1bt8+lLyKtqM61UA1/+r0G5WK+M2K76BUdJEk0NjJ41Rb9yN09iAigP3fue0uCU23bRNjaOt5oGJf29smo493Otol/NaB1rQ7/OEOxofFyBUh1YdOTrJpsiNYWBbvF9WI6WbyoG/vuA483aviCpvtN98W/bFQZZ/pu6oz91U79/eTD/LghWlYsC/tjW4YsW8R2YC5OwyOCPlK/yak3hB3SMoOXp5uCbO48Pi0obiws1QPLRlRBU55k49sB5CzJcw7vGSvr5r/lhlvf4DKt3XMk6o+BukbHY2oG8k/r3JqfqtgTq6OpIj/iz3m3es602HRVFtcJ0vMAVhRT//a3goYLWV3BfBqT6kuG1NS9xSVd8MUPqF7+v+8VF0TQBD838e3gLLSncy6I9uQ4rolZGh+4XM3kH3LGLlZBc9S84P+/mcfzk1XAyE4/NOPa6aKIERzUME/noYGogjzikSNRx/MQ+GG6iz6MR7WV9nX/CuIUgSXY44TZKNwIPYjRjkOsHpsaa/w9OO/KStCXNZ9nTR89XnYMyNQbl7gfCqTRR3DRHMfyhYhjiIXLHZxo/DC96QysaPTw3ILGFc/Txs+Of0/tXblz0L3ymiaXH1VryxH3NmtTMf8LpLGJnJgkdkSuwtncAqRig0bz2NiCX3W9jxRHdmvurCsJPHFuKnLEUY2T4xEYQwUWEbihMGch8KLS+ITd0NTezpWrq+VGV9iRupMFU/vmNRRvL40pCqypzRMC1iGF/oZXcYhecfdsbfDGo7tDpZt+u0wfeVmS0lOU9Gj/Iu7DwrHBJAfrTdw4H8DnBfgIRWD5oAPBu6+Paw8/dzjA93+jCMRFbtuDH6Z/Zu4WkxjXfS3w9VmvE3pA4QZtvo5vgfC6HgkuxkZqq5lFC2KbPlC+UT5vsIu/P2PhCJNMtIP+sAJieI3MaV9n1NSfUyIXajyH2W68soKqsjBJ+UxE7v5j3/cQcCN0u1v/Opg1MivRBNes4sPjftYLXGnLDwP2Jl0M4lGAtBKVVkgj5GJOQ+FDSfQaYvIG96K9k47AiTXOgJ/HZzjHCubgdHhUP/5J09jWPsjRlC1rTnqy8lyW/+aOCoSwZBz6EMJ7eewlAYkdonsxhjCI1SuK+U0IYNMjxlFjQAVidY+DE40boQsVTK0jw/j3iZ7VCH7IsUZfJsD+By+i5D7kItCOTy89N48Uzp6bbamoLbNxaVzOUg6baROWMPvzPiNz9h/74zThyGr7Im8mISrxVkQ6ECX4656ZpCtMvDjWitzG4YuNerfn1hObw6yXj5g73fKpF6YbdqVsL0bgRug8+ggeWUNZDvVqNM5EMGzH34uQ344jXMFi1NfXT79VnQqvIut5Bow8KVQv6XOPnoE4vjEv+/tXDyRLBGL+2r0TIJl7MAgO3ktD6zSx0vbPfzmgxxsdr8XBHl/GwfpuR1ENEreMzmSM4JAF5yrui4I81//e5ocIFaK0E2HYgPESxL6guRDPM7FEN9lJXwYM30mn0ttxuI8r1e/PCD2lZk3Kv47lw2hZ6gKhhoM1AmQpzrWLv2sYx12W/qM87jXl7qCuMNM9BDdINNHCR2g1A/G7MmO+QdVjLPxwBJ8+jOcsTz8jj39JuwQXWAaHQnAjpE4JL/gJlrZ+0YA1N9rLR70cYH1buxNcOvlTYfDE8oIZJ38Jqty6o/yEp38uUHunO0NAfcoxUZjNiVYpQ/uKVxG+8o8HgB0qa+875V1ysOEQR82Y1WKTE3SBkZomkao9v8a0oT89A+4fMD6Mj/rO7W+B+26tlXzImnzSN9Cx+vS3xf4p6OjrMNsv68kNKWP51uZQbWy3FQkmQwKHlkQ1fJeRZNbVsv6RujfA96oDGSnLVhdXhqSnwtJAsYLCoGQcCZiHL5PPZDS42vrLjRv7stKpcDA9W1kqmV/8p6Vl5287p0+1f2/BXi7tywHdP0QfzbKgs//cx6jPAmyPPA8lRcHguUozFFdTEmNJmHiNooUK6+pa69mJyXk6ZVSkckA6QBtjHJ2ffLi1de7Zl7NXm6tRJjQW4bxCxB/6y6ocWeaHDAtMnLt48VCC3JiaKqdHqHq1fVHLuAcXmLfUtrSe/bgBQOxvXM0UBQqRrKkXibqGSfJ3LzCuLrlVzWVyPML2GWSpxPHgMDTcSn/V5eb1HTJZ1P3N5sWUJ1IoCgSev7889CO/vPeXUg8cbpRSQx3F4VjaQ61EcTT1kcyzgN8655Jbw/nzM50dF/pAwZ7pnipiCLqCX6wKEuBGqXN2KxVq7elwognIBLdC0kT7cF1ml1Ldbld6WoHEUS7eRU+gD+NhAysviaMkUBXIQ/3pFwwfm405UyJCNOhKHzhk/097Kt+tNkThh+mJDBceMbB11ti16eDzs+fVhDz9xR0qhh/vGwMkPxGvhATl6cZGyDS8CJWBFuFp4MzB4OSbw6dWCK2hUJwrgkl34SJP+nVtuBj0dPVoYWL7YfxwBJXuwsPsl46bWWKQZNaZ3x6dg2kdyUd5g7LWg2puXmV4M0sSoH1ALhk+f/nhhqM3g0hru/NAnOfXINJnzWoBkLz5reFacNPWG0e8q9n0ERxmz28qt7VCMmfxj2V7VQ+yE9eKmRkyHMqtaHMDqW77q/EI9uhM25Q6dhiJzwunp0qQKUR2gipWY3Os52nHjUuP3y51IHC1YYwILAG22G3j06xbwGOPd9aw4eshMSdKtqZboPhhemh3ExO17PXSCO/sZcqwufoQ9ZdSWLWoDE7Vu0uo/SssqGLzQ+HVMLy+UEAXu8fI3/TGDmEmhajYiXaMEq24Lv9OWVer1u8jAOC8meFkKS44AM3Yt5NZIBakEeTJRN0wiL0e7F8UCd4Q1fC/N+JAhhs5Gw9iAss/DvvYSRkgIYshFZbqjLIMq04uaXB9TDt489KKzgchNDBI3F34yg/0MoSemD1PmlnZ78gd6vlz9aP4tMAThFStGsqKEQlEfAkTEz4JM0YqDuiL+7f0AESvfsDLsoFvQUkDMcTR0Dl4P89URRgYPib4PcVyFR712TNTrJCm9N1a09twtKn89sD6jq8vuoaa9hWKi8vVDLEpOipSIaWMNlfRuuVCJj9DA4jnt+uqS7Id9lw9XszT0ElnyKXmWsNYj8EqKsTSz12bBaZi0utX3HD0L//cOHB3cKz7yz87t/b8bC7rA6JEux/9o8Bpkx5jGU+oR2i7/kgvEYDRibRp9Jgc6XX0yWfRvDcy0tKgEDJibBpacrnX0nt7rc5fRYD3drZCq1OaimfyufNiy6JINfhS84H1mxdKyjACfR6yccVtx6LlX/7Vsr71019xu8au5BVtB5rmQ+U/FPpfF8AEaifBiUKsPrv07xr815D4iyLTKQicSZ5IwWHBsd9IOn73vY2/zN+us87TmB0pGktettkc5k2O+CGSTTdKxJL4C0T+kTc4DYKi5qSIgahdo90BDSGTM2ZMeR3sdl8RJ7LHxAh06znLQS2zBpDjWFxJDjhjVYPNCB5vdB4D9xYqhOn2x+zzmrSfVlht1b9Ijn61eeGM9yjk2e8mI4Rauy45J02ft8PF78mzFdave+7YtPPfvI69DQX1P/zh2Ljrn+zWF82Q1yDaxz+oQzpmfNOHOUFpQVb3ug/ADc/7j9BOvohzDxXpj9IS0WBBSfofu2j3PXE27lLcyV/7235xprQN7fYfoF/hVx2ZxZ3Si0Ld415M8y8OZwVycCLkJgAx3PiBOq+UpnWu37Xoqg+Hj57/iHCSNiLaySMoEYeAu6LfALjhafcBHnPONjvybeASr3qrWots6a0FVUu+IN2Wf78BAlBcaCmzKLQ4ZuGNTQc7dqrSGhT2fFuKObskVUtxkahjDBY/w5SRZONnsp8y+xDzryIin1Bf7abH3KnoVqo9V2ju3gYGMt3YG/MSjK4kdBKdSOQTgcHBkXDfzi9fXIL+PoGu/AGMqCDcxkSiQLf/dv0Ln3MY6ZGY2Q1t/L7UK9n6r/HbOgnpDzgPqwP1C3acoywkeWmc2JO/9raerjT7+K2H3rpELq2TfcjIF+MmdZyG7HhyzB/a9sioNU+2/L+g/8WKhcPPPTu3Za1tscsGh595tgcmV1ipaR6bUAsQLaIxrbQn/eR7bkS2IprFKzUSgLi+28bzBUDv5h8plyWeS/X8iGR9jk7A6md4fiurH9ScDXwdQgOCUzeELpH1DOTHSfR4B5Lu7zUASlhu/Lk9y1haNW+Bq7jFkmJJ1YfP0EDBT0AGKSoFdfU5KSFaO+tWHoWppISJ3nLdkh/I2+i3kxWohyD0XWBXbmwOCfJ19avD2NOF8n7r+ieHHuhssCIoYtMvKAhqA2fXl0v/9lZk0yV5aWUR8VIJKxy5IRlrnjWImMhWD2Tnl40eMTVqLHArEmmNgUMfFmK3tH0++vafGFnuQBJASM6LbyVBvq56fRg7WajoS+dthP/5J4roHz/x19/e/Ns+jiHJTSuPiFsZzdjkWYsRW25uYVZB+cgxU5PRBu9Go1SryJMLX3fy/GUGwBuW/GfNAGOcOH6Ix/IfxoFFnRivUKKapY2kdCzYDwe3EFNyereanOt3r1zzGKMOd1tYkRveHYBVdSkg8DKezEa+d/2bsrxpZKIdB3ZQaYAbYQLz4naM7wZW/DD8PgO66Sl8XB2LhKIriUhVArR06aYWCFx0ZjprzcUYmBhSuqmr2f9qETyIlegQ9DIK1B8p++iMlOKAOkvEi6B/Nv3Ib1v5h1CJpmedOhcq3fKt0PCqqlH31h4pwbUPhYtoge/qnWmC+r0qAWrnHEyWgUXrvtsN28IQRt0SIb0v74S3MNkt55QcD+wtO3mbHmD8ZO9psbFgdBURQsxGg+0nceUCxYY5Z1c98Hjz+AsFUhfvK5MCQqswYF9vvpKgW/UY8ltizqmSFQw45uQLEOdjQu7do/8z01rOS2NoUzwuBDM/SsrC3DjUYBIlAezsH1/Uo/fu8UBvMymMnL/lFkqEPMnL/5K9JkDS79e1UFMgvhME6+ZIYhGiqCeKrdWHOxT5g1tX1FtSslVKtREtMV6Vg0O8I02AgAP/+w3L0KHOwZlSopJg/o+QnwqT4niZKDT2qNASH4iHsF1/v5brt8WbYTKxgaG/s+6XpX3Z3EAHtrr+uED4/3MCzH9gn0MPLQmZvLKmbsni3vau4fsziocO+uxxFvVnmgpzDJEhsq1Cmj57zi3Vrp/sPY31Xe1dpk0jKScX262i8oTmIct8VWn6rvC1ySZmPgmNydFbyW2JStrUwCVD1aIcm6N3k6Fy4S/1pefmlkb9nP2zsjTBvqTxVBw5Eie+LT/93JVlLNOqM0rUhE9/u5IIKqnMpTPtd8/s2TJ74rddF4vHQssl6OjkxyIM3ZzbXSbHFvUAkTxKZGx1vpO1ch37J/grW357Sm7L4APT6Amgmj/ZUFu31RkRbZBKkxpPTUpRjFbaDyR8wlPieHTdL3eTFVaG2YBSritOjqpoXnV0o++zP9RNZGeULb1sWzJ6ud5cmSJLdTDi4yxieq2GBS+gytP/VRrrF4sMSsX1p4UIicWP8BIThFNt/T8VrJoB+L8NNW8YpBCz3kDEa3+HKP1PEDfvGDoSeOb6dX8V9E8U5c8uz3TWLmjIjOujx7AKs7uow/eUmEMUWf07SZlEWCmWCsvLxBJZmVhYLhULK8skAGT0iaulLg/jJ58YRJxykkiZVwcRE35yTN6cOl8o0OY5Uhz48TttPKSssDo9t9NV4BxZsbqQM54/Z8SSDdEOpqUjmRlIp4yVzAKBYIDxKpYq1Q/UZJRbHAr4EOf+/eizP8hbbGsEpbWCEttaefP6s9H373OG4A5FuaUmY0BPlQKjh9/tznr+cWdkOnbelf+6LCnlrxKhK8cSYeWvcvmvf5/Nu/X72ecf699FAMy+70DJOeIMqzFJgk4OP8LbxQW8+nkneUfCLWhJUiNrEogdRaDMdpk1UWyHxM7OYFpMNn1EkgQ5yssbOaGyzzGkytsyCuUpYZSz4aFZ82msOB2PF6dj0eZnhYafI4fJU+5OW6rR3tL5dTySxxtFSpIi9CabhcnOkNjZjii1K3k2BTA8VRvTE78ifnXsEs4ChzYN3NRES9JmJjYb+s3DxkFZW3s7/+Le3AX6e+tFLdcLbP1tLrkImwI8qb15vlGATQoTkl0UZlgYnuIiR30sZCcBqRAeSZG/fcmJgGzureoVkrojXhAtisA8zUVIqbIt6qzu8XkFLS9HH8dsC2qPjkhii7LJAxm3fmQbxq9tQTgvXnBCN7/+MSvj9NNDuuo1i7EJ+FkbouXaO514y56fDC1/vuzWXT3UJfz+cULn+YOC0g+XOmgn1jq/Xu8dBTKA3pEkudE7nexBRIuxUlOjzSIrluoMFfX3JOsaDsWWtOSeJO4HaK6HVA13tiyHa+cOnbYXapRcrr1Y0dlnT8uh8/xrSGVgXA8jfh86pUApheDUenVmpuX/51sRzW71ASWvkutWV6q5lPqmv3Pp1RSnYP/zo5UC9l9S7tfxykoVdwHQ86x/iXs9vJloVUAdFnWmWo/rjYjfh7KQ66RQXBm4hjTPXw4FmJC1N6lbV2g/PN6oYe67fIP29mOP3Ac/A/1OJ9taFaLkKto/l1f/IwUAv2sEpKdsAe3lz3kQSWAMfpxxh2rBx861QjeepemMJsT57WZqV1iuLQJNJI4BXuOlnIOOcv7SQcOZtkbkwshQNi3D1GevqijIqqorK6zf/WfF5MkvJbVHGksb9v43/pM5Pqb+YP9OY19wB6wv2CA1s6F/S02D26L8JxyXVzhKLHOY1jJcxsftUPh/Em9LbH52hNRUXA/oloJ4d7iYRXfSGn+Y3dt/wbNy/84XydXDWdlzmx0F+cVpZXFsU2SkOIY0p3BZZmuyKqyWiCy6d6xtZktw+G9VIYbyXHLobT6pLu4alyEQEKA+ImDhIWgaLuT7ZgYItgXrtgO3ukgK+wcQ8e30haky3qc0WH0F7n+RgWOmkeYEwFSRicLcefzs2T3lBTSUNa0m3Sj2XsUjX8QrLKlhv5LA27CAYXfu/HmZeXllKX1MrowjNA6u3du4qgC7aDHyxR4k5lToclaDAGYdE8yFdM+U1s7Hx6oPPb8ZJAEN1G25rFlq2QleRe7Ob/62Z7ha2ImyrXpd1HaibXTkckDpvolHyZWLgSivtWO3U5395vxGZ2FRVVFWLu9GZIRKyV2L9jt9lPFea2doU0bXjxQvMUcYyHz5DiXJW1XXeiqpoe98ZsWBzkWL7/o1HbyA3DoUc+1bepbgGMD5EaUj0iO0bYiiiiESrRuKOgqXMNPjz4QhZuyZfGjMsNfTtT8i+ZEGoToyS5W7cGRR98bhbmX0QO/BeR2Aq/bz1/DKNflJBfN/Ne709f5xa6+kQ7c8WSMtTpdzalrTazFvBFfvdzZ238J1PN72V17XzuqUgiVPc4973XvLKwtdJ82kzDOIBWwxG5cWZ0/sGc1fQL6XeP3n1sblx2jlgPQWWx9qwFTQVFHQlvuMGWdtY0d6/HrXu90ND61dWDxkphsIC3uUIYTMqNjbNrD4ll/jwYsIGPjXv6ZnJ/zLIsDJHxfQbNqI6MpYXFefMopqtU2sRADFPvIRDAKzgkxehkGiDwHH594RxRf2bf745l+ov7D/3rdX6HMKj7rihYf9zhpvVQwtjQHCj+LjktpDYYDtdqIUHYaJ33CcSju+gZAAl2GIYTY3GLkGgO9YgixC12Gb0LWIwlGIXB4Y1t86jM0hV9MayLW44k2b4CWIBkQLvA6a1waRyQNjBgZH0XnEGlIDoRZdsOd5B66n3NHsGoIiIxpZR8cPd6+V3NFgm2y5hn/+VJnjN2o51N2fwg3fHzqV3tkczQ1nO/hAeOWxORrXCbV2NWqUkjtbojlhtY1gJX6wx+HFY+9io61Qt0Tfp9gqfLwR0QyvlYYoFEExC9eNoPMJ1aRGQg3mbjTrbyEA/nx5Rp8+qScjzeTqV6fb+nVJnWkWfXe/0d6sthZqDRk5CpkjW5dkywd8wrZHF5ddV62ZGHc19AU9BwU8LMwIpoCIXH0Rz+CoMySsx+HJaAQSJpPmJFuVauGDS0g4hHI/mu9Dg4+uDpG2jImstQtrrLU3OyYj5f52gEhesvBmRf2Z1uaWU786Bwdulee/expbJn+tuvh4P9rgtghSACmObt388yhW5z4ALoEW8do2AWjI6I67v+zsLD6w31F96sb5k3se3vLv387sCo+M6FlyMLKHiTBBWwGKy1f1X3+c+MKDcDu7nFPJyqfq9zxIRkT4BRof7OHIpTZtriZLbHy/zYpp0RJ/fRBmZ1dwqlgFVN2e3y1w5N9Bxvd72ApZRp0VEiUBvu2xxJS8LIOfwkeRXz9HZ9aQdxVaH/82bfkRgN9HYBooEs5GNA677hktRj1QOJQaqV9pbCMet/hpGF+lMAwEZsHSizPNluKsdFtRlsU05VvSS24PSC7JTrevCOB3ZwZNVaRXBIhmCgv27khV6ZAHpIozl6649gC4r75uOqwobDWKH6x/So1WtuZ1WphaXtFoLC4wQuN11wUEHvzfWpRhMhfZrekFdrOxwFGHPqYihzWj8C4rdAAk19rL1Id3Y2P1ELSTeJroREP0Yel3r1B/x8O/W6hKCOy3f8nhq9BYDIcQAFBgg31go2cO1m3SC01QDQxAuBvTNegSEaCrlcgYAD9jNjSxbbZhPzzeROY3x+HtCsnmHLx/h4K2b/BOxWbPapAfpyzwmZkuAIAORQpzyn3MD+sTtgLqJAJznCEf/qFPzuY3ZoFMVJybOhM2smzvWcPLUyWAUCxRMj5MLyhA3tPykLzmiGxoFXVeErCs+aenkyG2FTsSEsL/i+uMtB7Bqj88YA4ANBzxH9XmQDJvK9RqmFGkmgzmyenCglOh3YiqqLDLetZonpIk4ExsbMjNRXuAKp+z5xmuU+2jYha34ed1GeXQw0L55bMWZ5c9wYsvV1gjF76L/1Z/ckVbgN1e5hfpZjq7g9ta8yOTgCY5bzZnHXAFSD30o+4NKMoGd80Rlmadh7bhmMScE5BZ4o8abPfyhzRhUZNZ+p8ouXYl9/nne707nbTLvR0uJJ05ZcsYwGy1ZF7yMyGWQf7x9k8n8p56lYwjACAsu7sPBIIF7mHInsv9l5tIcaafv3z2ukY8icj7+wLo/+8PuD1cL1ZZ99ewLa3hPeWfvwg3Dt4ryg6p3fbSPhT/zezQWVbp3oelMSHZkH4QtWUw+Dn4GmwzohTNwS7GPSbsJz2nVNGuhk8ygiJ92FqeD18aS41XCnyFaSKr+ISMqPRRJ2kX6/GGKdOg+XoqIb0m44Rjms/nJORhC/BFVSWHy6y9M5UHIyet/ul//f7f/2/K/b83pw+3PmadfT9RGIcOx1JjH41d8vCIqCj+WFL5666EK7/Zmjz7UaLyLdUHj/GBl6gL+t8/aUUwPfEy2aZ2FFzvosvw688jF3DyroszXiVSm9NJ6U9eDro87/WjYPeNs7tX9j6K1Bxq4g/c9bsnupedCqal6VB6xdaRfUf2+Peb35/LvurY8yj045qPl3Onnb2Pb3886dO2T5fyU863C6OB20VvBWRIZOqGAHA10APsW9AA8b2jWAABA3Ijxg6GgE6h0dCV0F2Yr/YBKqDejS/VAb3G3gNIsXYna3+igA2POUi8WN3neXVtjz/7JTlZ8pjxRS4bs0g078Wh9WroC5L0giGOQcScEV78tVI4pvPdJqGh5umKhprwfBN0qbUGwjesiOfkUi7NhEMFaveYa4nw0v+JpR8TwJ5i/4FFIQJNh2Ty+wfLjXrAqs4I6vGFaqOLASlDJ0vWr4T6YKvW23EXVoiFgxTZauPnPPO4cp9CKVKZOGhr0xz77RfFWKGdn00nXg4LBOyXDSstBWUMqdqk1QxzOx87rsYi0sIWjKhFh0PGRoEBd4zU5p4zxalyIRQg/GbnQSbe/NNq6hsoiZZWRAyATqWep8Vb9f8pg71lkJ2w2dRDGpishqtFVdIuvTwjyPvHMyUFBVq+zpdTS3Vo+tKXur7ymM1rg+WjRiqZ3O+ZmVUridVBZqENmbZmDrHdNqmBL0bVPV9EnaWfxuEYDMzLG4xGwhjpOR4gOd0HInRSJ5+xoOuqwHacNeyeBlk1gzbAhpnq1/2nA1lUMaPhKg7tBH+f8z+enDxz48E7V+C7k9cnjxzZsaMlT6dMZDZ4wRUZQqlckWT9+268UKaUS4RMFxsmi6V8+HD7mCEarYonRGHfvNi188iuY7+Ah/8QFHwtwZSQILpw/8mLtx95uxScZMPaQH4z3529c4dCzc8VQTwfn/0AdFq91Oq3b6OQriAUS5hsLypN5Jw7vWdi06nLz1w+z6aPT0xsXL5IDBylzxXlpYqaqgcjoxItdkd2eYXXhS8ZHaV5NnOiC0t02ChKJc0zlRuiiouKon14efbcjZvnzjD7h5cwUwIswGqxuakou+jTtAuF49/A4E8SXJsPCAfx8XXTZIqABdHcUgmOHKsEBK1efP7p0zEYVxAmRpXrrG1JTdy2Y9Xo0j1nn7q8nzb3rlyxuEsy3eIiVtdSVaCNwbt8MDHaAmeVs0EEDOX+nnSkOCpqK3JUrhkQXBuNq4VCC13ldNS8yJa6SaRKXEOQWKmgYy9d/Z4svKHnsywllOoH4ulnTKIkxfFJKRqZ+1su1YcFAKbnL7tM36x67BZNppFwTFEe1dUbDY1HvU2MptZMk+nSjy1NQAjbUJ3brApYIgFHQ93eZ9FYNIbgHDjwby+7OkeaH/xqcVUVw/zYHON8v50GGiiNC7hDizkzJethNtBbWXAe/elT+p9nngfW+0rPeP9u7kufqddQqtTQczexW/ysDm6uRHzbpN1UmCnr9yacjEThfUlGQpNVJhgX27DqNq1dRLCKKuDWKtS7TdIMbvz4wV3ZUY+bCjdAgA2Rgy5SDUVTAq0lW99iOCYm670pZSWhJ4XC14jUPzIXRnmJ2ue32mQlRvxWMZjUVNsFv9/tzJRJoxVVBo3EBkKV3cMCNyAM4LOiS7H/nyL+6J7KLc2MYCbGL9ElqzIT4W4t1lx3XKp2rot7W6G3ptVn5Q7MzPYHJp4OHes8FJcNrosxyTA1+M2i3pCYjic8nhJ+Fhx83d3h47t4R7Q008DkYDm+OFQcHNWaxrY69njRy6MS965AOgityOby+ZPN/jYA1kuzg0CpQqVbRoNSNGiSCYfodrWUOJJlIkJJlGnQiOT09fG7or97b+lUfBukKkMtqZfV5vLAUzjja4nISgknY19kSuH/csoq0Pct5qx1C1X9AZWkFnqKS1IyZwK96kLKIlWYFbO34fb4ki9bTqSyLd6Fk0AWzlkbM0p+Lp5XoKRr0PrWXwctlpgp+Uu4PxUxXxS2CVPiI1bxei+WtUeMUGpJLg1eV7yi9TsL1/6yJGBrhYBFxhrVENWHAV9g2mdmp3VRlKuF9KNOwSY3O6vDSaLRmMFxTePhHfPFCFeGg/96eusfJ3wWm1aLD3A/Qik91Y8I31ArgWzU7Ei8efokdLVmiThq/yggi7/dj0emAUOdOU70LmyI5bz2I4RBfsHmBk8pPScQuMPNPatkWslOOJoAjgLJnMT4FoFqnzu5jDDa5JWnzm0fjN8904/q7BYyPIH5bpmXmSCUN5FkfFOKZ8fKQuIywDmaSIrSd3lFCF56o0zKMkKl+0HMg8qc5US32SH5F/q9QRqImOerakIH+NgG4iVuT0GwTCbh1j90CAvvVXqR9WeyDa+ba4Q7jTmbeJeI26Mv770ytaD7e1GcyqtfwP4KlGfh6li2BVpHnAWqtwFr4CyoxB1u6C5mVkKCwRjJ2roi79sTZaLebmco1Gy63cXWM6Q/Q2SnhRkstQ1Sy0Op95up1eqSU1+mP1EildN6Wk/LaI3iZ94nU9oD+RXdihInUXb0KC6oRF/eNHZvkTUm2990qRKRcFEQ22Ewnf3W///GtAUw8dDLm3jNUPpZlyQU+63l+6k6f+TT+mlKrM1ecyqPzIQt1v69fYfiKY3kpFaW/qsrVFkM4EHC03DJQ5IsHIm683RsE8c0RnkyU8pJCXkUv/SMtuVgR2/Cqxpjuc6w8EEtD5u9FiAYt1+/W+6rFIDPFB/8NerTstqvx30+4/M1AcciJUoCq7XQwbA+P8ST3AINXuws0VUQXof6ZtNSkQ7iMg4R9KDQQAS4OXJx2dgdADlC5DAiTKeaMLokwEQTXCAK3SkQLRmg6mtUMci04TLhb9bv1o6XKMGGRTKs6q6bkQNxyxlBG9hNUBuLWMKe6lrWU5hhYbfft+ch442YrCf92xBotD24MgF7A4SCExlPei/7E3N8saXMGJAbZ0s9JDD7Dd2wfKfkc4qKZL+DbagFdwRfNyHzE5Q8Rp93oF4tVgcaAR6C9LZpchyJodt4TKeDzhZlQXOlPQ6l2qPYDgQabBNmx0ORdLGvU0fFd9REaM48kAJEabttLjTNtoghqkL5Dvo+V5vm/dimSBq1539wAmnwVIXT0/P1X381Rb7YwyKTykDc2bRWOMg8pB3Dwp9RHHpnqoXtOpMDQktCj1F048zlmTYKZAvaZFBSMgB7609UuCBLGLVXDN93HSnRQogIdbrOdnCgNNEuyTrG5I2l4jLKqTjbmZZRdie0o6TZkMhDPYr9s+EAchG1jUqkU+Dk9v2hUc3pAK7SBjcZa4qUhHJlnR9IH1o1OnoWSzK4Wl9quCKCpCxqdOgz3Vw5gV+rtySl0z9oB5loLi2mcFo8zb6guFYwmJyiHBfKPeeflZOWUVDBekEcNT/xTPmNUqkQMrnezmxGAsr2mFSCX74kEowYkvEZykhct4+jm2xTZwKZTsdxBVxf9Fu5pdFcuFDpkoBVSCG/OgVtNgTkzPYfeTI7ZyiHhl9wWhUSDuFmnXYpeQkAjy8ZZqo7r/54GfDCrTnyfvkI00jXPvLXuANEJ8LY5iJAtMQRFW99+Xnb9ILYWLqYawyp1UJy+SrUXcneo5gkNQCKeCGrIYUfJmcsI/19WbbT72J0ASr9I5j6x03cNdSsKo9Rr9Pc3+xE0RlaqTUhT8AeZYfkpNJz2GKq+1fvA9BFWdj6MOd2E0QlVCzVh3JoTL/HBbFYbSqP3mswu7gZBezpTOIFAfTWS++L4ivkbe8uTQyGn5denpqZ+4dvKtoG2UFLR/JNMw+8LawpnVkSWup/TqZQUBNkHik4fhxshvo/qXTrzwBh/VPu0F2udI5LYE9XedpM5UyVf0GeM9A3zJh1EoOJU6arUzNd/1BcVwW5v+5wORxmYZ6z0zZQquu8rKf573XoMU3hvhwUMOuMSw8uAIqwt6m5D2eqxXwpTpL71w/CMLiHRNONrADzabguB2gkQuTqemMCVVZ5ubmsY3UfbGipN617mQZ4uvMOMItiyLL6ahlC2tYXBFKLZgSKnUuuJti7apPNn+ys80+wxJAqFYpLjQ1VEEyiAevxCK9xHTndGvf/g3ISVNtO3rbXj9v6hLEn7ZL5j9pB9Zfn6fEboeVaB0xWpDOkTzazBlWVSmbk0iE5nIBaXZ3rH+6Fp9AxXT9Ja3fygzY8SbaXIQSIA6hiV+XwpUC9TJ1/a0Jb77pU80wCg1WZcbtrJxqjeH/+BLWxeLpuQAeHSct+SX/3NIep1Xt88p7SVXZSz2ref6AoqUm0dP4zDN0co1OuuEk6QpISFcRrNmIqWpyV25IZoGsRTfY4ph4jczNjIOO8T5Ju5CaiwtW7d+BJi7m7duknHXrJc4UU5+CGwGARXnzwTewRbiZvLBlo6wZA5STKrjwZc2kNltTlSaXXimRFkTGkckYimmrnHsuMncCNFuOhIa9bqhJ9YTVr2tiLsEr716Vkdd3WEfMvjTyCNGvPZdWuZ3W37iEXmYr0ocvLGOr7KtMS6rNm9I58w8hkf+6EDHu3sjnSWubC3uV43a9b6BglzARY+ZhF5gTJeS0bEhwwT9QZblYDb97cj2R0sPGqJsp598PuiLyEKigz09Lj2SbiNPrr3ejV0fTArK5kI9Zbed+r29sVAvfs/TB83e4pTOYq14iohZILTLG678+XtEnFqhqQ1rmUeD1/0hBzTHhXJUx/+vqt2DEDGfqXxg7z/2YrrlRUscV5K64b1EAsFPktYg0sw0RP/6YDELu48gNMqU/r2OPEkcbrtbteB2JWe2ELSK+anp+NkpWGf9ORTtEHjHC7MiYz2l9lc6mIBjSoB+c7KOmMYY/1WrMHw5Kg/qtXHWazp4y3lBu/QDbPoK7KQB6cEe/r32CralxJr9MEZurKsD5K7wtAnWuvfv/66RTJmR3d9Cb0v/5sLfODcu2AdAvaxwwCHR0qo+wAG+zSyu+ECtPUyhPQYyaVrX3miMXQVMCtZLfttufrU2lKU7J0w3ZalHiM5twv6f33zWcIFLgsBHtb2CkzjX1/ISNHZCK/+CsUuuv482AC8Q4vWV31Kz62dFnIrzmy9HB3LWeioDDHXadIzUDH6OHt/M1+fu0u5WwUynSl8D9VY4DdPPow5TxYBTtEI5GGKgzc9B1vKnsjvCswiJhXgXW6CN8Hnq0YbNiA07QO0b9+E2+nnE1oh1FjRn239B99hIkyX6EMjUC8cRbf1UB4rxZ2VqVairBjyXv6dpOfTBhB8unCoE5UaxO0Pn5UNuP3PaY3EiRhXjC3n8wMHfBhFlN+Y23UN2MjCHhPN6x1YnWyFYk8qUeoQnRVPj0ES8gfej13U5kAj6w7MexxWSCu2p7u/tZ9klXtEJvjcww6lh7jLPFTVjtdHMQIugkBSftQOUMz5PVUo/uYWU7TTEnbR8r6QYMBFj8whOO4gEOhc8oDIXOoHlbzFZC3Ss/z37o2qKd85ZURfu+Cg3qWk1XeNHl4Gd5zXx71Y6UnNSIJaNoZfBVjwB/zed8DLqkm65bedsixiq/lVzl0cftsWpefRERNKhrVfEhO1wTGHGrQ808L2sNHSHbE1NpfOazhqhYdPFjktplBH2ymF3SUYBYEc4upOkQRylMzKfyz5JdkslDGsVUMaS5vUkJbMaMpuRdlw2b1WpZQCZ8lidAKR4ASIZ5BvRIobOF6vbHHEMnaSy5VrfvYFAd6LE4IDSYtaySuCUidtCKNAbFFp+R2Pv+0IFd58Jj1kGyzv87sTft20KgTKKN94JERsXDgRLyEgN1eThtx57JfJYQrdjU1F25xO/tgb9/PlXIzDg89QaGK0u/lJGPfhvbD90IS8j55N8I4tcfLe7tc5e9uotzW1DXJrNXPPxJW5fiGFVPP76pMazuMDgxKt/CAsu7+f01wS6Xq0a1x4wfXly5MJNDpk1/Ymc/y2Z7kmewZ8Bno9gvjbH2UsNi0Dbvx10tNSRMGULTge4UJ+eL5hr2waWLrk7+Z4mr841pNTnO4VsxMiXNm9UfChvLVq4KuivWLh7lIqtHtW6sMfFNKk/3/HEucXCXy2p3BjbPSTMep2SkF1T+N1Gd5rS5mpihezk+dfeEHs7FZ4yyL1WrR9cYfTNb0ufZ1CMG3qIbWNw/eIO9zGs13/uLw7rS7b/ilXleJG2UOGwwK8o+E3fJf3HrOpo7WP+6d7D0BTn54maVAW9tFpvCOxmwzEeOMK3xmZ1P4oDl3V/QDR4xEy2S9rh/4jJBIT2qBNoA7ERNJllv+AeDRX9PBlBbhl4lJoli55uqH8yrZaGKspoU+Qv+ks86njsIwcAfvBoASSkUQ0B/VmN1+70cZ1zIQMDI/bJwMb+e2sDSiwzeB8Fme+rJkypv6i+OtMA3tSAuGqgQm1XOzXc1q2cB48ltSNOTxS59i45C07PLoHsy/zAcaNdrLLiw2Z3LRql6oje1xT4ePyO/EMsWK3ZuTuRmqZIz+ycgMWUJU8ANLcA23kIqrAYgLzamVXPgPw0IoMZLGNvFU7niuYPBsRijFd+wKcexkyolZBg0ppw/cmB7nfhcxh7OtJH1jOyqVyRMQTMRA13yuggZ52sBTzdJGYBCrzGYAVEzef1tr6gSB6wRJJdQSNptUCgbTJJarkD0V/+fiLMGG7r353Fc0JU4VwgaeAXQ6GrPXgX5/F03gDjU0HdO7sqgcrSF4kJ9ZSJRPrzxxbXlKnwxG3XrQ7KSJX1UbDY3kKXANbIScrElr1NOZhdE8fs37t1FC9LgWJ/1QxxW+MxurgERgeFQPS1o+RIDGNa9lv7iLZBLuE/KUv86kHvDFA2WkyMtbDdGbo67vrulo+STZ6nGEnMLRGTsktlNFmjPorNxiRuQ40sWahv4ehPLA5M8/uMIkQWI6w7wnLAy/AseEUf4DDiRCSBMxNM+TluXJOipzVGhuKSAuBU15gKGymDeUyfK7YVRpDUlRojFwD+37ctLyJAn7ASKsL/2QcEMsVqYrl+J4G6puB4lGjC+OUYKS3UofI1iNdSLDUGgbhgYLDA6uJI8UCwWRtlhVxgkWari3LAZJAI6NwkoguymRn46ubmt1tSboa+6u3SybQ0N9WqocNmJV/2BFuX6KPDjJWUAskm2QbaCT4mK6xEsdi4E1k1VFWSW/DERfRXEslWguvbqEoXJilD+tdJBo84BPQx5vOC439CUEq0UaCkViiSQ4QLd2wtYTj04Rwj63ScdWqcV52eoYr5CKYd8IEUIfdzQsw67bs6/O80kcfeF2p2VSVYNND5PskXjD9IMlIy3CHQa2FCrrfeQcOoSIgqDfS6r5XRsvnixC//ykv64G/emmW0o63ADUQ+OycWW78vHxbRToOslf29asv/VxPQqghwRkPtIVU0r+0+Got/9MQdCvpyha116mYBdzbVNHaG1432g8LWokS9t6hkUksKVUmw2JkGAZCFZZGQdkQEE2cxRLqYGsRMfAvk59JMxoi6qlT1hjAVSVZ7O2wYy5UmlVY8xs8KEOwJ6SNbNZ9zQOwzsJHIUD3fHrupaJmj0tLuWb97bFoOnedsaJuxNzQpZgLFea7hL81vy8rIjJeCpFa5OGJhhaaJKk6cv6XilnsKDwHR/NVtWeufMJy9r7qYrHHi8WgRnWfZfrRLn2hLfvVNEgkm0IWOwwIsh560cH01XEu/XZN+sYbGV3PQZ+B5WDDTzm1YwcHcxADCdQu7Rj2k7u5NCWsX8adqzEebxCKh6P+e3MwTEKAB4GFyMQDvm1dz7s/tgHhxGufOnSrTcglk6naRYql29duuQs70RixXyGiJdU5fE0Zs/TWCukYrFUAerlDsczgoOlEavaYfGdVVP+rkdDMjUo+CKjoPOwiD+MqdjMnW05OjiQcvyt2KTK4yPeZxXSeutKmUlceLYelftnuAzqrihdfbSgawxfXhrzpWXcc2q733L68dDb9+jYPsZeLPdLijjSoIi7yi9OG/PvYUKcCW8ETzfyn6+u8027ie/TL0U20JkEf4y/L3qmThqR0mD0arcfcTKiLH2wVG2PYCB8Pw26Gkd97ZLzpxaXCxgaLddr2lde+dJCWr39br2qLpnvgj/0edxOvZ4zp3ffo+2bm4kIMRShWrSFntoBwKxYZ1W0+O7wzv0bjzNNaj4vagFXjU/Z68a+9E+W44D0xxPxYv2VaLAwKOVe0CwBAT5+/J1F10BFOCmILdRz6YuUttumGNr+lsLm1vDRIZNBIxuqRVtox5MkXC8XmujstPha/y3szsLnC1r1UFn9K77o/n/vnPFJ1GgZ8rhQ2i8urP3adtXzKC0zvEz7VfzE8Z9OOUapjZ/+GwMt6CXoI96fAw4PMfXnlKzJWw9mG81vnJCNXIrrmcu+fxXP9kDF3phfNu2DMihWg49zubBaxp4ZLCuJeXVHDdxVfoB4b/+N/rq6rl6kXiM7zS5hAH9LPdMdB+mg55tQLdpmYY0wuVdwLevBm8ZLkbsw0H3WI44hxBfPXlAbGuVgqkWO01kUlbS4ufKa63sCYdXP53vFFK6/sNJOGgqpn1KAy42u3Oi7OWZwtUGttGChLb+LWZTegXJm5tfmeb9dRhA1z/L5FgpkD8brfRmYGkbHT4fAGtDCBJgLE2Dmfkr3AhKZ0v71dG8SPnGhsaU7v3cunPg7nPTSDKh3Px4bJwFr8gtPOxsou7oWWU6ZtkAopi8KgPU2jOshiotvPXu4uOPJVNjwkG8OeEV/KS2/9MVQRhSxhUhX6222zYL9a93m3pNezHih6GjsH7Mddz9q8js0WatSEQ/nMhi6X7ipBz0yM/6ABxFupNO52nB3S7nrYIyIAWvVxM92PSnd88YUK9NztPPO+XfDE8Md9wS0haGD/6MOApyBLNgBJ2E+7NcGL0OyxLI2iomuseWW/1wrf2xBWhz7QSctvELLwxwKMVjSLFgotxA+vkqUBB2VZFEwPVafzN10TR1+00nKsTuK4a6fbWZJHDwUdxoBWiqCtm3QjpiVGaIaf/lgigARI3f1avsSng0ub1peE6X+t6dd88q958jOwkdDhJEaxidixEVsR2Vmag75y+RYxQS84cNfRDb1eIVnp9469e4FWI0zCWnTi6Z89DNG9CGAVWtGv5fNZ/0nzuhK6kA0KJsJxy2NajnvQwJCZ+t6gm4uNULdU4q2uJNSZe4ysWCdnIXt3PPPqmLWXDcxSKGd3K3Pesyk8ZJjW8F+5Jnat8FhetNwWmM3w5FUrkpxRXADQuzPK7lKJ2uU/+C+BHzRd/jN1ZCLwDfcK+JgYRgIScbJtEu6Fm5Y9AA+ey6g/paHFUCXNX4jAEYUu/5WpofXOiuMsLitoe7Lsk0NqZNmkDJwmE1mzJud18ANduQeZoI1KqUrXkNB3mdwBKe1wVVjS+tMiueK1dp0DgjZBVMhKTGXcHrYmDOLFKFWSEj6I1HwpZgobmBKDf4uH6R88ATfq8iFS3J1cshspm8lT0yqmP+IM7ojkdKSWapIoNJD8mETfXWcGJtqlVbDIquRMtKkZx0gHpcJz0Yx0guDYy12+mAEkyxjKTOpI/04q5NCwXoy4LMwo32cGvFqeDkYDTqxKGKehk76mLXlylleRbKzHURkwZgjjCLcQlPlx92Rjqhkd165ksr1tntJH+8RqoXh4QM4kgw9LtAMAAokMf/IkLOugElEqps+dJEldXCW9eAYAQgNwX5Lnk/YdDhq/vSxSh8PT2yB1YWMxU237+wKwLENd/EBt/CCoEWezU4dqk2+fNpYQI2cFgxJ5rKS29XnrmWw89GzPs4qnlNRVdCQQECqTD/tmL/p2KNec35nxJ/IMwzHTR45srtPmOHKlWUAL8FSQnqE5Ce+h4CgRtWDVmXGVE0uVCZdwcYY/Evzut8Xzh6wUZmr8Sst2+xoZBLBsLaGS6v1v+QiAzc1g5XjLxmhI2DavNIrWL29JdfhpHA3lGsrJvyGO8MAyhb1tiSe6kBrVMYPTcX32IUUB3Fq+DYLsfQtb+RzPZ3ZVcJ1n8fFLdcJ0mIIbXj1CtjD1C84EzVK4H55HBROywbWeRPIPWzoUArBhk0lWXCJRpBtrlzrIwDW5APF+yJIbbRSBEYc2Unp2FIOWV1Wu0WzsOO934oUBiOeqcfEGd27Md2mJN9RuQq72khg9rb4hwzmNv4NLwdCsQ4Uq932YUunDA99+4hfwgvqeU779Ri+ZAWlwDwueC+ZLSe5Iri9nkNtsUi4eGn582j4H4kVOo10FacABROYcT9MtKYku1okkIlivzPiEwP3uztz7dmmTI6I7M8KZadO0RLn9Yf+S54xjOIwEEfLO4+2tGlkWX9Yyp/tvTwnd1MPfo94X86/ELv5Mw++4AFGL6AUfNedgs9esaC+EqqDa+0JF+Mk06uLnjOVGH7ovXC0UhCRQ1nGQduzBJ/JNfq9Zl0WWYeqIHblDeSqzlMoKFWMTHhjSquCDfuPy5oQ0NzD/2QHEEyaHqKy/mbfHb/WdH0117LCMGw0pfWc558YkUsJbWXkPSp8jPy3P0o1lmhTBvvLQgc2hd43PXxyJdj09z9DQFSjGqxRsRr0V1bHC/Vmb4IBMQcbFaiuL/r0y0wPF3gfTw2ytrGJfVvbOUjnEJPV//9EzSeYyl5pxDjbDayvZgQTeZyuaJjjMh1VC5A38eqfpH3ko1TeDOqdQadhiJgXcjtmf7Q0DAqP31Ls/P/mSasr6pFnzQqe6LeP9vde4zCkNxC12Bz1Ok0wT4d97uNimdTYfeTF8NDJTXi9uX7poxoSo/rXHjQhTj8m5PRAWjdjCLWKLtDkMsdbPuIk5+9aPEnek+M9d7E+xp/EutVf0d9aIKdYaFeUUdDWjE3HnGvt8VuSmEnVXz6qs7tTbRVcU4347nkcZo18UNug4atR9h9sc9R8n4l26v9gEYJwTbE9aly3EOMYCrEO8ViMrRkyc6Ys59AuKf0lrXfVwRzmQb/7x5hMD6NT3RMuk/Oc+2QAqJeA/6wUwgm91HCVpLS1LH8IA1akFf49JascM2VTQDtmw7qCTeUPwXGYbtnVgMlnVo4ReRzCoRKh1I4cOZ072+0yPsGnp9lA0QRzVGk6aD/LGaB1bLQoJCXMCq0U8y0MPBbHcSC5GRRQnOsBolnBMZUp+Ta05/hOQ4FQFuy56xMzxxUFEbYpfGU9aga7K/5GufNmnkNv4H4vN6EzB+7uM1LyW1oif3Y+87ZDrEu2peZISO2rhowVoBaO9SjjwE/28kThm3tiQjuvtO+8TEY9N9RDg10czTALOnPQRuqn5DRbpmTkrmwOqugNyHKmpOZ4i/FrvmYs7Jh0TAca6NglG/IHxjTXbTX1TVuEf8+Vdd6Bgn3z4YfKC+icAN1IXsKgnCMiG4LUJj0Ow5lVRAipwqDVcwN6mfmzNOS4UsZOahY+l4rz7sGKiwMCU9f6a9+v/iaRWSdrQmbXCdUxA+raQyT39Fav5j5Q05IWbBdGCDApODfzRZ8hlqxEGadRsiq2kQf6hccApyBYGrtDnp1HcNLMuPwWFCEYM/ZThTWOWJuF3oxDBokGu6BIB0I+tuEBPuE67t40xpc3XviVGh03G242MFNTqgBMAWNjmjBxIiA3FipwlUjWCr1LNNI+LRaJ75RlJVI1Slt+xvcpEV55FKUwqiEe5TJFubW08V7niM7SCY2KnE8JUi5PF0a9oH298y9LABBID1KFTjO2bIhyfLE9wgGflISqOzUntaVI6S8xYM/ejnohXrqhtiY3/6h2KUvgve0bvX7rIgSpkWCZo/+d76kFoHHFx0NPzoRdyN2ZlZDVBro8NcMYqn/+ycYrld+pWuLsk/wyAW7jxIiZBHZL7nEOBRqSLbXf+lzrVN2r/G5Ksyn8zQ7LRHHO897S0T+v7yBxWVXA6NGXsyqdKJ8bN+OLAcymDVM2efQpzQXGVSQ2sMrNQccCWJZs2ziy9ES+XK6Vko/aY4ARS6wpgNvLYxYbAuuV4l207Tdp2RhyseSp+JnaaYWw24lnJrJgX3nsyKG36vk87YwgamvKBRFf74MMXL90BueP2uTByc3BJrptsLxuXko6aafRHoJIXtN5K7e6cZi0O5diFLTvCTCat/t9V1SN7wm+dkTiYfVc1dgi6osoB13AH3bp6/bGG4YD+K0eyzZdeOECvXtw7fTRQwcO7DEn6VTyRFZoiMs/mMhIkKu0WtN/XzwhbQE+GO7bZ0yOVCkWMEleMhVZYqVawWM8vHDw0NHJaw9cbvebLmrSR1+ZojIxo0a9uERgKc7XaPgYUaICMECzLQkVxYoys1RulgDrWM+ihUVyus8fS89Z9kz8q2RTMojHqRmQND4iNx74/5ZLv9nSxm/mv8NPZ5EBXqtH67Hdj1ygF1ePrVu9ZMnOq5a8opLcLDkX6/JDRokduSXFucnxVDFwjB5TlnZN7Ms4E5O+UBNKKtNTRRy0K2hPdZmtoKZSFPr3+eGRFeuOXHa5PcBdno4pZESuCBgo8zOao1dmOHPLSg0GszFencY+H+z24lKNtaSVWG1mc6YUOMIpONpdvo7q+zdRArgYYclQrs5kKwJKUn0yR5dm2EXBIOA/6fZvf8vazHPvwhKBbIF4WoeWrU9dXs+aB5b0d08I26O1Mr10Bi2Ntc6kBKLLGxOjLa9tnCcGuuhp//OlEvJXFgK24eE1c+68uvICXTze5VevXNLQ0pCqujgumh7Z7v7l+8663N4QAwYNvJ6t5iDbEcilXgolfZEoFEvh8XAIJDlnM+WOQP4ABKE36GgJJpUqW6USsNRaSWOIbInJPdiutzlK6XOPy3QW6tQ/WevJS0CKrsU1nTSzWB293hmNPPz5mC8UT7FyxZM3qyIRD/mSFClF5Q7J/kXoAXgq3SRRnFOqHnurYiYBeQJCVbx2OOonjpxhpzRzqn9abSp0D0k5pNGV2gilNwbZUC6VimC0lA29DvFXJDEbFeJwHhKvdE3iudRSsT11AhJkFl6QiIAt4Ui29YgNTV1QRxNwGdi6n028/s7gNyKAIcAIcugBxdsibk7vE4r1NPWkPSYL6s1NS+CBKtRzB7UgWn2d+pWviDWLQceX71JKmA5UYAXc7MP47js0mkjpIXm7kA2j+zaQ/5BERCv0mJZQKp2lI3RiEKKnFUpWNwzOnXk94Ssm5ixKwNXZSeO++1NDOoSdR/iCUpUpMIJqeUrPU8afX9gcshf5+yRbGjoIIJljxFvzZ0ZOBXgS8EdZWCgS1OsxZIJeCuNGhb/hf0kwaGzUUdX/eQjaXsN5baoMFCQz9bB481PhMJCCyvb8VPQivmgKA4goTbVhaq+Fc9OXqURNALt+J3wXwBTygo/eHNXp41xghna31Pq47p1hTUic9uNATLruimUBec3tZqo4JjKh50FY0d+axFZ0wJ0NpdtEEH4PrlOf5OqfyWfK0CZO5p6pfcn3fE4EtvYZaAqgD/K40eDvxG7orFqeBjbjj2ua3aHkMSszkLV37bZDX8j89G1dvh43id6ILH2onm84gYa/x9JqmlRyLNUQwZ6/VNT8h3khali1VFl1RPpC611DCT4swirzKuI91d7QdItRF/czhd52g80ZsYB9EmDNh5DZCRC3aFJkCHzOPmvig7oXNeT4EDBDNOSidYEHn+tvEeiB5i+flsUohKsVj0ZO/2DrH+JKphtcEdxcz4WtyWyb+/JCF7nfCg0yUyWGX/+h+58xrxIuow0waIP+glnj9f0nL8vHvWJW1JiU/NBii7PQ/PbTv3sBgeZLkclwR1bohVYuu2XtJv9U60oQo23+LVz469s3YiAbnR5i7vIWsNO6qGGur5jo750jyStctimBHZWRjTDT/397/afUxs1qnmo1bdmk6onGv3vJ6nHO6/CRMprSNDrflb0h6Ov6OWYWPD6wz/x2u9xwA9d2IG5P5gLGCf1v/upNUzb4OW4XxvEz/1OJwiuixhdA7hbaTS1oDtcwjjfa0IlvpMBs8M+BH92D/JWntbA3eLI7HAaODlyZ5v7mzYzDL0U2Wcj/f24LNK3Eck9TBjeXhy/LxaLQ1P8+ajY+QMNGRQbL1OBxSKUa9MGwybCbPqyZ+iqu+HoiVeQzBe6DZayqYRDwxZaOLqG83q1CQL5q5Q8Y68Bj5l3f4kz8xjY3Oj98OhEUVzh0/+WHNsMnmeV096CuLV6+0RGiusehnprO/vvlGj+ayoOevyYvnS6LuX/fWRRQlgORp+76Zfy9q/Py+KBLwYm/vR6e/tGdVMLbq8cuQXH2R1S/1b/v1jWmX6n9yI9+EoCjzdY1IgyLByYtg0GmF8uYTPmWGauWdxW8tnrXDvijM08/zP4ivER37DJ5auXN8MW3yXcZzFwGOvVnamSQu3XEsCeRe+KMLW6elXod18bh83V0N92Iq+D6qrLu+OfKbx3JZPYQ06KvURSZaDLNpjCanDAkb5I4GoMIVlK0lCvk50QokYDjYY8jl0nhTJl8PQqjCUAZt9QZ1X5PXk21rRBUBYf+H/sr1EW3E0kNFre5Ait/I0y6AG1ro09EQ0YkO6dOquP2VGxDnzX3RLzH0ZymfNC1hjefcyZuNhWjLKmoOPdsDwFtGfidVEH7CEa071K5YS7RSVvRJayjXwPeAiN5Rf66/iCJ7Z9DVMlxb/uTvrVSzaN1XALGtUPFxzGAgYTRSls/tBb+W5VcmFSEXBlFsFS8VwB9HAS+3wXQovTGgmY6veodx+hzZmIedpbNhpRV1aCir5tsQ6IEK0pUmXylNyZBDlTC4kijZF1zgx70mArTFCilLugVFk9xZ6Awz3jgcHAbY7x7OIiagxMmZsgwc4uMNAAMGGcEdEL8upraD/e7HU/iKdVGWKPbJ1WoBu+FKKkyCaUmufWYEvStG9589PiQES6b1rKTjXvPt1AgaLK3uc7GI+X8XW9DkZCcDjBi7R7kR5OUstCccpsAYiFJGRkVqQKNo3qCMfgtv0bqQQ2VE+nCmBvNgsCrWlNkJpVSDce1bcc311Llpfxy2d1vHDTqjmJupGAZgei9cYuUgI7rdEUWWgSpdd3N5SfNl56VIXcwRBy59HMLUbyqpzsnmSiNymktJdJK2ta36Iy2yZGUbP94MpSAPSbKakpoo1LMjNer5GnDcHfimdrBSNe5lpPRJOmouc8zysFrz+wxyUSulAUty9ovh5NyBm7ibhXpsw9ndKYtovJk05ovlFEzulpgwDPIKrHkZIBW9EoWPcMcZ3/zaVW995t9UXHISS941kXfMBCfzr9L79vu+if/AbeyVfl51Qj1/zz/jxxYGXzHwUZ3qCEy/j+Ko2+9d05unLGg/cWbYX2c8Q0QMRAiSpog91AS6Jm1bK8yEyDBSanM+1qEcUGSOQMNgput3WP8jm2sIoyFzZxDfiACB0b2tCcEBrYr54BpQF1UetJ31poPFbaIZRSFHKpdIVnR56eWDxygtAzmHQa3eq7XHxvWDMInfz8zz5+vl0sZzqUVMrPdvDAToXefdJZysXMajGmUdZeki9OkJtYFuAt8BvekPxJM28uDUeaWCmLdm8puNGSXqLfMTuyTcKCC2FUT/Gh8A6jd6jZ34ynjL1Drn0zjfcPWja10w+Zer53Q+gMuSA8Nc/Qy9eVwTMhgB1zK+IbeCdAHDNqM9MW/JoVw2PQP0eaul2rzbFWifmwEBtWlgqgatgbdjVWlZuiaqOonx/iayaqi14HDw+NvQuF046rYT/cZsfI4w8n1DpoKVs/1+WLF+dncXCxZjgtOYbQu2UaaT2IhwBQ7GrtWF4NC/G6xYjPEysJS8KUzgNW6UWMwObHoXB7sqUkeqCTi5UxN/AEF3644w92+nzqeYQCHcBL7cKjm9uFmNC4q3KUEk2EFafxkHslkikgTSNB9LERc6Vwllko/nlTthQq3pfZ08/d1xwJbJFHzHxBOnArH/EV+SEordKGx2TwQjgFuswGG3NFWvC9ITUgSNv1BcqfdE8s8KHibRspLJSYKtM1MsI203J2+05j5AkHk1ly8Dvb0UYSEWH5Bn3Fqd14mbRcRRV1ogqaWdyLeSFpvDeyFPhPD4T722HTu1YdgFMkIqi8Ai0+MzILF7ZiHraa3q0fNC00vRD9lyliotQWyJ9dnSsoWW+WzuEaIjWIGGf5lPfQFvAwFWm9mEbWeFbKisTiBqmeHYJxo/MBqIfKIvtrp4u6TW7s2NkgxZxzJVN53I05kq10Cg3S7gzNVT8RSVmDBUx4lAcPRIRcw76c1/MRBY8BFfCQMfz9RsDLeh9QPoqE5b/eXTyaDS1ejOJ56rqmJUr9fOYLt7USw8q4Y4JYboGSOW9k8eS4JpdbhKO/NQjRp+S9+CS7y4a3OGg4dk/MJEjI0/JPwXY9AhMQHMPiUNDoJVpCY2FjlJ9n+CWmuqEm7LUp//1QHw7276z2ysbPVdu6LRls2BWAHkGJFfYLeo1Yac2PpNXSX124AgPj6135UsFukXa8Wn2w+dN8QA4pGdi/e/nRa95a84lLLZYe0XIG4u+U7N7771SOZMWU4HnBtkxykjFHwz+CEIN5QIZSC16XEqwDoVpjO4pqG73gVojEjao47t5yY/uS61jJFMpS+ScU4SCkclJx5Iik7UezfVJa0Wd0ZDBw/zUxQSrJaVYCfKulnUL+DHrePhPjvJ6lyx5TEo2KSVSd281nSDB5bZjjEGgzHU+FYNN93JVWOMxUg4WYuv6E15HHyb0xtTpNQINCLeXdUAlpBHASu3hdI5o6I4jlolmL01hRE3Fqz9By72RtNGQBNFGMVLuAhTuNmBfpdJghzIy/dlnR9tgj7oCiexmHIFgv3UwFmOLDou2n3idAuLBKBTAFiS61CLh3SlScTc2UYJA53KOE2kiumAJAhoe2GXeSV9mxrZkX47XTJ2EmdmR8q24KoTS2DSud7ZDCAxuy3VZDrTZ/waqNaKNHqh9v3vbRiNrvFSkBfrB3k8kEo8HNEhoPIL0LCdApmeepZ5AVwZGcT+nA0G1fxay6k4KMbzaZO/WtWwuAGfI3E7VMvIsFFkiYhcGVFt+tiZTn9NEoRALC2mSiKquj2nqaxlfTf4AhELOt7J6MDhlaa/EviyUz50CDL3n7JZrZjC7+/l/o++A8ZyoGiEHjBZmQNETnL3WCSTFImiUkJJL5fMA1B0nktbq9HVjSK7OiaZqYZHL7cPpDryDneCZ15yAgiisz5MDT6OazKC5HYf1L/sP7Qg0OOYWC+91G5O47PUCQG6X2Dikt+Mhymw04GTIWFgybrbgj2au/GfuM74XFuI7Eqj7rDka8unHwiRJMyyt61vH+UOgZI5afor15VIJBSfidSnsWjbi6bCiwxCkr/ayxBpBDCUM+rsQ+SW1xVmmNJjIrmsWrIZ6aHNyi4OT0zw7qkuzSfKJ5Cp9UnyVyJ8VhT0npIFHb3lSRglSrynC9n2VuuuhEIn50fbdLSfqISLTH7mxcNbw7nd3gcyT/5/1ddUQiZJCsdOoFJjbOBkopm0jImS2rnSYBW7AqsqK/7h6xLgU4WBYF5M81VphhXCJDwZNk9poB+vAhoD1pqZxfrYzAunxhlTm5BUXaGKyIIEPqkzqDLBZkHS5IjgRgnCggKObzB3NazRZreFFVFOjjnrxO1HFTgYPxKpNAPxPkWADyZktY0C4qRCrdp3UBUzrxb/zBeY3vDMaFow6Vl/XU5ZX9fbA6HohZ64qYqUBSPczC4LtxAzQA8WgiVPlJUBEEuhwrWimx3+VY+fJ9eZ43q1yJFy2LuFivX9Hr69Krz2Yqcqv/jTFMEwqmqYZRct6rpzkSyo9mNFfo33AZHhM5MBd5/dz2ImdZynZ3Iz4UWgf+rAOPzvKINncZJ0KEKqoN9eaHDaJjjYhIXcPzBEpzBJRzHlQZO8jJKhovp74q+MpFJ4g5UwBOG69x2JTtehscQ5aa7bXsQo970lHsOg4s18eIda4gunhi8nndAVqaJIIboDmQNhIlYAtDziAHDOBygh2yVvHj1n2KGhtW/V33N56GJBguV0qopVlXPYJwyacjXn3zPcxuEVN59zRcodBGxgnv2EcgQsUDNKgz3zR2TtwstUkwvnX4h6sChGyo0FC7eMIqc84VHFC63Rcv52C+Re2W7CjlCfugFYW5a/gAMFQIWtcNdW9NcIXxRzVFkSamj1K6uCjJDtYse5X8MgByJ2T8bHlXdJsuVEXxd72JF1OV1h3qPxyR1akl9DwqkzNClct4ed9Gb7AAP07oKIxRUHgVqRk7KeWO1UGTZF0u8vxqWwPIJKJVSRuVTMy8hPBJOcengqS4DyYyyUxkqlNOUxPDXISD/5AvOl4IQwBhJn+FWJZkq6AinBzlTBTMxMu7j7z1deUSACrwnyJF6Rd925v8N03RDxleTGfPpHL40wOQa1BqXMtQLJGV0OL6j5OPBTH9xcMsVaAuiuWYbpRC+Y637yf7xII44KTaK6drd3masDgM98nf+gNZo6qoii5VBEUwJwpRjPO+OOwpszIfrmw29Ftx8d7LdEUQZBaH3pHNNkhXFBuK5YjkA7tPoIIdk5P/+7jytYLv0c5PQhM4o8bDJlWCSS5iRTFsyv5WpXtcFr/YfPxzDt1DfenO5snaJNtyzKaDRq3s8rrSHTR0zh2zzVAUGYg/N37GOud3BRP37WY7d/3htFrSluggfFPEPdx4SE2X9qNb60YCBypB6RgTuEombL0OgOP3AlUUiUGUCv36A6XIKySL9iVuztDx6QvrGJs0Z9FAyJt7dw3C54ElOzZHLZ34/Nh/lk8bz3zzFspGFk6t3/nVcVSoqPkkknmmdMHiFZLwk6yKFph1keFsXk7z7y6zSpd/9ZNIgydZMJ0b6ReqjSuFCKVyyn+teENlcnbuwVuhToR0C8z00VKpZaSf1m0JFEmQr92CAlBG8eaOp5diEQVmGCAx78uTobpTTBCw713dYMUPX+PlKXji1/X787xVBDRpNJHa7w4U6vP4QF7CLhpQkkOrX7D5Oss1IFH98vr0NJwjfXCbuBCzpJpmB7JEFNCYDN9xbCvKQl0SR/fUgYFyLplOpIAHYYqC92V+PLoOCjFQ9s9lg9jqn/5+xBLmzjCoZLz6nZHCQUs1twhBEdta+mZtiKzB7nT3LyQPw8UN3F4Pj6tBQCxIdtMhCA6KxCxuRoIxZufKUUQ2GjaUalQQtsbP8O8cLraScwKJavvpy/gx3zsSiRZK1TRh9k+QWDs3k5Sx+b/6rXY6PscfUU4xDNTle8dXaYwSP3vtI3XQGYdqg5IuMtZNVPGtR8aocdq1TDeVm6q7BQ7dtav4tinnY+aImmtNCjGdb6SChPFucDHmDHDY8ZxofyR6I7qyO03f84OGYcuOMlyKfmyjDoiWhtarVvUdT8Ny7oEmgRzvGQ1oxfXTsAhZpeRWScE6ivHJS1+Havn3zTgPNMwsuIGqw8EayQl6aZdjKH7GrXF1+cujH44SNRKO0IrhSTBue9NcRw+FaQMgvXgtxPmOYq0Mfz9KmTlcZKGBqN3pTwCK/GxLIB+RbXFgXsX73/64zZBK/N7Mr1i619psu9xAV3T7cfcE7OAOd/D787hOh3P5/b5QFR3fIvRm1kD6zSe+VN0ZB+Fcv7b3gVhWV6v1BdOYx1mRBiWbhpU1a6oGz5HcLA/nsuY7FBZfJ8HM/GGbIeH5nZu9Say969e5yZv3hbX/0Um8gd/m7BDqnesV3niNnU+Dx/dHOOQlx5gzGy/vR8pw/+3bhNr/IG+TC9uItT0BAtPwsY1KKhkxHT3ZgoPTkDUjJOzeT1w9eT32sy7Hzta+fd8jaPlRSAf1ViHWqkJ6VMztr3b7Y+juwNcr8pPcjr5MFiSr5XeabJJK1wmPOnsDHk8Dmg798YMg7lFN2NRmSnzwkFK9AfQxnK4IhJhtofO3TWLIZ/X1M1nISNdjXw/1aOhyO0arlZoWO/dmW5tZe9iEl5TQ55n2zqDeliydmCQzhzzPobXaBKPx1s5gU1DApcv5sNqj8bEHV6SiwaVwQKbmpd6WmpHZAisgdNx+U74EPiNnSXZM8H7xar7ECmr/2nvJO0BWslvQrpRnj5sCe6uQOZlYOmqlYC59ktntXUZbeYa+D7GZ7x3zpBHk8xwhSkIoDONPIaJayDgtWZp1qMRPCIRxuGhY2TD8maRs9LioG7unVd7/CaHoSGZ7RVKUmjhK38SoLkhiatmSzuRAXiqfYWDtrGsFMSjBy4VxXm5kXlE3LZHUGqyf3dVxOaAj/NA2/bw1GZoVuBxx4/d0nCXc+bXghRLU9grz2sqyPpUZSCEZsCSGZfx8eGTVbao6b4180m5WtkyItwS3kJUM8yLoeJUdTR0tZkdSs0lrHZZwaPMpIOv1B2mrpRvlkWumDb1BLEhNKnoYniJ0wov73jXEEIOXvi1p9g0vjBBAPYGosCaZhXa0p+/WKjKjoncnVG1MYoEqVySCC81muY+goQDL7gObov7eVRjOnU2RhRfdMqXFOdbunPhLD7le1EdmpcBwc6AbgsK6wJVA15KD/mYEuJ2naE05h0IfShBXISkbNDnVl3NXtLNJaSo8kg7YhSxl1CnAR2SEh9mQq02aLYH89C9tSyUI73S+c71zK7IeMseEA+dfA5qVkkXbsOVNJBYlrvju5fyw2swKkwHvspdszZn0ragIzKttwKsXgztKTSi8IPb28FhW6ci/7ujIqzjEHMSD3tkfNcxRTKv98P0kz7dotIPjhuBbyA21gZOc45u2ksriTbfPRI9iCWxavs0eznjtBVfrLYXRXVURx05P7h9EAWzwzCrijImFxWWEEVh8prejXqNrwXeHC+zBwb9Y33/VfcYKT/bUJjVkdat3TrXbSEkKOL1HNhLwW5waF11B1NiY1dnhak0cUQhhhrg474N/b4VmkgSXI9rd2z4ql+uC4BBuPTx4/JxPLQ7WNWhBKKH04tbg3+PtX1Aylho5IjR2eb/LYKZlMYraZyo43a6PVTD+2HLTKQF5Z3tpYg9N9oFIy2esjfPjqtMHKzOolkZYXysWMIjoFEGjx1urGTjIGCCpoGy9lxAZcQX5qk3eTfjc1Rcwz3LHV63VDvkgoBoJLA6G4PmnGp1ppt9eWMC/sdq12t9tpdnLpQUVb2vBQZW0GvXanuHp3OAA6qJ49ruTNFwsfPbm+kUiXepQsCqphxoxai7W8AIvdYq3zYjFGESO0Enlm67M6om6ZsiABH4XudNd3a3sQ4NdFnHtfmiHS9lYiDwMJyRiB/0AyyuXOuW7dnqfzvsTCJSAfopvlfEyrC0na2hZy5doEArqtYPEgcNfmNz355WZp6kQ03aZmiqIYiqKYcuhIxvQVNY+Vz0H6ZrmyL7HxkyIE5lTH4zUsdl8zIxCErVQiOT/YliH+B10P6idV825pLsgPZZdCkV0l7PWfGBxPHX4FrsrxmaIy6Ed9n+J0I66APRXRnCqJpwClHdRNHeMMj/gUzpXbgwkMEOT0ufshzXCkyMEZdBaXfVlRVZCOPFjC5YAYKxUfScM1UVe5xctuzAxB/Gu3oUem801nv1xf2MOEzueC4VuEM5sIzTnbTkYQ+s9WHAC5Emiufz55byuZlRoIMIj0hsqemeDLYE8jEwpuU4NzXN9o60qFqGH/0WZCKhhjODs7xXCGsdYtuWzcNfuPQ+hNu7PSZotXM11FUJtPw1NVdRXCAPVDVaCoKnIH7UVrWYqqKvo8cDq1dYkAvhC8SmEceKR+eyc3hT5EI+YM83R3fpqNiV9eSOYKthaepSBHt3ezfnw/fvRbv7lfGcP9K2Rg/jC220zJvXyf0wztBph/wEKMiOo0Ywdz8PB0cl/teciS7RjuPJa7dx+xgEBC8+Br+lAG++2we4u0O3LNyY6MvonIdI6512oVUGNxE5YU3hZ3z6bX5ZDJX/7Jhs87SK4EPt1QWvVckB5g84FadM8G04ngxw+Vp81KcYaweyYSlh7eGl0+C0f5Q8Go9hOJlc+wgQb5lwQa1K8ZPnLCGl04d5+cIdtiJkg6DC/KPHlqWMt0BrTB7y0f2Q0axcLmGtLglsJVl0YFO6LQ02USCWFBlU9nGrGQNd2CSWuIOpaRjUJeyxnVxKDfVjfodfiskc8X6iwviDjNSMBRdDCDJ2W0lKDVH7hqSdeNWZExuoKx4dbXrAFpKxQxazDnqJV2Vx2MBmE0uq26kVUznYQ71SWmOZ+f6OnB5kKlQeveuGgwzEEyXUlTs957AZhnguuYxxwKe73osXdUVLJHHEySHSUrOtz5jIm2Z4FYLuejftJ2YVMI3NjIN+od7d9/Kqfj1OYjksTNyYW4kB5DQDNlrjMNn0rHApDVrNe+ZDlMF+g3/aH39KsH3Nl2vaGio2nBOHfHwf7JXdfN5JILdHGQT69g23XVfyWnfpH0uZEtU9Vp/PK4IwXskL1w4tkpCNqLJTu+3PZLHmRfmAnMFKklOqtbh4dLVC/IeokmIdTNj2GKJEUpteLUDczKfJCSXlws7rHqMLs3V+uPnxtGGAQiw0ZztlOQlahFD1sBmyojqCaf32n1uMUpVy6coC1e4Q2DRPzlHwvXKm47cj6RAMWwSWmVdh5x70Ltr06vfdjsdOrEl3Yp7XrBNwN8z+kiR4kqOaUcdrm0lTKTE+7bUFMQtz6/z71WLZRiha0G/685hv/TrmNsfvmsCOTCJPa9SASi0JRp8CmbmxMHcA94Hu+KqfKrKOpS6y0p+6oxPmL5GSPR6TBmwJ46NfVAGv6K9yWuWUnBElKsqaIqNftGw08/W1xm6ZKdJZLRYzDacXu9KImYTn67TNa5IPBZBIjpe2kRYlS+tPtds1ITBgZsOxwZv9kP40n/1Npcho9hTQpJlm4ks+n8FFtW6zU+DJjpayQvRDcBnYH6XDMKrCFTo8QxVd1SBEpkEEzrc2dqQbo8I2OTe0uCgd1ZpdnUafbWEX23tc0S/ePwUa/RSpbIj+umaM+OBXSdw1mek4lbli08d08RIERQyAuOYGj8+XexMIRAnVE/PRPNZMtJtgiur2chZyFJmR7gMUjP94bCFPzuAcZVfTk6Gk4UilHtacuKAWc26TQ/zHsO9h6XAxg4cLuETrE1hvzbNJBp64Gv8xkqheL8a2lg6U6yQYf89XyyMJMan+FLwj5ztWTQyW1W9qCj9tzEEgVZ0QSOQs153/HmhTfqiAv7HxuSA5UyWFwkkgBEH25e5A/kZziZwLHe0SvFl9V2Kzba3Z4iJ1xiT+wRXnzQVKscO059uSrh2X6DLZ27iRxcZ6BoTTtqA8Y8FFtKqJedcflwApe6hC4c+3fM7vYw4Ro40Fy0//EmF7GG0fkJ795c6hkyJC5MTXM6B4ZrqYXhiGOo/dOT5yizOjQ/zXHMMaqrZOPhbUatd9aqMA16FLNcogkYPXLDkjkX65jDsoLuQ7M5PmHY0AEwcPTxal9tR4EHmTTSu3OUs1lOoxGp1OZwtNJEWeiqHtF5UwVdfnGBuftm9y2aYOirkzg3WbA/TTgzU1OtyuEwo7Hg9cYHZi2idaUJ/+DrC08yEYPZlYQG+iPHxHI8a5Tgk03EpHHVsoNxGqNiNw7QAtH6wSjsviGiTRlto2lMjY+OJQFs8/NDf3FnN9tuYMSQoTnxMr3VvcY4TIbWXxLbu7QSqEfnhT6FCPe9tENXeEbaJUo6/kPU1uvUNQH1VHlwJhlukl8dCQt2R2r4hp5r3zikV70DR8EfkuakGWnvVjWCdnd4xvOZ4n1uM2kEWga1X1xPZ60xzz+5O282MVl1M+YJbg9mj9oWbGc9ly6/9pqH77p0THOaJ/W9EXCMbTX00be8VVNE73jzeBAM10fx7b3nXOtd2y+m31uw38FEY3nQ+4LfG75KJvoPHFgYUueK9Y+JtxH5uFnO8FH0QJIR0daZRJybQkBZng3EzxJRa3I2lsk6ka8WxvkfsAhwp/w7e4psnBVkWJ/DQ8ABbU3v5eKpGgQU06O1Xmt88u5Vi8RJy/SH9tJHekCZdL+AsNHlcNrlPE0yXB55pK90QezTXKFBVZM4UTx3+J/prdbW2uLV2yRqoB6idq4mELYGF2498ntHf/P8iIZR1qGv0dFbH39U2cdATd87Mih052WbIwuAqaXBtgS3GphUIq2nqrGpFoyZqq8vmCmoKUF1a52xqjKienyh0e0MZO4Cy+JP2luDyaDpF7sOFHi2CQFot5amwe1lm06pMt6Wt2aNPUQkFogRaFDTYCAy+txT9bn2F1PiFB8Tl0SRwKHc58x9ce5Lx7/u1mtZRu6bc2tfcjFaNICThh0TfP6v8LX5j+D5fdfZmHxoXb1iiaUZT5j37ZxATL2SZUHr5LXy4rmASL12CcBizWkrDBtdmSkJ7C2NHjlNiHRYNKgPvrgplpVF95Es48nTbTGfy2Xkec7XDCv5oog7F4B4rvOVPgx00KVl/YjBiTvJ7JQM9pTHnbRNxlOZn0gfeENknVRQD9rmnZGiu43ZZj5/o6LqGoeBWf29lNpqEXpgijsVXyLcUTiIP1yz1d2sC9q/Wm61DYYSdEAVT+nkfUVH4Wgc2E8gATmM8ridkJPq0zBbKy4mkUq/JSOcyFRQrghua+BQnzMfDzOnW4Vqezrn5VrXlqKkx5ybxYDLQ5TlVcTmZlIZmWvGk00njtps7Pv3C2kqEAscwpRDNJIMay+fqB40Z3ymUMyXqnldgH1zxXO9BPhqa4n97BeI0r4PC55oGdepkVQudoKyZ4+PRcxXxnOmPs+2cOsElwVzbW7wnbdBOp301TOAK9ZMj6UyYtTuIWZEWWcjkZYaMBBSTHdpm9VFFWZV8DY76r5LkD7KeVQaEOscbm+hrYwQF5+5bcU2q7aNK3j3pRIMtC/JyJLW8jkukS5mZ8GMKkMRRlcwO2e/4braREqKxtpMzWkVYjAk5vZDXFtHX56u4geX3llna0NvAzx64vXbFkh7b0TdQ334i+vjdjFhfsTY5G3+A5/7cP0voRIHbhSERE0ybOsrBdIoz8jywcmCUq222pA6aiGlRuOINiVwW0nYZNMbNDJ+q5O/9A+dxun/ev8tuQ6b2JxLAyv9sV9YrYjeaw+OScpBl5hhEhtbpvu1DYqg+PuHMB0ZP3+fHYPeLQBS0KL3KKhtxGkKh+2cn8c/xgw7gHNy5arFA4KMvri0qq5jigGwox1gPldBjMU7oPxGuokNu72RqEWeFeyFUe/w1k7ixqNpP41tEfOCTsdstNtps0MSB/FLg07TZMM1dcy422LzDftde9gboIIWeNIs5/D+AMNacD0STB8pLIaJmJ7USb4Z1iZFSNGsi8CLo3ilUXDzHqRdbwffW4ddvOIvftIfYWWHf2nF0hjFBfGt37HOxd5A+j2gVO+nk2fc+VYCGaoi/fZpkx0L1EYGbG32b1uCxTw2lezZrbEkx8B7aGaQxONz8SgXCazz5e59cT6A7Evy+N0d712UEnZzrfaMk0LJSBnRwTVVqH/PS5tFUpZLfsqhATpKabSbUhTn8sstMiOqjUmxajlpQYpTNow01b/YABT+u9ian5zRt27wTMmkVDssKs+3REF9++rasNsRVCC4+LfU8XNYWqFAAAB1ExgwWQUBRpK2vVvzWeOC8OTLhoMlAi7luOJBwYn+qNtgoG3aw7ucK7U7iujz/aqul3hX9R0ErB8wq6PvvaQwTIHTOl/c/KLj4UJiJ5a72FAjFXn3EzwBwz6DUuLYXbutviui1Wv0ds/zkfcZ8PGKLmxSIKN+5B7FEYcCpenj5dz/BnijQzuYAc0YXZclAZ3SFz1SLFRGENClqjV7yFuRYX0uJ+AD43/YRLpQHcPAhE0NpZg8Hqit9QzIgqkaPEvAxTgoVHQLqUItvbKTrUmMwxgkRq6kNfEUI1mejbAJZL5+NVsMLmJBE7iK2CgZNVGK2St4OJ2vyLHe1vKILRd0wZtaecKRzbPB+26r51KB43yhhWErjG9KUBF93i1aaD45E33rU1GK+xQxjfLSW6mTUSOr8cwnFR13xlcfmZuMnWJh8HfZczFjKQTGuQxbYI7SO7hyz9UiE6ZcYNkJ8h8xszlTm60IsRJ0DdHB3krkrtttV4Lq3SP6s8FXHThVSmjgNjvsYggPwaaKjwV8q1KTxeA+monLGrEynIka/x5WoTb0ilfc35l1qb2y3xeiwiU1dW3aYEnO4mGQW84trZgoLGE79Ksm61Z6N24TH1UcFL2uQjRNQeh4F5YeFaFMrrclmjLYw8EVjXqgsMnT7f4w5v2rSm+lVw+1vjRkshsMencst4v+EnCQte2hhd4tRGMYiA7aOlAr5o18nVtfhMVJJLU4dZLGERCLs0LIqiCTaGzTHi8onKCKZZ5kRcH6IlqRDWOuTosTxSLAsw7ad9Lr8GvXac9DbGV1nDRdx70/6LSNbjeJTSZ1ZytsdzqRbZfVVSgcjOjdJEswxIG7BFeLfZBcgJ1pxOzZ/pxVTGjUNAY836wrBUzuSQokYOQ1YlNi0BqmaiZiGK9EOIveGbTXQ5o4ZCpicHm1GLdENa6UpHjI6v8uxM3zKV54imLeJXf0sdgn0kkW0oozGtqeXkwkUhzr+1R4Q74RKc1YZDYP9rrvflMjAxVYDqkplRopnpJoE22vClZRGym+n3qzSgyegkL33ddkWow9NidPTwiv/1ydMzcXwdffObpPwiMSVAeO2EK1kDCORZVPp3noG8EcUJ0AQIOExXz9/lssxvRnj4TcVryVRxP+vHQBnXhdRd59Gai80nwDurBYJo1WafSRc7S/k9lUVoZq+fQwQPCy+NR7/1a5UJpaQdlGqMzr26NXbSJm57lJ84ZjjDjnitIwuEK77ehnoTLRt2kcnS/mBop/Q36IHIzyNqyKo3S2B8LRN/FXF5IxaXMVoBFjT7EdVjR0W1s0uNxWMRmlhkgceTcuoFPiFENLWuGAlhJO2wvBpAlNLbDXxdpXX5sFgbubh9HKjEWFfAvYcwwLy7HKpKB3O5NUUYNtfe9M1Um7TYWusany8bkwnWz8c6aBASt8wldjgy021/zjFnEtfcK9gZWjuEzMdxqbod870SdLpzi5tLJHpRfKM6wLva5qCrFAHS9yG9arkPHsIjx9q707DYj0rCrQ6D3JED1OCF8gZ1qqlDs3qyvSpOsm6ZBCPi8ieG+pOVon3vwcx4CACDuux6ZY6CPSw4RaHWn+zdFRNBTi7RaG7ROJv76Gnrq4ZuQpmmttvzk3y/lrHtzMYk6oI/cZTF1bSLUZuSXVWutix6Ys/I8ryseTzAsfC5Tnnm1c/3Prd3vfpeG44dmgFbVw+o6NlLN5bB1Pl0QVElgE1Fi7fgF3Tlp6fLlpLmY99m30HgCKcnS8DgHVpehV9cCrz6orfukPH/RhbZFaVK+rNGhSQU92PnzPTymxVxVlGgaRWco3immZYL1nuBJVDHF3ZrIvrzkE49UqUEhqqjAMFZvrtjAqypAd//8jfjdCGQedIEC75LS/zandzVkJ9U15W+pjsVaPCbrm38bbOxcAi2x3mmHtpzZSGvab4UREbuThTXFBL/GTxyoIgMx0Kifr/jXOHeqq3B7+WQaZUAc1oY5moAoyhJ0ejeJRPZ1ZAegyd8z/tYJezyyV34UmGX5y8TO5aRXk7W5gMRu1ZyK6ewW5pdSLbszyuBrkZux1cYL0pKUCMfSenHSA9lASHYj4knjE0IJazEzkz9TfVLOZ/xVlHD7Ji4sSjIROEmCHqLAVQ2MNHI8v4nfznELksCIa2DKuJoNKruDLiMgkD4B0Kfg7ZN1IoyDWvf0aWupT7kNk414UYzKXiWKCNCbIPKpLeWE0fBbB88zpQ5EpLyBUEwzuFjC8/+aT5U+r0kI8+I1jT2V5m7EA/BJ7DOBAwSzfEjAQwWaqxowEPKJ6VU9CFz6Y5L9YmFtnntz6eWtE4OxKS9iG1m3DUK3BXz4LQEiCapTShvr6+Wpx9bXjZ23YhXIpd0AbYMSmrtR+dkVdTTUx2SSeOTEf3unQ+XAlrzQXZ+6Y7DwjGLfx9+5Abv2RBrCFrP3h3QiqTXwqk4TfE9RaRtRnkqZk9TIxeruwUskG5b13DiKpUC7VpTynOc+i8JPG8TY7uswpEOpMGnERN4RBdLNnczTzVVu7a1LkWRg6HGEUAY3hdHTc6FlbIFWIBC+h1JlIG/++SLoiy+at58PwCkR5UNBNx7aR4drLusPK0H2gjjb++r4hYEq8CqCDwEhk7jkS3jK4NhhUYZZP96WCgV/ttFm/szcQ+NWb7N5UxBVg3IQhjiXWmNvNB/wwnLbS1yWgGCh2oIMmGF6RivgmCvBppg8EDUeGxHAfcWksFsgmcDCZ/sVWEkxxJmNrWQyQ8auNs5EozNimmxmtTRb6kVrxnmLDfZki5LiRbo2syU39rbHgVKQk17CSJTdS27Cj3Q9UFYOyoYtBBFBUp2kemyBZxkwYVsOB8FBZRTHsMvgYH5y2GKDZH1ombDvMLKT4H5xlihIMhKH2PW8WwgCgXGKGZW6KqXNUrMyFzKBGqx8oG7AJ7IXd0CV+70RJeNNxNBzWKA7OtYdLoDEYOziyKICwb3DM42RRb5UPK2gVVOaB6arx3skYxFUz3QeXg4Th9sn1Ta6xHA0rKgBnClAnlPi9Dabfq++Kk8n+YnV+1RTJAKSiFDJQNMVQ5Lu25S6xDVafdjoacyKxQoi5tNo4W+Opn0x3GGfPz8xWvzQmS+QHYVvEcLnn6od7f3lNBYnEEpdp7VioCoAOE3nUL4V+33GPfiIMw7J90CpHXIdSdBHrbzZ+PXZ3RFGnMvpg3ljZBFXHEqMwpS6vek2G98wsYX6nT148H5yKOEH4qLk+J1d++Nuvy4FoBdTu1cYMdQQGKtgsMq1IZMO5qhAORb5yyJz+SN04YL83K0EHPQZPZORrfgf04jLANqL8OrpRllKkzUgoAXs8bgDnXdbhf4vuEOczDQcucPthkTiXOr9dtnln+a5FqPBVIVcB7FgWacRhQBG4WyCd1eaPlXPcxVmWB7JCe+f9vTFCyVYEKZKW2k/oz6R9RUc8qHgm0GHc/GvAePycS4UxAowGQHRxajN1cOGHNypS7d2n319i8nmA7mfrwffy80C1eGxMejjGnFxZo+OJ3otRTesi/d6zVpeXzTcpM34SMPD4yyOnNgRGJIEd7ujLa7jwavb/90eDCyioo0LOQHnoyxxjKQf49LgXlcePzdTSyHhXM6i8v/PAfC9b9kIyR//4o0+XsJAuD1gsPxw5ULGQ3hWZBwS1vq4/U2sjwXmri86Mk97scdJHv1+iRnPRprC70CCVKT54HAL8zU/mEbz29n9+qWADNQ+8u3IDWGEVEsa2tYjj2g43EiWhvVR2LlUKo7vEN7EWpPSRIFqkABAOl/fjvNRNtRRNFCgC0T2XMi3NKjfmEVor53vMzS15JEhvA8nY7v6zLVdb83+J/D22L5mWpfJrA7iUZ5eAIvhTPp+GDO/bkLDFVpJRI1n3JYtNmaMhS3e6Sdj2LNq2CPAZnHdK5K1GTceay//9qsTH/ZDeha7O45cVyq8obMMI0xB5yorbnht4THBzs36PV64KvY/+QLFEo3CaRhNpeteiexs3V3GHrAIqEsk2KtooZ2L8puwZNVkMFGJfjAytgb4mMyKPzKpwpkqox2iTa5FQFb62D0cHgp9X7IUBTRk/x2Towfr0FBnh8w24KzIq4eCg3cB4yLz7RDPntDU3RyHux1V1QuZSUr0qHlVXImKFEMQOm1PWY4y0q+Gb/9erF/WYTAIlxxGgQ4lp5FWh1snw7o27YlMNjfAonr+5mgoHXB2tzgskpp7iaI8ZN3c79eWp1niitTX5q3FtVw9ci1tWRhTosVXCfJIswssQkIzfW8vtluj1AVwwfM8l8qvdK9NGxZOIYBlEc/2BNYCVDEMOggUGsszA2R/epjKxmuKDtlqOTyKCvJtHmUYEFPFI5yhW1dp2xxFFwzqIiuWKPXj6IXVCIkVtLnUbLsNrR0h1ON7tYWJ2UISRT5w2CnZOny20zwGPV5Aw3rkpcEntnCh7OOsz3ieFadZw3x/jxo2xNsYazm1AD8/IewDE1eqgL2G75pIlNLqmkV4LPNbGeqiEZxJxwCBSejTzlkM7aMYChcCxUnW0LK3njCqO6AQ2aKBV0Bep0YVEA10yKhJAzZ5IhYfwIuqVkpML3Njm3CI9b+c9AsRgSGVLQiVO1yibEugQbaXEHkd+TGA+Cxm7C8o/0OHeJHxJHI9jIvKp64aKeY+JD7So/W3522/XHCQkPGZwZSM5yQUD7Px79Jj0wiE1GTtUtaONZmvAJTcTeDspKpbgl0HjSUitthLEYsUV33sAY6KxKEodRwZnV0cdOd9i529syUZ05qksTKeOrlFEctbGMdw1gZ/Tvg9xcOERQyw7bPRJgXIIfJEimh1dPzk7NvrqQ0b/oDLUG+o9i39eHJV3PEbwbyp130ib2e69O8ltttIBAPInsLa5YShf5yHvSjlM70R9LBubwHLgtjtHP323NrvYZ+f7H8nI19nAH3lyKDGQmkNLCm74szmuUGgkgbLuMUGaVBRBrVLBb8/DhL1byCMTqMuXPnG/LPW/k+x1uYvTO9IXOEa9XssWUQ9DeLfx0W6rogdWGdMRIvw7EGyh2VncN9mz/z5eJ+IKSgVQE/vq+T+6/tq6kiIIg1Xx7JHe3psGfl8iAk27+en5qi8ZS29Cu8Sfb3GZd/lLp7L3Z1v9Pgo/1LOZO3743/FdjQaC1+nJG8/P+j5ZHSSLqZUu4Xw17jShCa1N4aBSZj9Tg5vSV1d7hOCbcl+u/P911T/bWrXAOv/S6fcdo61VeCcRqOG4tfXD/rTazIFMeYiJ6zjV+2ChHQx/XCpwXNDhLmToCwdVdOsg035/gYmvs0Zgc4v+Xzz+18FAg07RbngPYcwq1E118aMZnpl6GpRccv+TxMQe03qhAkJZDDu4YdKmak5QKJUJtaJwYjxWhJCbSJVsuE8SNM3rXrZcqoPOWNEFVSEUNhI0pg6o1K/3AgCrNR3oIkUzedXgy0D1088z3l0aUMOGZ7p1j7/msbu4Cu0pLQ9+/MkMWNgQvh8Ydadk7PE5JeSqFJ3HaLenc/xoNeIyVdn9uQwuHC20yBx4KCu+j4SIE+tpISDYI/ziqwpgJtfK5Kts0vvp12QjM82mqTSJZra8n1ONbUZVKJTcClwUl86XF7OX576ZnLphUw2c7HYym39a8og024RXvxLcIHLd92Ep3rsC5+U3wy3d9+0wcM9eCCc3NbyqQKnbGNg/oi3Qs8GG4pYnk75+IKOhImN/eG3Eu+8/PWYqZeM3ZKMtyyoyoiIo2Q6dlYUTmx87ZVqcvwck0f970qPe9WvZEmeiO17hTuLt5ZuoOV+LjKdqby815Z4HpawJ8+4dIo1ISjMAVSnluMkDQtmQmNtGdiJlwoW1vEw4cBNvFoyvtoCZsSSaYxi8mFJKytVBGehSLMIqcBN5bvhzx+8siBVFMLODZy2DAtW9uzwYShSbzXqHuLtri67pXr6NQP8ft3+9HsdbCXDAIXnqdLTM79ZHNPYfvd8oRCOJ+sRQ56uzaoS+/v1g9RkLbNakjTK7m6s5bly0ByNjkxA03qQxERZ4wUu8fFct3n1B543Pw9Wa7Ns+55+fPsmL0u7MhHeF5UwMMsXVdsa7nGLusuj0aIcjasaAEHOLikRr6qkoGdWgxEk1UqSeDeSpBQnVpOsQ2jJWtQmJNGDHIFUTXQX32cun7+p5pRegNKCbdW57XwkB/NXvD8LWTqfdtFi8qDHXpQva4yPgaTL//XRN+ojf/fWg127de17bdqFhGfro+B6e43Y3lhSsj3cPuzHdoCu0i/6b/o3+gkxO6w4PbjWfFhJgQiNx0eb4vdVp+DZXfIeoUBcLR6TNCioPIkGmAXfOG0dNCJeji75KDkIV9tlyASFMh08/11bPvm/sc2iDbddL8VzlPVY1JqjWSF0uqz09uSghTHbYaRrU5W/dUuUCKZ9WUZuMOVVt1BohV0lAcYJqVIDSlyyeSqCgkVSOUYuN8Jx08OS12XAd9byMAAtMoI3rEwKWxvlY29x2hDC67jFmG4QvBsfCQnbONUpwfxgwrXnsne08mfbfFs6/pAAxzx36CnxTJ4MdupZFkQ2sQrMv2U7R/kA9BV5fQwR2/uikRfm7q7WCFNMI0ztITe4uTY4TyMLtudubaQzofNQu7r/6xRec5eUJfb0yBrIit/uig9ZJJcaMb8YacxkvbLLVXIJYphUExBVc5K/NBce2/HQcZJLGhmG6pkZV+uJgBR1efHHwCBpD/Hx7knRTR8gsp+Olg35vRn8s2u41mowR98XkiAGhsP9RfYV0NrKAGGlr3UUqRCXd0IRhv2PYG0yENQhbN7zqiePC0XmszUJ2YCeoJRob9W+ZYCsPi4ozU1kuSeQiHD0rwJO/oGnCJ4M9JAN2gU9mkkql1/HCXL5QWqzBotbbCuTTnYVvZeJbfrxwaO2uvK1roooIYpoUDChph/JCgnqLGA5HhFkiFOzEmw3Xn5nUBWlLH2qfGYkTa1jarHCEnB7UIHE9wTiAPeThEGYabIQAi4CeZChTZssAF55qpa2rqYVcmldcyZkKJoZ9Oaq8+qP/jwOKBT7zS9PSMu0ytssHyZLacq2ZNSKgK+pYvGbLym0/3QqaecWb5Eo+yHljAS01x4RuPjofT5VH6qK8I8HtWNglb1/WgASbAdhTzCA2oQYdh1UlB+40A9fo3dUAWoFwjwspFCWBYUnVWVPxyr5YO+K9BrOn0XHEW5TAb1TSfNiKWsBQFE0O7pEsOwh5vNL3wg1PbPZE3QocUxZ5R46/CGHKOL140moSxvJlQQsmIWbWWM8XPnfQ5Xdx1TGZbaQiqsxBFGmxy86Ce/MBwQgwcRQsbqXL7B+P30U2mVUm9mbnBC4FHb6aWz2fEYi+s1wyGYnVMXBLNR44CiSiXvtanAq6kQCud5nLh/5UzNHN2n4NKKpB4Y6KusHEYlFkja4g3E7NUuAYnXt4iYV5zy/hgITtopeUQ08oJ4lpXkrLZBURf7TFZkcqts+Ms2KlBkvjwm3HF9VvVqvN/35rzuZ0SMkLWeE5bRKFJU7isQVXyK6oPE5QZWbTmKx0Mmd8Se4oi/lfsRFbzk89dp8X05ntJj1ixhJBApzd3eljNE5mi63pmhX1nFJoxnQXcwXsxrgtL1AwGDYssahuaZAzSKzYv5sgCLut7LXpjUIfaNpiKZEZx8VieYUCfZq1DpvUephpptVprQXZsPv1JL8Ja1o0UzirviU9wmv2jHVm9NEmPDKRuEKStwH+uNi7nkwE3f6MRJRDoZzleuUCFXApnkuPmsEyAwUDqnJCuXlx8dPVgCKxrKWtrLFnufbWLR7O6fC63tu6KYV9KMVzvZrA2aMKpi5zewyUMO3ztpOpOtlawK8P32LI9roVCV3g7rjXuKyCnq4dDVrQjjNxGXx7WXefKqqOJtx7TgOmMJn53Yiw1ejglLY9dfITnEAUuKCqirwijz8C+sd9n8xgqdwnwp+A3MiUemcQQg08vtwPFC4ilAFtBI1eVJqiicu0BE9VKgOF2qMMXsz1AgWGFIAvfAAIQcKXbVrLpYtg1Kizi4HO47wzcYrMJ/RAtDELBxFhHPcS6lz2kj468Qki/bbED4IspUgMx760cI0o/xElJhLaCEXcpWbBt/T3h5dO/Ys6vD9vKu7C8KPYZuSk7h3fQj7EZlIrtDiaUosSCuz4gQaqP1jtJQdnf3Kak52dA9dtelxblMBfbD7EsjxLHAwmtTc8N6+zR+FN2z8ta/W0HZuIsgpEZ6bMQRDCMFDUsAccCjbk5poH9cy7mhaEOZdEwmDCXnXOLGWTQEvFY913ZcQrsk4XhY5oSnYdFf6fWoH26pcWciGdBnzmUxjEUyqiUVg6UIUkGSbdBW3qxkUQwjU7bjxvtJJE1/dPiSyjaDystQ4t0unu4aF3geG4Szv0glf9E94Eo+fmGvIyrrUjsTKioaukjzZbLlXmwBiq5tzXbRTZW/ZYQFuvvSmJ3vbhEuI2bUtP+eeiZ491LoEec54NJFIYkBHVhAiJL2zg6OG/LT/wXXyRC1/86zMo5ob25AdyhMAHh7iXizhXUVlkUVuhEnK9U9jHG34O65YzTzvH4iAlENd0pyHLc4HqehjJnJsXlDuVDzDUqkGJFhhUMQF+hiI8pEjfc3dzrbViFsC6VTlax8wU0L6xkM4dLzUJZGDuGH4NA/v+CICeb3MeFOsANcfeMWTB8LGyYz60rW+diL+6kcEfPlc7QlA9xJqK8/9/5sFpD3CmT1r87877mwQkQ96XlqurZUMnfEiTjMA5MRZaAai8yPNkDYW6ofaTx/sqxcfTE1r6xvPefpNyliXgFGk0oAW3SIhNcpmV/OFSL4Q2sd1lHD/RK4xVqfsVU5Zt1Vue0SvLqU4giyxXlYSKYXpLT6DY95Ul0Q9SzF+2YPb2KiyFbfNPaFzUOs5Upbfv7aEztIcO77nqZK3areDpyxWhgXpQBAbJw0z+sQnTlyd0cId0php8T/ZtCtJ1SCyRojAJpy6O9IVycmc2vOzxs1tMg6TUCsuHpchklcFcAhQqs7UEttiYZsRnYcetFkTynauNInpJUozUWznvfn/uNXQEM93z9p7NAkvWUXO/hecEyWTD3ZM/m4Ehh8btHbKnbyMJLiSKKJcWnOvHSuU/pV+/Lnz3LT4oPDq3ok0QgTAQCvLFnIQJAZwSdMrJ6tL8QNXOTU94t1RXfXcG8ZZ6zGIiIb+L0mwgOwuuqcbCB36WcSvAKN+PY0Zv92ldncBau/bXtT6/P9rEcuCaL/YASxP6w+EIMKd0WmYCkeU7pdQf/56yM6xPVeFFFsnYj4UpkM75485MGYWJLFf6IvWtdBYRxQgE3pvs/QJTsx6ZbBZ0Onbr5eePpsejmpKrdCVQkFEAimzeFWt6w4zqzeHxb+D4gCVgF/Cqcm3elSbMLyrbpjBH4HjlD6w25Bq2fWTrDrSwQlZovObE8sH6dYsfxACWBA+tJnBaqbiIA5bzs60BnxfesdUI/c6230cHU15OLE9UL5HNXLn7851e0uv0dDTdND3pC0Tzz7tVFFM4eEjGolCo8IufGEZt1E3UMqHDVhUqlc5MbV+Z+hDR32G7rTSKU9txCApz2FpVvst8qWupCRumXiMwy3EqgBoU2bwj24o0lyQPbSLanF7gOF6GAT/cSSCFtvN05wttrkxwebAsFKJ071NJLl3sPD892uRIHBJugqdqyvVzpN6UNMJmab7LSS3ZZEpmTEQwV996IaML8huHdy5itUpC27pMDO/zsgrsyAtHrSEwNE6hTk9Qlt2FRXNFqcr/hREMIxle6ul+BVSZ7l02aApZyIBxGDEUn7zo1eK7NiVGcJQprdxS/86bEnq/rWksuY/7bsa9KkgIftD9j/wPhJ6OEQk9BuD6GCVNM/sG/Ny1YDhWS4E7asioPRSOBHHfh0aUCRsi/XXM1o9diSnNt8g8uPGb/zAc9Hm+tsTJdtQuRuESGnECF8LJJyUsqMF7Lv03FBhLlY9HnmwKWHK3ZDIHHjavr6fzPnBVTKLSbGUzCgCdSWTeWzn/fp8TxN5B5GV9u5d/6nDWPrTO/pNVnnQrtCNuP79TNh7MI5+zveba49nJx6vG+NviJdfef179OzFPPR7rHcpUfdfM54OyTlZaH0sM9037Mf+wSbAaPdwI54DTPxQCI7L++mVCACoGu0PUs9TyE7wSRMJMXCIsLVOH2KnM34IZvCqOx/YdhhEdC82vnr9410M5Lh40QxJiehhazmyzPrCGtV77cKuald/e/xuW4hVX+NgKCs57247MTs20y8DQvb21NXeFlKWY24wFRf0FB67Fn3rQCEc64acQyWwzJ2BA3/kuU/bxrYZ3jHiGTRbOnkhy6crLxluXot0poThHHQH63fpSkBRpxjNTBEwK3RF+9DsIUpkxLOnWnfwSy9T0KUoVqckKF3a+2toxgpKmsqidQXZ0pA8nVl4xC6YswbtLL656EBpIH7QZhHLxtGCWK4ED0KNodz9VlPXafPbVWNScrDA7vAGv9YvrdwzSSlM3cGguNJp/koyS5axnEcslsofY3U71lTH358q0ZxKy3ti27GFdmVDLE54t9DkDAKiQgE4ZkYUCgZVOzHbrPAIT4WaRnwyY4nvmZbPHaSEf1eL0mKHnka9JrzmXlP3SK6AfiTDPZzvWvK1nSkfflRwmuzpopcF3D6V3Lmgs1mcXvrm2kEmyyJEGL6/cnK313C+Obrc6f+9quXfuyJnFUB5lyPgu0XfVQdcf8U/YVgYKh+jBOGj+SrO4p9IDvo9euLvzGm68w5mC6l/7uI15Mlzq2ts7VSjfxBl6FAFGyFdndZIyDT9Z91KxwtMGSX8k3cK0TJmUNL7XzuG3cDv29aLoNPN6WBTLFRUXt35uGfLmFmZbrMmohmZN05naWf7so8ikx74u5nJV9jFVoAV6s54TaqGLbqGEVCwZT7UXbZ5EFbXKB0GRb/DoEZICzRANpZf5LVM1aUgqjCwpgMBIGZ4oE6YNXmEgB/MzN6RehjYbvlBWBZ7AYe1Yh/D1FVo7iJkvgV5nbQn2LgIJHjaec+ZeSXAgMekYF3YV/i+xow55h7ESPolpONcGYOSLP3c7FI7iZCCzS3QAHq/CUgn/x/W8mGQQo54F95D58V2ErTZNqMtJRoCpAQrIhBSIgQSIgjgEqZJrGFKbxXJbph04dPd4pCoL+boSnNgLnkqQ5AHGtAqHdHn9QV+PE6VYTJwMzhwXh2BWv8OEn3dugiw0Oq0JqhRPZmYsKUo8ZIpV6wd/duSNhll1V/MPI8AS1dzsueZeFpYsxElAw1JjtKCYjP/58Ll2/OuKJudk0R6GkUOsYVE663dycflcp93u+WCW6NNB5o4SlzFLKr2oU05U4oferj34TPgWqooneZZDXYwKmxncn/GatWAPO2bYSimA5b/H546vCaAC0qeIMd/vguTJRpDntAS8LIV1q3usD242zYRTxcWB4/nvmOgJ6y7NntbSXC+vBmjj33Wz2I5BKHXyCqilEl/X7+tGnbqhGrQYzDs3skPtW1cpymvSiP3LZQV67xDyEHCOe1v+qpst1aYZZvzgnSf9+r6nOcZRXtQ43MPpMTNFP4pQy1+aqdnV/96tWtsQbbyYjqyOvUUIN1PGQt7mYNP3I4ZJ84Z2nKphYjVsjbn3YxFm/kThTh7gawDglEHQh9JEggvwXNpsD8xgFW4dJ9xKL4ukPALUy3yMYO5AnrYIZ8c2h+LdfQZomjfHJhAtJqc/WUyypVrXGSqCp0OiAj0Nqm3er/FNT+SoImYxqrRNt78MxJcfcaGrzzuljCVSDByaript9B70EUlRLJ/REfUJpkuLVulfr91HscYZswIRTP/js7yYDCJGAwsuUnmf3dKItjiGv1iJG7iNs7hxzB56eJZqbiBh0XsNwfzTRgGq5E7+mFSu9bzcnBt19yvepBV90VhbXYEODBuXPYpAqlZRJl7C8hovhXoHAIKT1TI/I2jU197P7zpV1HkCp7D5KXXMulspTjs1/YJfXbjFuBFpYHdhRnkocD8VXAECd2lAoyy+7uo9a5B7XzqorS7LDHPDUy4U3yb/Wlk/Ez2aSvd1tUOSYGjDCksJggHteDcNMvjxW+pZlc4Pncr0WyL6hwBoM3E9/Um+usl0ez+/E/xSv9Hk6UTZp+WPQhVYawxX4zkDpnbbPIFR8TZdANdW4zG3JcqFCi88AHW27elwwtzd7eRcR2IR5ubWWE+Wftw1SsT5y9alIjycZaEPnxDoRtnUE+juLb/hG/yR52kZTNx4PIGLat3jtEh0wB9TCtiEBXYMTGwR8dYyu0YUt5bWkcu2MGcvHui5d5ZOr09cUrDzq1sdYP35e5jSkTvLxe40vOKDg2Ec4WJvFpevSQ3NSJpdBe6E4Dojvsmsu6xuKxfbSzxZTQid3/LWKc9rLirbCj08k2eDrj0tk8kCrzlagRGW2bSFXYOee2dp9wb5AImdqqzzEcP279wn0YFXyqfd8uQTcArPVRD3nTewkmvZhEOSR8vAHAJT/oxgoX3/I49Vnv0faotmQsW2BG6xYw4r4mrmTsA/XsmmAyaTkMmSeLQdZALJ5pJN6ikt+g7Px8Q3wCAiqCRTjUP+aTxpLZKu8lmnkxfqSlcyqsLrmP1IRQkDNsmPYK7Yd0qZpf8j52UZ1PLNuiZzZM2zzIZcd6Xb7LXoNXyEMYabeXLU2LICeIwsujo4/YsSLMxS91TwGARE+wgNUucq5vm3d9ikD0BA9voSB7ec/OYTHpp0I7jyHRsXriURO7jpCHwauFNgNfI7yUq1f5s+v7Zh2bjqImC9m5RxRO7S/TzrXkSv3MRCkWoykwfX1qQTEWeuwHHHBBLfxTIoMQURGIWJWb1thNVMmWWCat2dyie/owyUoVcmi4pGDV/IlePuMawP3GHwH6UH5RJleVeO3TuTzFfDN3eZo8IJZ8mrh5oPpGmS7FY7sOVNiYq42+fG2jVZuXTSbLhoYwdtuRp+mU1rLRmXA7PNKqDLBLLtMTC5NsBMPLsqb6Tvbi/0bNPhOZBBTbawHTN7iq1sCta2p9uK0A51wODL7ANdAWXAz90Mh6OuVw7/siregEo3yPPI/fvP/an8+mMRLeOlbNBiiuYmr1brtZivmBaixqCMmb4yzpMf1lka8BYGv6DIWh46Fgcf0clCFJqad9ZdGg/5sDilzGj9MZyiY89MaGhgWi2Qw8hQ7QA8tKwwbC2ZiIBDhE8ToeAg0NLAI+6xyjY/T1aupXqTNRTTKpjHNlUEKhyNcNp2VuiRdKh+au2BGojZGkNUwajSmezPmwfciuiVsc5sN5KlmGcihp+929mUNW50iAXD1OCxpr7HoHlesgmVIv9P6qtPugUQLdeM1kohcp42Fsrmyfx0Y+D4YKP4//juxwVbivIYhMYr6NGt0UdHr3XsOaDRK6MHo62xL0O3NupKMCbveytn2D7s3E7w8s3XFIOsMfw+zD2pr7f2H6AN/4TvhqKzI7w0/cSzycweaZcUj+/ahIK2PHvl1KJca2620tPVHtkaz32RbBJG4Tzr3Qa9vhknVYRq1tYOpRjCXeijvemXS1zp/1TjhAxYKe0cbEC0mHP4BPQ2WTT0tA6z4sBtDLFxrHBCYhUTPT/Ya/Z8axmpglKmtjwmRb2//yEPqVY7f1Xt9Y3TxoWwWv/5uddikq9R3TAIKaf4HrJd205NVNE6m/wrFfdXd3kTl+fU7aYTmgSeUlTVaAE53fN+sYXxU/COzSDwkzXSR4eyzzrTBUUIHe/XN5WZugVnsfG/HQ5QHmjHpjz2pYIhhn/H6+wkvtVjn+79T4f8NIXPafSf4kwg8Y432WbCtLpclstN/sbGcNr2quFb9CfTa/hz9fTn8j/3OTMeWF/n82Jhhnems2hP/+i9/8R6g3mhloGXG9veEU7j1I7EAR2di/cpQvghP++vJfSiKz2ttgyAs53DEYUnANL3I2zLszwXJ2pidj6plTXJ6GqH38FqRIQJ7qs8+goXUOY1beNuJNKcLxM5MVvovevRSePyl8nOJmuc+IqKcV1WTLEzI9bxeywtv/OxE+QUgLbixnQg9SxBXl3RAdXRqMQXql+HqY7IuRRmi/Iuy9Uq8Q/JyDZFhbHVgbWTZZmJqmrt5i2hyhDqYkxCZCIG4eTREwFLiP/4Zj7tU0lqX2EkoDmRZzmc71GS4mHRekBoVzQla/Py0UBk+fJbqRbnvpgn3aFam0GwXI8NgrXLH2nTdrBN7CCNnjKUPtxdikmk4asFg9Qn+GjlfEnqFjKqN7udusNlHZ0Bdw+eiF210U0bCQtXbBPgtLiANOBnrrNctJYCD9SSkPsoHGEdf7miymEGl8giXRGVFkKwtX+uh9fmY09ykUT9udQt3/wHAT+Dvbz4chhY60k24P46OPn06lBILWRs/BZ618uGuCeNXTgmmLjDcAYKuQb2V/7LKxZ9cWLTpbevwEaEkzuOjsBAM3txuepoaVbCyPl6DghlSgPy4rYrj8SQ7z5I5MlgDo120tLwsW11RkGLPhEhQjja6Eg8MRL50x3mmDcReZobBBYdnVtiGrIuKO3K6e+5WV4aI645GYWTW+2v+q7M30cWz5vfmxeOuNa6UP3i5LVv1MNt0obx4k9PhLXB1ROlyXspCqUJBCaWfkHcd5TF7tbCjLCLUSGY9l8W0cnYpaiz8wrdsbdsgO89BqOxfc74Km6k678euu4J/EYeYkgcVJqveK+nbXNj4lObBndH93rpdBocO3BkY61UuYN4dbFq8irlONNLX/IyfSQplMa+z7Yk1oguIbemVh2v/Vx2hbox2P+cOrSoF6tX3bUYjmXjur52+R5PDghbHmKiEngLYzE+R8CAhi0cudN7gwyO7Hnn0RoFgwpR7qRvarroTLzfkvETN95lKr4kXZ4R05fOuEW+BHXQgFD6B244AbjTBoG+ieteyAwL4zG4tV56WOtnz3yj6c6DGLiJ2vhcpUbPjcOkArqjlK+d/aiOdAMIRcCb2Hr5Y+pyT2Vg/7sJ6DSZPMyPvD+UEupKeg7y8Q9E4hi48mGcaLJ/MCUtxVll4QHzxUaNjE93BiV4+HFyjdWSmW3mA+m28RfgEMZ94eS+sdoGJiQRMQv1N3r/8s179u0fq8NbRvYk/7fIV7jXgECGoEINwKVO2zSBB7T/S6ZmxjLiHv5y8rw9cx9OaYkDNPH+yQ9nDX0BeOUM1JBeczVHCpw3BHvlJbFYndJLFNbSufKnHiamO2zu5Cm/5bguSWvko2z4/Re/cf7voIWYVg9IHHHDFOgxzxPIqOkMsPwZXr7vgqC8LGRxCus07Qj/IweZpFw0flhToUL0EeWRKpDy3vjT878HwsyEtdiYBLUYqlGsF+DDe0p9pbts1uT8z7Zuc8qQuPdxUfAf3O+eCUcnxvqJqcnHM+1MvrLshMNMbhpDCbLCmXSY/3AzXyBmT03AfFkQBW5Yrc8oxn7uArR8VbKAuhukVFmD3Ad542pWmW4A1Sx8JwJGO/ZD48L84a3LWT81Eh5WUpDsTZ+alDOxoz9pHziyWmdtwSAsr4aKxG/8uKV7aW+PUoxqgMnhNqv/zMNmOQ8GkTraOJSqDFsV5OO1H694pTG59HRotj2uppxo+Sap7YUvNPm+QVGDnPpjQLC0u3V6mcJJQKE0hEJoyAhcLhzWJVwhSfFobFrqmNHKGataKZFpDC42FE0lwwG3AQCZkvL27WyblTrzPGmulsUcEaXUmJwxTtPqTQN45fpbWqgjGxmW5YVJeURMlClBrdzrps6VKOCklZBk0X89P2I/F+P+/JX5h+aF//MemTh0pTUQXH+qxR3NtiLS+smt5WmRHMSBffAAaz81CvE72HCJIVy1hAtaLrXiOjSB1sbqincL53tfliVgXoDXXO5wS5Ph/v5BS55VOmszL4/DAdtgwWpFdnQcUbacMA+4Vpz6fADpwtUB7Xwrzi5dIqT6M+oQ5bvDZzayszF99FhopojoB2sBKIVJg4WKUDG0jutHgcwu2ORI0lgPCW6JuHoFI8fm98meq+Wd6zfs1vj52dyx3IwDzlhufe9SC2FnDQfP5ZBFTOhQVa6UEGMCfgkQh38pP42wgZqFndiXqlk5bsMK7AFQgCnXsgxqesyTSBmF20ECWXmsEYCvFx5q6ZyzRpmF+drl8xfQeQDT815isdUoNfuEEqXpJZXQMToPwyXFyEtskl4vhuDMVixnD95FUst6Q+bxoB/HcX9SOL7Y5nfngCPf+ezbS5nP8KNY0bEqTQN26Mp8fjbTOKanpq6hCX9tw0qqdnAAaCFB0HTbOK7mTF1pIM+APZHR1S+sZ8k28qNgIGtYY2ufRHtbGjo/ieWDLn3hpyKclmLYvMAv7Uq03ob79ygdYOPLcJqPK1V//Q4rUpWV1va/y4zsM8mBRTo/c58gCKP8pGntsvKhfSF2NehPDExzUUzWGID4AfZOA/FmSoX3mIiQ9BWni++6Xpi0t/Nfz/ef0AUx5R1RqK3vaYsCqhNVPUrJ9W0BcIBVYvffG7xutyO2iAMe6S0rXiMJkoq99FY8U25SagqDfp6Dd374QnPLByMqKcPjJ7Yx0he7Z9+V/qODPm7oBkJyTFELs8BHy3fJRW8kV1WGSXuWL/T5U0ldXnV0/vc2z65+fPORJU+MPmbnw3/92ZeUhKomTV7Xi6MeAQx525PXxAhiNJH7+J/npu8wihWHBg2y7sylHQY1+C3rA1lcGd/Z+fcvvrce2AI1oYSbJaTg8QvtRffU+EHViGWzZWogO4TEKVrQNlZ1FBKcR0gLxGo/EfUxRnsk8ZG9rYx9KH8Ty3mfgywFwBnmSUHAeJH+xROKlxraE4Bb1gWz49gOLgPhRz8KQzdy+sv07kNrXh7QJkupqH3u/s9CF9GCN6ro+iIEGPVQ85geL77JRYI1KO+vIaOOUDgcxH95IhqksEODUCvu9AkkB81R4IdENFMskXXEjt3lixmyF8/wHigN54UOfDiLlLlWm0HscGHyU6UvwqawWc21hxr2nC+XYD9EqlFhuZRxQeqtP1pErbNPI2JRlfIDHjGPCUzpSOYNBlh/K7hRJ8jj+Z2le8x+srIQp11i/Id5poUakzHzGs7sgrM8m1gO4fIJhp0D40dltgKyX36Y++Df/tPLvCzQcVvq8dgYZJ+MsIzJcqihW0LVOADCzIMkkSM2QKNK0Gh2EYt1ijb63UofK6vueN7OsZgshxa2RctnmwJdR7fTYC0aPtKnArVc5zXW0IVXeBC1LuGIfxSkpeipNetcx3QNU27yZZW+/oceodOSKAsT8sSzR+9qLV6hFYk2J7QIRtekjQVPItQJ0RVBDW3Qw9SpHc/cBBXIXX6/hDh30b8IeC4b4T0L31ffA/9Lg2aVkhhCiFv4niFz6v6ZKBvzjZm6tzgUBT5r3eTLqv36/1bMn50LrYtYJu+av2LI3bdK6QNpNL3/3BFCmrXcAEOiFYoHNuF9XIM+SN7m8j5eO6EC40/LP4Nkkl7qEh6YBWoXOrOefl63/TbI7F3XjL3SRi6FTdl4DfjL7VVCDTNqYuB0oCRBkgbQpxFkw54K41FWuFuqSAThe6JWF2gKJ5H35m3Nggzd+o2gGcHw0ssJx/C8Pt9bp0D9bblp8LGwNXVjjcjU5PhQiKxiW/IZKG/+epTcpiiS5OyGq5PcPfG1zPSoBGLPugZE5xR1QzveQllF9TlEZ6kA4C6OQfQ4GuYYY33ZUSEdSP7RK+FIJD9B5ifAvy/24QVo22Yuszny0hYM3lu1gavIM9rhYhZwH3MQhyRsR9wkZLOPdsPJ3W2ByDNkvalaLpWq1BqdwRBccgaVaUH9MarFkWt4MuVsLds4EUglEUFnY2x+ftzy3cE6MX4EgIJJ1MMe5/F5sjSpSJOwP1DTRaH191JsPqjGaEWs0UnZtEA2X8qgdr+WBEZ8MWZjU50En3MqTqfBBEfX9dq1VGUbvJCZKuYwvgxyj6y3+PTvAzDiG/Dz1ZYxt6PYolx5bQGPTgjJ+kL0WLWY3QtC3mintj+oAagPcfV91PgpY4afgN2s209TS3/Z3QQdKKeGBR0kh43lvBDDjeBcClxtomUVTk98LwWRLt1Gcc4FnRhjTIxphsRzV1/19RH/kEASanHP9MMUxAsyzo8U4dqkoaTxgklP7IbFAP/AHjWSjiHY9GhNbaj+gYdHOMFpXkYkb1JUZp0IrXPVCpQNQyMoACiaW0m/WSB4dDrTxMXV+nUqzqg6NxodE9mCqLiLS+oNWqz2WGiXsg9oK1Vj0Oz5qMACf10HzPF/mqJO0pn18WFGQIphXIXBkGTJ7x1etmp8a/xzTdqM/HFs037WWWfAnGsNZJIqoBWa5kTFdBx4v8JfooMVsV59wajFYw0xtRCom6DcIHGjUQi9qWcElSH33Vm/JK75kQLDCBJdgHOTD/mBX5+Xbc+1y6NQC9xacjSnXCLN8c20tat/yeYDZ4PI2+pclbgP11BqlFcFnAKRyYJabbSWOpri0DOkDN8P+ysC76bxZf2QATlIFvol3I4nilEE6+2XIRhQi+Q+BWSetfzUs6PWEBmapNAHeZGhUUvSQwbTD0JnUJhkaIpIZQRwoKXUsGdSnt1FaHZeDMRo9mZqxHnrjrMYDopAcbn+T2YzMARAIUBes4P0S1xnqCMMyxH1ZVRVPepSK6+9y0WD8Rqhg2tqiIgjEuZYBxjhYVu7Jgt+55GGF4opI736Pxp4ixEcw2Ecw7EyYZHRZkZpUuQ0ampZsI39C8bqcuK62kKRx5f5CvY4EOrXEni1boHGjGWO2d2ct8yQnQWLY7RlJG44vAIxg/nhSwxXI5xuNjuFwkRkD+GRsZq5DADNJ/TCBTqUawvF/ijmL98vi8ZYNCKbUDfErrbdKbbMtqUlFJqAlOo7IL83la+MI9aajjRXbkLc0Ovqp369BfW/FNcx7Jj+OfYwOffyi4Vgn7qAxwkjmdFhecfCO4EjGufZlRQhrc2qZBYBpGBRHRg3C4rPl14L1WyOXc9VggltgjGfDh1fqPjDk/4IAFpJxFvh08uG8y0YSMne28joe4VvGpHFoyTb8foeQNt8rutq1K8FdoRDX5lGp/hR2+lqdc6QplHpGB5Kl1zxSjK4Byk1QGCDgc+fHcdcAIKvagmJVRlcintuW+eQOz26sMNFk1qduF6YFy9rkQ25UQqIGZrV/ubHoYK1TxWVNtpei0d12BGuLBBpKcQygn1W+/fFIKUu3zeFlSum7SY8It0CKcO4Uk8aUkWLX2AIFHV7LExlV7AdxDBfOrFUAAFGK8FELBY3KWZjecO2DW0ztzc4/ae9PguGOg932rNlPFJpihZ9rSnzFlVltJ88qMzDGaWzgc8Gnp8sD5oGUQjWkjV3YZozHXj57b91Lomk0tn9L9D9EZOVZa+uVHGvYYFmUMtH039ZfzFI4LZcn2Tg1zyGhPRPB0IAsARLPbL27qteJYTx19vXZ2tc1aQI+pShWLN4uTvSrCDnmyWLrWASFY0k2C5DQFi+5xKQL7SvZEjoQAJhUymG+aEWKSDb0d8iV1CYxvN/GIUOV8YeBMOhVACtgtGe4UEa5L//TgXs/tHahRlACTCc0phf+jP7dh0vgZ7LybfPeTtg704T7pCbN1WWDeV6oPHJqZqWMe3KJnZbQWAmeHcbgEYZA9oCEu5prolseQCy0HsvSZlwZMC+PAxjw7oMh9BCNG5mw4UJO1bBbGT+7ivVc5VjqJvx9CEvLjnVVc1RxoItb4gVsiYLKUVxaV2aLvVGawvleDMwry3Z9EKTdwUCcAQ25xqegwnNlnRo8vaTw8l3AAK8tVQ+Xedd6Nh5OnsAA4RB6ze79OuPOVHayeeXlFekdcBcU9Gnd95IMi2zhjn7Q++fv6xSLggaTEtvLWj9sBd/hb/An+CvzGH88EOpStoV5afB6RFNGBMJmjVPvRwttmkTjCXqcFrLuPBBPdIQsmOUE26ikg8at/biDHXs4L+sSBC1ndtVQ4MdYwqTufiiJMRLrVeOkFGeM6XsPwFDgcKpirtyDVieL6Mqoxo5RV+dTczDLqp3dzBoH5eZU8utjrMwYo+wlmNzxSMr6twEPpHkwq+deMA1msxv5NEuUYuXSnHZTBLk0sWrOSmcZIsTjIVml1CII+3iUSRVCTafGQOyhbSe5o4V32368pHmnCSay/4NTzkq7PDKqxKFEcrW8EjzgreqIir9ZmDTiCmOByFucjrl1/wwAhimZED1r3DGA+lZsz9C7fyy5kyPgU1WvbGR2mc8mtdIx8NimrSl6vJnczOR8YV5kMlOKhNch7YY60oZlW7ImJDK8jtSuJkrxkXHrVpN2+1ZfnvVV+F+hJQE0VRAjKEPE44WyIKy9kdoVtoDzowSL5ziGCHjCQOzjpwP/26UZYaUa4qBVOEYCkatDZB0qUWc/uccJe1e7qxNwBr+gIPhOUcil5oP3jCaTAD7qBIlSZzUqWJOba9PHtpgt+YIoxBD5CU2VChN/89qtiYjv6YuTSg12HP0M5JEHPQoEaUArzXx/Plfrtz9I3rlOHNcpZrKDGSd9JoufuZu4KY76IVl0MNenbhViYy9wNrCcM3CQI4Gl9xzI4uX3VnuFRjm9DoGtmQ+N4q6t6oSotnhTMsgUCtBS/VtrsLqqB1+vXHDCnplt1tNchns+Fg6GOeihOoJzK5vTJUWyjxN/zkVzEwIUerDIYnvI6YNOX/s/22e8ydb3dmz9yEljAHMBFuLOXNpgOgwyaW77a9cBBgKj27/RmEgHHr6hCOtxAJ1TngQETDBZKiDLkPJv9160F46Ok4w3HxArNFF9R5tWIRLIhNR0gqWLG3C5zq23PQ+WSXLKgjCuUNRoEwKpgxJmi8MOQqtinSJcT0Qh6a3qjRnxTyokFIh7ppUMYboOMlg4DoagAOh1iFAKBs6KL8trSzCg0APbm8F6lzREKrUxmL+g919wQRdHvxT3s5Z6ziZvrXHD09Oo6eBJ8BLMGpebvNg8j+3nlenMg+s1z7o+je3QNhMBu/2Ts9EtnB2kzI3LFXYktGGJeyEMPz0+ttp6s+fZ231CWYEAdKQjaVYjjlY5IjeDJapevrvlvfMUHetf9cuQovBKn7G2ANpNOxI1oEzzNI7gy81KxVxOwOvcpKJkY4FfBQAWZNYrPG5KX5MBIPkcYXwFhKkfSC33MbO9sTZwgpRntcYyHdPV7f+klrU5zxaGW30tnPITJRtCJhFitY0fQOcV3ik0hOBmlOEEMHxwwxhccN0jGM54FZRc9GUqH0AFuhpfY85lrbqfIepejA5OLLjVreVrn6Zg4IX3V8PxauBx9a4+Lum8T9fvJ9ER6OV71DurL0Cz/zRiLYoTpKKFhH/fIDQFmwIvzXjQAoFyZghFWosJOQK1Au7UA3hRm/MGYFHrfx954rp5w/6HU7BE2BDYa5YxfCHHh40rrBIei64JaC+1fPCj8N4+hl7nTZa6KjQgmJ31uhoNHwI426AAb1LcvunvZffhw7R9I7lWLmvFBCBJpEioOwDo20iWWuKSZdWL4QYhfzd5bj7w0XviL0hN9Q5vpjv1+1bPb03mr39KXcJG6NjPo5Z647mlpPahYRpGFy43c3aKh8+gaYQ/vaSMzmuwIZ1+cN1FpHbftux5IIKBMTDL0QDJk6nLuNaYxVBaW64LOzeJXcvm6HNYl9hl6OhpSnLr0k8nch0jFHad1HiBCFcXKqolk5gFgwGwBDhkKtwmF5FmFj33nHph4C1WTb80O9kKciyfcoTVhxeZtHpKlmLqvtie9679qmKH76BBmYHVekKSsNWOdFHmcLatAgNaO3UZEiqzE8D2whfGgqiOjlz491sqCIS7XPwj4NNBErG0/Pt3gDo5IHqf3sxFH4I4Vq9e8JTDcTwFI04gJOw4WCZninUR9hwvTtwE1ZQv9x5zYq9bIjB1SA/IeWuwfBCBLO4qIEjl311RNtAIxOPGeiq7lXaFmqaBbXCwYUclFh9IX+8Yt/kqLUM5LlTVjrnPDHa4/oDdy9kPcbVtUx9aS+1grbnfT4KbjQEA7w0utboJ/vLv6Ej7ESxPLqUkyVlDLXyU15Pxp/938IbbcFc8oxQOQyafuVebX4O6OjAMWmNQmuOhA9usLsvasnSVhyAbj2c5xHltd5lIHj9J/LpRAg+NDDyvdatbHa2chKK4L9/o+p/Ypuj3vgHHRay3vcMrGOTN97fmDt1B8YkIDRit7deZqUL0TdTqXFr85IYPFLcILnUt5bKixCZw0PvbkygM61IFvGRKKyd7fk4gG5xNa0Ga2DmfJHE+9nto86Gh0WCkZSFa9MvA+XH33HvFeyGheGLhMMfWJhhqs5PJYxbAQu09oTdVLoCsUU2nrf2cT825g8lCzO0PSEraNnsNuqYtEfpD7jPYwPjD7xEfr3Wjl1ZmKdoh9UnfszoU4anEGeD2P+ary+JUXbis3KTx2dqefvDd7fCKr5NnmVolDw+7vUbTF4ZkA2dOkTw6MYo2bVpb/i7ji52JX2/8Yc1rvElXdD9ew7UHbwrw3n0aFBZtWW+uOB47WAj8VQiw0dNXw96Kkd9l7m3rH1okryNZ1R3wSVTv/EyxdXXtkMemdbHZnqVEjCNUqnKtcVlwP/1h1zQchU4VQ2B9cEnWP7BT6fdsSijsbhzklzF/2r7rhs8860tw9jG+HmM8HpoxaUSJn2iuPhfLqWTEZ/N2yJKXZRbH8P+uYyQP9Ub5cDrTz06rwfJ/979fIwlhOwVe0PDV0Ux/j93f+lsiMRyRNLOjtPl+lR5qd5oCQ/Da09M/lHmjjgtZomByUdJH0KmyVjKmqhXBeyRqQmMCKaYlSUexaD5xFdSzL1/zGNTXSxTLPgp39ybXRJds1bK+3kfI1uafprvagVoHzb01uSvK1/YjBa1tX6f5BiURjjB9nFH2v3uNoixpGSnRC/t1oCa8VwicUwGUrPPrWRNBfdPyYXyUaWttdiDKtvceT1giT1144nu3+bRadVtqjSjIZvl22G9PSMhVTh6YuTiu+lwWVP2A1Rn2FYYtc6V3l3AzIHbUaWcdmsQpUb68Fl208lQk1GtSFcYdq4UBOEVjyQJz4i6rrgKonTRh1zQojwT33OrEYkgrFr3uHYWCQX85lRzIp0qB0KndE9r1bhUyO8N+lb7HPBhuwTfsq4QaDwbrK5cQRur8VcV4RSj3cjuRrLxsqOIM8Hg+kiJQHpWxi6E+8ATdrPwPLz+6F0e2h+totkOunzZe8ixHgmodOzXB46PelkuVkXEM7teo8HDAOPTwgMqzHsYn/mnhvXzUmMa/lA+r79xJjJENs94rdqsC9FESaARDWs4pZYIWMNMo4v4FUCHzuf8OxcfcRWl/ckaqoC9ea4Qw3j1oH539YP31j1+JlT0gqyvQH17QT9FICxeGkdn7WCmYouJ5o0H+X6YcX8XgUmEimROo/XyJGCUdolwfXvaGappRxz4C2dIspJv4TNRju1bPAV6XlzOCn3bbY8WLxIaPzR5suap1JTTwyDQgkMtyV5uokub9OkgoUC6ldYbMutierPpp/kLzvKGfcs2mSpiPTGRpoyEwDK9/sfaLeuKvPUDmw2FsBc3dzwu4/rRzOmJjiCgUZD3dX9eiHBCBp/LjMhLZyhBC5k3PSr0KjzEHhq9DQ9wHdeRScvtJ3JvjLK+Wq0p2FdUH1tx2NqyRYahLbBfO0rTbwpj1EzlOwcj05rtdjqex/1Uxws0CnZjjtCcdtvB/KvzI1VT2XLNdplsTNqF5xGSV0kSM1pxUU8/lqYW91h9M4UHisxj/yiS/LK072GSyMm13vA1nnjhinywtY4XQR3stVdLhkVC+TmpN4wUXKNjUXj88ejV9GuwQC0Q8q8zK2wlNvVygRwBxYTxKfT5prRgyCzuGPfxqbQ1l2Y1OmOn/lQ+jvJLvLQ1rGUlCwgnjMt8qHFWTEHRQZ7atImQOmWAONRMNahTBkYn6veJc1kGz+6tmzdIHd7jkbzw7RrWG72VJvrUiVFX311oXGL9wdO+mfKuYYbn+mE4PH14t8ijByOW7VAHvNfzHKy6xUGAS+yFR9BJtmtSCFlQj/UAUx8dtjTZ5iFoQoGtctWHO/jeua3VVw6PI54tKmlbpAMNyt5an1X736273G+kMwN0APBjHtsW6jGc0RbLWnQ+FgxYg4EocPLt/j6HbWDrdzFfh2FK0cGt9kwq4DsMBWIdDwLJeghmqAvIaMQR8Hr0gbr6yqFvNhYIUGwmqOArmZp7qVQl0tSgfnYQ5ePlbZ/l9byYVVWRYOlzbxkZVk1kKG1vvqHO1urytSL0sGlp0cmirKKfbWEqLQTxuT3aevmNIMfF6/Rn4TLhOwpxAZc09fSXW7wRfJbEJx51CCcDsRrCnh7GtxdiQ1Zp7B5Mza2OLARD8VrjrxD3IOeXg/hieJ2fQef4mokF3mva15aYeCl+ta66G8VFmzeKa6XPrreyPx7/YWZfV/W8QEIE48lp60wvzRHNKWrOz58tKTEoaDXf6bfLYFGrp/K0CylCKua1xSXMbfZlWgv8C0IHfiboEY1/KOPSS+P40m5trZWKGFAiNwNuzfNssVzKJGp+8KLb2GuREoXDJklGZ7zJAprEPM84j7nizA8UnnLmrqXPAStD+AuMNV3gTSEBrYHWBPRMsvJ6niBeRxhU4bIsBVj+Rq2W8SLOcuSY1qB1GthcZpt/jOEZMoctjhslxov8RmN88ljQm+sJf2eF9KzAVCwJx7OkKhp1P3HjM/f+HTX4oS0wSJOXPbs5CPZ1/cpBtXtv6oqoyjmixXrTw+PccRR3aWA8Jb0Mqlm8u/RQbi3y/brfJsDPzVvr7lT6Zfy8Q6VZqXIYg8MXAOJMQzw5y6BDg7yI3/5T8of2fR/vx4lkvdaQqoijwlxoMImVIFUqs2YTd8Qlbj9/H38UZzZU2nNzjNrYcJc3jS+V6WTNIsAVU09UpMqUMgGPBnP5IMK4co1OoRUBS3XrmftM1vt+CXSnDFWoQGmqDwHvjkYSrVH2yXBXIksJkklrpAu0ohUcB+HwAVGIUI68hLg0sdZB2p2cHKEVC0mv1Lyib8/dqtmyra1kJcZIInSvekcy0Jl4yeJV8bHts6M1saBrmnHejj5rgGPHj2OQFpA16DEHSZD68TJMkShVmFYmOLsesxNGlSDl/B9Eubv+/zP3caOLKSUU8CE74t6mKU90osh+KNJVyMW7tIMPcaQ8Lp/UXMO4My9tORoLvHmaa2VC4ieDcQaK/v8ntUxNlkfuxgJinGHry2dHzK8we16oJBYJy6mqEcGBcDKCpL1l+T4HIVYp3lz1cG8Gbl+klktWxfk98X73RUJ1uzwDiRkdYnk5XaCIMcJNK4FlN4danovH0XB8YDkOgcas3mOuJ/BrfvVjKfQGQqnx1GxPFRY+pJ0DtvVCrN2RF/SrDpqNNzEdfLAqGbRkM1YWWTCrkox7nTpX8dn1fUViBK00VsvfF9U1QpM8za3KEzdZ7UPAVUCrhA+mUC0h2brBcAD3wT7o2DK2V9QdRxB4H6jMoO12/F6QLiE0hanUIGx2QMJCrXPRZGiZN+zAjHUUwme5ucfVHM03ZYDGJXTr9yzr0FHT4GEp9SW8OTpGMrT9mTXkbxglgSkgXsBu6c007Zvcwew1+cFADMElvXHHrVXjklACgpj6IyIIxVKcVvdI2Bkk4vcHwAHCa4qNQQKFUaFB69yRLS6V26P1yIaPyYokwYH87HcQraXts++EJYM/gxYhUEk2o9erlM6vutvY5P62n8EmZ1xlu5gTsk19NZitThTgDBEd9iUihjkdHh49x9O8CLrbobg8hIBwedLd8ZLxNmZ1s5msjWc1uqNN162+8vD/robi+QlMyRNv0JA1clUaq6VtpBkPpxtI9jQ3JLBHurRmCHjqEmC5F9ZQZGeYG8CbQTa4wDXzyUX7vsu6gijUGBhRX54tL9TsO1lcGH94q96TdGHxvvH1GbU2XVbG66H/3rpCpiuQMwZmVGXQWA3Mz1cZVCM5zTk/AkFChMEsLFBf57rpFhWOZgavYfd/2h8OeI0mPguIosHyBuHBNM3zfXHQ7gkkqph6x6EyGTgMBZlQoxA6sHroaAMl2VeJ+jbdJrUrBw3MN97O1HPvA6DCLtA2uJfx46MrUXotaFo2BHHSRpnFBUUOcUUgCFLIJuK4Ju9YH7xiWUIwMoMnBqmJQPEai88fbZrCWXWhpAtFvPuf2RFBc5afecG4NYhWq6fW1Jt8QFeqZXi5F4hRzTMS57tQti8EpKUpFFG7s1gvs4armgaMROKZjs7CVaQmgm7Xvcq9MgNqdcP15X0QnUnG02iS1ilpWbnFbwCN9reajvbjIHYXOWx7P3G+mp+qRk84g5L8QkJUC10x7nsXhRoLhov2vjvnxcO0MRQjgMGU2uSK5Z4HdQTgQmPH03uL92p+ZzNFGZP4q7RDht2OKDZIgXfP/Bt5Es9kiwtMHtzawKaIhLOUGhfr7xYIxOxpsxlX4LWXpptOzGcaGxNY3OLhsxlJ6KfH2LhcpxChVEjddJiSaScdSms1b54IvltPdhXrwaQJsZJpIpoIjPO2qj2coNLTzG9qXyCjbOO8eDpHOGIRUqJqeT7r7Hp++9WIK46GQ34IgmMAaDUFb1p9pb0OLwxmv+ekRNe8xurv3z+tvUdr2Oqpyrh6PkjGv/LN0MORu3bJozhJHJN2JUgzV0GwGno9vN+rMej9pR50d0Qj1qQbq9ReuGolgTrUoGEp1EzZy9pEJSwr3pXV7QZS3siloh4prXLuzRnc8Py/kN5Fh/WtTNWJ2w2VoP7rh5hmkquxkwxsXx7X/ibU1vTGz3aavGMfW1hLjeE9ZVg95Ququt7MhReFrUcBp1QllIJer8CdRPzBRxIZKmpNew8O58ZgNqCwJugfZUeKUylU8vY2Kj3l1uviPMf0EhOHSH+jA8LKl0jOcdNrM5Sn7lzFG34RJCP6dfitKhsNBcKWVHfZ8N3P4jEIngYTNR+BIL//Pd7CZYPeZhUUr7qx2lQzYN24HggUmyHA1h5UqFVUL8qN8a30cXcowXFUHEjt8bRMZciBzjhqJUiLJHtE9udvyXoUhGuE0w+8BZrsI+9shhID1LPCnr0AQwWLdGt4SR0uE2Z8dKAU58/uJQKHh440MfZhb2/SsqDhxdCtcOlB9cpLcKDiVX/+g3mCwcLg7bZrRem9xNHgt19V3nl3PKJQCMhPFlQcFUR3JgElFMf1FScXXWyHExlBFmYKMf8BsIm1bz/ffvIK5k+O8+D2CtRtYhinx6OY/MiVG24fGRlF07q9A++FYjQQq+f6efV0LWAsPtGJspNRaKAaPjvddItiRN2De6yVGZCW5huVfJskNErgAV5DPVOF6GzHNQJutaLt1guFvbUjJq2dAP5C3pJBX62tx77FUaAX0itcEPpm3D63VHyxYRiuPcb24orieHbg8wU6DMssp8HgUNyo+LEs3/eNSdohYRpYPZFo3IXCoOjkM6Co+5wbFxjXQRS2gIZv61RVM24z9yXbC0WjQWFsBSZLIPOt8f29DrMh4feeRVoKs7aVTKLh0qQst7xhyowB/yL43blnGK8XNhuFjIgGrckJXxwGKobL3HPlcjaRjsIylYrdfu3NnzEX0tA5qqSNtIHW0LZl9N9qpt6KGJatK8cpFa8YLNVkKnSnptPG35r1FNuLX7UMkgwK2CiJtPhI7c4abYkZgXGRBimolY//dUgK6rZLi4t42E8uTZGvznSEUpIZnn46XVG9rvKwBQaNjhU+oc4Br84kRRrbMa9GD6HcE602pl0zC0Mcs5DhXb3y9xcoHm2+BLeD23GYcGEJY5JSJyLbnccyJvI/bbBsPInJZEYXZsn2sizyRLEUKKcvjyiBzZMDWl/+WEQY+/v7M2Uak3E0DYM8vd1SLURXGr/qXYP6rysvvC05/UsKBkQ0TJKU7Bczv5Ixia5a5aGKYfaaI0dzoMLAhiPV77TbTVdhGeyzt3AqsJTHWoaqaqHN0hXpUTWTFKtWcTB4IJb03dFhXcPne1NVoIyiKD7WBGbGV7WmJ7E/k/Uzes1SpQB67lc/ADcwiB/sbFgLXFGd+tfeud9lwcpJpVwsFKmgpZB9UniLOmyyrf3XQ7sC5xSxzS+EhTEnSw0/+tPXz3V2QbfYdloejO4IGBQqHIUEYIoEMb1D/LBzjP2vSefY8AU2SfHD0lWtDokl67jvPtT3s8N/MD3plq6YZx9fd2pzikjRpHvHYVIOdjdbQU/XSp+d69pey8QNMhjQfJFdORxvP/eDgSEDEbbtKpmmBw5Y42mmQXeJh+gCMxNJRmuc8ss7paGWdBqMFuz88L1Gx6haAfuuQ4/dV0gdOrfDqRrPYnEYwzlB5nkf37XYvPY/WJKWivXHcmVSyWV6sUFV1cc7TAMBQmxrH1RxM8w7Yt8xMFKMHmxSTkJQV44qEXX7sA+h0tstTOxyamLNe2JGFv2T/ERq8qs8xidCQPhdlEDaAkZL/VV/LBX7WLZbtyryVsUPTs5Jyde4Ka2WEo4PRJLgZ4sNygSwJCyWc6cVPZ6d6A71YtVuHTYMagbXotAuaLwkfQ6610ecV7oye5B7jFfiJq9L6DUfmcxRL32l98hXrUuKePWXlBoHd2Q7qhGZigasK23IRVbxgd6SRvbCfmyKD5WbRVOFApWVVS4WqztSVyQiw9DyA8VGc7rllMiOL3ZiSAeZOvyQiJr8eFS2Kh/2ki0tb5igqIy6LpWMo1thOg78OXpk8mHCgcSvjTP6+ytB8mif3ekQhaTEbiOWan7Zjf1gPFMKhIS18NrD+lPFm3QZIPQWQ5NFBjEhsOfmrLDBawQp/+eUHaOysotVQ0p5jwrp7M2l2VI/m6kAzI/T2j2GByzbzTD1vc+I28IkSdvUGa3+fuWGjJ488s8DxKD/OzIJFF/KTOPqYx1f8xWiALcdaKHzkARO4pwGnZxv+eovn3GIhgrGG2aPKBnBjRmz0lRUn9lV59SrfjCI0f98fmrs7jTnu2tRlqPcORl/IwIIyLTtrN19S4Y60Mkf3xim0IKLPR8HNkQSi43fSjhrcVKT25/2vXik40Paqwt35XMpicjLhhguvovskGbNBFby9Lb8EF9MnTx5Rkstj9EOKU6JRKG8TfLA1r6lbb+P0knw33xpqp68mXTN4XTW26Vh1Rbzry7+8e1nJ/I9hXbBxzcFmhIlq9fehzWJTMISUCM2qcESY7+cwUbKOL+lKtp9gG77tum4WV/l1qwJbBUESiaMMi6ViLH8t4rcqCT5VJfybJ0adPcMqmmpEM0Zh3VrW1kfI1Xxjc6BG5kSQ7CIoVFcdkLCSUdxzsKQvbzrBY2WGZq6bSL+AV1gVThMqc8gjBGGQuO8gWtx35aXqX0KkcKUChlchJZAvHCeADFty0LtJRLhTH6g8yTsXHE9q/B9Sjd233kh+26jG4RtTNsgb9XLB+XFY41796oL2kXAljDxNLLnd19LRvN1GfLYw5Igs/W7Llqw8UydLy7rzBL9527RL3yMhycD8YW4RGdWvy2egA/PqmraXFNpJ+0nqXz9Rvy0o5wBCLYplzKAb0nOQokIVfsPDXMKmWzYSD2F/UDZpxUaMGFavbYekkA60EXLPgxm703hkW41EGk76tnggm9qI+ykufJmpz8w0ulrbr6UJg1bh0ZruHH9NENhe1fOCWCsaIKgBB/yJa1+TFqZ506llNHkOIZnr3CiM9RyrGvFalCyxAk8237lD2PeeN006fAyeWofM5oZD0SgYfdxqiArEZiC7HGRSMRrbEEZuKXcp68Zg0E5HAiVGZ/lZfS1a27/dhW9Wlq8l6nYDTeBTVRJYAk+Qs89fco0+XwE6NiI74UJ9y2yGSiDUKSgkkmtR1MenDYGXY5Bp20k7eUR/jZpsrxwVBJgQ/dzSdENJ45xkOPxYvKaq1o4Aa8/fG3kCAyLWVKKJsdhJ/K9RyUU0JUCXPyqRWnzRzTDwBroaIuepLjy0jxtZdYTXioverrt90u12yts1gniBNZwHwQYJMY+Czlz5FJzUkpJ44Q8DFiTJqCPGD40EuNTP8p8BUVI66bc6wzpY4YzPjB95dajLCgnwJDlTCqx1BGvqhKLY0gL+8ZBfUDOCoZj2cvWnt8IU8CkIW/zPbHm5AIhCCKxqJ1WVRQiazZfWJ26Ka5VakSqxf67NuRUgcILT1aRJgttYDw/8ywuHMb4N8Yi1mw2wRTqIoL0EaMkG7OcHulfiQIEZxX31meIBfwz22eRWKjyyKkWWrOcqkBpuIPsSgjHE2+/nULaZ+AdPbfvl5RjefGNzwvT9FohbE1mlvuVPXm+q4814AbWwGz8aUtkb9mpOii7S6ca9sGwgwEIAuWmrctCaCwEhPci4fs/4RKYmKDzXH6Z6RleKtZU7AgiB15s4JymtFrCHvR47RYPlXT8t8qtKLHY7JDJIJ7DIBfObhd8JNYNarKIvshBaO3r7s0GZbPu/buk6nSUcqmIcig/onzYFvwmnqZsqtLIk/udc7lyGFLVgfm22NmyOd/DDyiYVSqR/KVL0QqmAG1zv3qxFp8ieB9NtY86CWCDCWWphZkNH2/2HZ6u3Y8rlzF1PLaUK5jJ+ewEqgGZsW9C0OhEHY3evrxlcFPKGbUBY7AqyZKYvFHz3MpCm0a9RqkYmqkApXhdND6/ADT8xekVqUGleBVDVyyeMbVDnbovmkNbDTDygtRtkwdTNRxIwWU3sZ1IDUmR4gwTr+xvpPSVZ7mFo4sNwDhdlL/J5G+ukdVbm7Icl9MUxqhng64b5tto9i8JfBWjZEX6ciHjgpSQ8+ey0+bVKTwQAAfv9x9FPgN+Qw3THR4tVJsFtG4wuQWKO3dxsJv6HsayweNFJDdUa8RChAZAlgQWZL6NDHhwiGjZgFnuWW/b6pmGjdHeWKHKjPTuBbl8u7bJEChNiisWt8V/htk8+BqZoxMSyL1MF1Zq5bFjw6XRr724Ed1pOe02Smp36dSx6/V2vXc/DAT06yF2kC5liH0kXg7hFC/2Y+nmfoPfkdP8P0mgRo/67fb9HFGMws2KBk+IqqcgJib+Tl+ZUZHGADaXnUokQyGfvlSGJzlXjg6xADb8qR7vJIqsrRlZc6u+wqUwkV49VS+Anl3Sm5PpDEK+K9oVZqcG28NOszKLmqxMFZOpILkQCgqRxF7NMDeuWKFAM9iq+XCD06y/5ef82ZWnGygiKYZz6pigHd3OYKJCd0bOe2/pWHffX1qnZ+jmkrwZChG8JCkIY7gBb1u66747xUtXX/gBC8CpDsrS7CdJy1hiZR3e+yHONru8cuhWx2aJF4s+0cn1E1bTgLJg1MMk87RVU8dbQf9rElSx5skMdaJWS+QNj79m8NDTlUvjyOBKCWLMbtA5eWFtPF05bcHpPfs72ZtWsoyUYUu6kpjDac+er3jB/QUcIctSs2oKplisljn1JhZMyEfVwtSRyCyqibBZTRuAnnP52UEI3GB0CbW0nHptvfUmXubeyfwMiiLrP/Cw0X3PYV8CCZp0+4sPp7T2K1ar8K9TDxRjIHOlxRSA8Xc8lglM6lJzQZagQtXz6JNMgCpzvbNSsdxovj9XbAh/DQseXJoSuI5I5mJE7z6CHPYKkM0UQinazSC65abAhe3Xsiiv6UZ9P4YsX1EKS+q5yXugUEcRlCyhQrv4O+Ai5mkZ6XzkVKlotHuI2qgRTYv8jR7JcQupusW5FvdVTrv8fmuKrONQluT0QGAxXLUOvLjBGnaKsioV9mCTrj16NXEJRzlbUWS0XG/1qOGzokQZ5xM3uBB4XlYvsXSVq9twRQ8PSes5IUtTeBekk7cFieQELwriqkjAGdrQlkqaKSJf3JFg8gzcLh5nFNNaV+aIEy42EfVTqqsLPEf/O4vXeiENoVK8JKqduM43/sOGcKdyJJ22xDi2lfA1l/aWtln/AUqA3VhCBLKVXQ1eSfE1KyAJRgEeWQrcjoHAkYbfoZjyFMutlouCXAuEDPcJbufFaoYqK8hEER6r5YSqC7S+Jo5G77NRbypXERNEELyyUp5esbisEA7kh0LzRRTY+Djxh9VeZOWJE0i44FXYf4MurZUnW96W1yQ7xjdF00aaSVFW/tWoSXCbcgQxi9VEpa5OFaJQy1NKm52l0iQhVOJU2FBtbyT/CZSmEDjQeVJIK0IJgLnpxz8iTdRdbSadzyToCTjFgGyxMS1Ric6jjcFC/fb2ptVl3IX0OqrSdJiF/ZbDrF5RDNv14oCWv+QgNW9BhxTEcxWTq28oBjBJjMub4Bq/+fY710Z5rf/0pzRlvhfd7/9AlZCNc9R4Lq2kt3Vj7NMNPsdzrm37TbbH6g9W4POr1M7brZNCjn2GVKskd8d8gXqzxVOmL0UAC4lz2P+I5qmW1+4O0oes0qrRH11/pmLtwcmQ0P7YPzv2C/xVSl7KAo9oJRS3jGbgi+p8DAMkC5UVMs00TdmsjDaIz5PwDeRlqWoXEwC6yB81pKzotjvtnuuGLn/ws6H+UZhrMP5MDWxypXiE/extqlO/zAUZKBMYb1C59k8OgDqLv9gt1jjav72Tzld+Ng041t668+V6p3iyc5At855wXV+P2d7g7MDkEZ88suZLDQFW/OvIJ4xL7UgryRnBWeiT76iZOWmPL6byYbt4oP02CeHSqzueH4QRd1CjmCG/6rW3CnsuVKhjXjJ4IuvSz2uUKiaiCpsuAxv0AkBMfIGh5g6+Y23ND696TIlym5lIJ6LGiiIJ4pZlwbrGIfB8S8hKPDi/wDvKAFlI7itVqSxDZfb6trrTiMw/X7XHPQSK1e5VZAa0JMDzS52Yqau7IRau0wN18wd6Dipy3t+T3edvoXQdqYEfmlaUa5WiSqLAu5C5DvNu8HDsV+3QbQuMpJiYFEnWsr97glSRvQ+0YBhtnxxRK6i7xnUs28kBf/oc1muv7N3dooSwhEO4Y63JTX7GIxP1MdLIJIg0UgmSZoWHzAEWAdZasF7aAdZV6x1pRaJOilI7e9YC6y3w0b8DOzB+Zc0dUZgfdYY4FEajKJDCDpz/rbdS9fte1McXag3zWs4o8jCplYVGwgEztyRZB/ajt1yuEaXm+EZu+e2Eu6rfX/2mZUKqf1Ffij+zT5JDb4FoACH6dPTZqhhouZcqzW8YuNN97ZdQIKHDs8208/6HDScd9XYPVH1imff0kg4KnDL99jCdCwT3YmiW4Wwbist56zUFIHRPvpzeUT+fvwq8MIN4XoWV9v+zA4+N//25ILP2QqIm1hxShMqu+m9i6c/WH0JMyVhsx5AjVDGonoi2KSMuYUYxwie8HtRlMztYXQQALnFHKZXrALm7hg/YDazLDxyqMKCNtQ5iyhUd5mlzbLNUBnP/UbYsank4qIcxDchpTeEC6EOcalhULksFpBG1Wv4vPGv8ho8r/6vRBTfu4lFKM6S5ip/3UAZzFVQlfjKRrfjmzEBSnyiMVOvqEFr5c5nnOnVV391PZq31RA61T8HK0XBpuG3UT1tx06EF/Aq+RcOOtTvky2q10i2iOUv3K9vcPTUbplEiKMOVwvsOVDvKAOmY0ICETeghU/8Q/T4ps+Tv0Js/mh1xUaBbfdbJY/STRbFFtSz7//VH1psessY0a7h/NLWvsgI7qNlRzZQaB3Bg1Mw6UIiUqfo4WT54fNhi5kFmrzvoBk5sfaWiLJCvnoT+w9tbb3/n9+7pb/CsDrUOYl5OI6lIAZZYS2iE8r8lF1w7JQkG5WUyjddAy1bYTt/ldgh8FuY+KVmb9opEVVOTRUnyMvSJHYfQk3EJ3wIdXsALOIsXynP7uXH4wc4NaRuDNz9ZHmx0hOulfYySrg5at9NgIRefRn3Tcz3P0UMNzh62xpHBbM5mwu88ssE0hN8ypu1Qdzjf47G3b2sjJ1f5Ymlza0SlN0BKKZGSNtt0qY037w9rWIKm8ooanxsyRIv3XiqYcF7l9zi8bUYyjOzYZhBRgxRTa/0dlvusDMo39SWNUSpNcMTIpgkcwJ9y8l/DhatS/S89qZR3PRdglS0SjsQhKwxQQ1rEE6FgAIUIL2ZgR5RmklVR4dPGatdDBzzwp0blltUzaUNhkPvWIJE/nY56If0Q8HacjpaTk3kUSltZqdRVova0OzzuWYUMoJNJe6aZ3IaI0ljpbkjvhVXzrozL8LLDW0hLVwoojqrh0hDCqWVg7qYDnpAAJqe0XRW1Y8mszLm9oQSkUwu0IaUa2BIuZ9OaLDg5MsESlcIShUq0q70W1GmxRomQQBEjhkOcmdLjeE3ydtOixtRfTuXkr6wf+YgpfYxXE8dXg7NucJ1cJ+lo3o0JygC+KQoraMjPtXcbjvKEjVXMT1LtI6Sg4S+Mr/7Jta0l4ds9XAj57KSdAow2pFJcAr7SFN6/4b5LAdkO3+ATo/YjDStc2ElVRMd8Km/YUPfBlvwCSM1HX26rocBx4dbVkV2Wpe0Ne1sRFgHJRQd62lBEsLCIavWOVL/LbR83TwPvctQ4VepmwjY+/3MSOpvKpLPBG3eGqTgHO2N37IpdseslrrWDvzNm4EwTZ3rUFUtX0fyIkPUk7LPGixNy11JKv+XaNSAjuirRCyK7g0mdQmxQDdo7XbajCWdCFbKWtsw00NzoRLa0TnntPtPzMY+uH+wuk8tE4JuEXzXyJWvv50IK8IHsKtVLTKIi3S3StfzVdkWjVkgvj2aIc+WzTUJK0Otus2VXK48W4ua5yr+BayabuLSlE5lXnktYZ0rN3qDayrh3TgVLv5nx64wqWYoKzV1gTZFQ0jmpHMAZ9SNNT0lCgcu5Gyx3JLGIyowmTaXyjDmHhWPITIkzqhUpgR6FWfm6WsoggfREb/cmvab6/tC2rcXidb1xL7HII6JgJ7aQRrrrX4zxiQBBhoKU69BldvjrVULz6bJf68Avs5rnxDNZepVPjfTg8dFQSnlM9q0sCEKZYxXQjq2Htx7LqtXgGk4Xp6us6NcyguEo7N6BxdQS34D2juY3eYJR7PETV4noK3DashhBOAtDvZfSeDJQUGfGFGQhpTrDoQiF9lMOZG6pQbUUgzDAGJJb1t7052MjSgOuA60EpYxJlwehs1pxazBcFCqvWJN55ciGbFuqgqqFoOAKYy9C3DZg+vfLZHwx8BsnjGe50dIX4vT2UyPRw5SE1bHgpQu062yHw5MYDQ4C4A9vBEokZ7MYhF7XQEobFin0LopgNiWkwecgLAuA+gmFRxFfBi32H6K5BlkIQCNXWkS70boNzayddpv7CzJYW4xpsuyCAqZYxWzlry3Kr2UKdwbli+5Tf0slG+1IKa1H4WObHhNXmPRu3cFl0vnyRSXjazBsX6/wSKmyLNEIaSnyHUhPcrupRrz5SxYXFTNWrClFD231FuyFyvhOq1y9uEFhRxYBGjq20nXKaaiW4cvoGmx+fFmajzYd1232tFmt0YkVBC/NDeHA9iOROrr6CKdLhBZauv7ZIOtc7+rdlDjfrMRpq0VLheRqIEe5i4N5Qytna7Pbd2C+JsbyVZxTlWRZCjcqh49Ln13aIBUAt+6KEslxKFiVdrCtW1tzqGVHUtTaW8s03DBVsjZ/dCksk4Fr5taBJgKSjvD69j0a6yVqXlHYUCnMSIrYDB8FIPuBulrFpNS0mvY542aIUK8eDr6ldaZ3f6y9ZYEOix/ODoxT9gEL0JiCaAQhCL4IKnKGgOGthc6mlMIgytJZZ/x6t7XbGdPz+HUBt19/IqI+d+pKpbpV+hH1hhJx9AUe8Jxb5KF9Qx3n06TlL2PtlQWFFmrDzzs9To2Rqtu+wygPfRqIojcY3SAzmrykw8ZW561CLjpt3M/LM03yZPDJiGrRS6CnGMUnZoTH2Z2y9KL/+9dyA7xlIqNl52UP9k13bfBbhQMzPn3k7/04c3ipEIsw+3vG9zx8GTgD95H+7P87XUheoTKjbL7qL6Ils8MZaN+MJ5M/eD8+eKbC8MX0kT94XC8/46izjbHf/c+6Q0aLEzye1V+dz0Xzo9uchjYAvq/uqVGR8GHmKfHhHryGx+jjClTSSx98goW3F3t0wryEzHxmbIG3M8fk3n/rQXx+6XboBNm8Fc7Lb73pjcVveuuDD5MrjZMqlF8UA42Oi9FLvjVDE6yQqr+CXtEUs8wsh5Q+BVPNaQ30HgtklrxA9wmusbeCXlzFWezCeduSvrGc2x9eH70p1vkdsfhhg3q6doaYRB/chowqNxUs4UZf3L1NuVWQTi62DQkZnLb7xbSEqQb6KmyaZByU01LP5fkDHJN3S8WCluVQS/TqpIqw6h0TR+qybMDSLT4PVLzNpngPWS7Up9dxjBXgjKrb7pNr455GFRiKhCdWwA6roFyfkWIQmT0HQoK0WUdF6QFq4pYu33sqfXWmujvnJqDhMrXm3XGCq8IUhWcO6DJGpo+sGu0XSNd43AM0Vm9pT4p963RRKxcAoEnyxwMmuWbwYMqFnXR0SR4TcaXSaamRwRLMW+bS4qmbkaUOA2J2XUega95maXgvEhGDphxpbK66uAxWahbxvaQumzvX3V1w46sOR805QpahvnUGYkC1wqOSpFfhBRcyhaqzxm43x9Ky3GaHoyM0XbU7/YTGM61/HmCVQKXzWIytvg5UHI4ZG4+K5EpqC6FEdLoJM20onLUCGr2NgaPNv9j0fKFsPG8BlUqLmQzXuZRrLaECB1LPMqoCbFchEhuxWUWsNgUHTEH7bmur7VrJn+zEpanFVk5wnM+Yb3/WDJyKR8BJ82ml29ugSL/7h1eEOZNPzlR63ibYX8a5MCHq+haej5loLJdn4eXNtZwVZjgRy08yUvm0zKwGXxcVlm8Ee2bM3z/nnBPPnWrsvZAE8yfXDQI39fuhjOxNw1/94Sax3t+BK+Mne/d9aq3z8PRPnfPs6zFGWPnWx6IzAMHgwtBzmN1PznFrGQuVmupKOed9p+GjR2zWhJm/K+fQJETMYc9nUWC5fEp/gzkjq0BVJOesWtGxZ5a/qdSkuoyiKUUp03zBCUnKdcJ38GIW7BLecFoldmBSZRDNNNcDTaK/l2QHD7YAmubaqv5g2Bw76yZeqyCHSUWviIw+bNlBZnzY5ACaZqrGIwiwZVPHZjKCgFeJfgf+bx5/340g9GyemSaciE7esZsuBavlwGgdD3qNLqIa485xd3DcGgRiQkTGF75omwP2/HC2Gnhhw7z9y/OAYzObNZ+3HuBIrr6zdcycK5ODGCt8vMWr+IsBU/vLW/6CkyNzaprtTggnB+bjCfK8mfAKhxJObr/Elkgl860IiyP8Li1u0kmgGKIjTbyJd21niopTgDteh9e9u2HldQS9kGQ6/Npd4S8IhwVzsQJhWPa9eZjzUMJwxRPDuUUnWHvwZKDBlJxDt1kn+YKpAUVZQdSZyHKIDgwcjhoMDcU9WFFmPpc6hdebOZ1233tFUtdO4BSv6ApPYyiaTKX26cLiuneokLBdz4SrrA+FRa4V37KHZzJfAp6ekC3bNhRJUNx01R/xXqgP3Qr7Cdzj9QGT3KJxfUeCU3uKFCkmF1MhtYrf5nWjhdsuaszFD7ZytNmgq1mFmKMxCsVixykB1DZgQEErxbUOCdXzmMjArHC75u/tudiuSzKUlnrc5ijUouNCKOJZqyktXaPMyJfrsdIZMjzIVyaYvnGekljJDovwdXcVBExNXolYvDqN3HdBSWXsLJ6e6NzcE7UHK+B7iV/enD31WGbbG2qTHF4Scmrbd6mn/fwwVQ9WbO5FzKf6aZ5Kgc8Gh8KQIvJakpCQvHCdaaLXaUTHAGIMi6TVldqFx91AJoQWFBm/mQT5eW9g3kX3h0jAGF+Tv0iJxbePJOweJkexDCLHbAIaNorh8ylkZjojiuAtzdWuXE8soJlu81wIiRu4NDYguPh9JVlil3EQsDjT4f+TnCEosaoSGAKtUEut77QN9AovgkmhkqZqKCwEvWeU5BVcci9YEoIjttbB3CU+3whxa1QTwRlzM/jxm9BYyd5OGCUY03zle0CPOZ5uURNc+1jIxDZchX47VpoF6v/ma9QSrjbhvHjbp0+d2aA5ezqdLNcLyMQsoGgEAMgCi6tAwtYlxVUQCXUjPKOtUeaVc1LqxNY6Onqlp3hU6vmNV/0bnhdXLf//H8bO5wFtIn1ELA96af+bOBpdoir/oWeEOj3vU5hfbo3rA/V9W+/IMQ4yn3a5k42KLuaBv8RGufKfZ1sIyb/+D5CLkKH/PABMyX1O2nkppauY5VtbWQBm4dio0v/pTD3M/BvzJ8xkB6KvChCQEpSIz0KFjvyIWUF7qPOceKhPo13+f2LoCf+4t7c92LX8O4/3nQf7MDNqptMgwsCUGhroCrQMiAbNXxvQAN4XDSJfqVIUaRc26Lu3qKLH333yMbuAnijnKAx6Vz8rzI7yklpcvx9LB0X3sOL+RIDlJF2W3FbgshipVKTSRIcqATxk3ufmrnlIAVV3fhADEiguL2nLTr9DAf8rMciHjtGzQd7xh3Pgg+kQfvquNOuZjx6WfPQh+oFqbxW5Ue7InQdOKJB5/dk+Zat52wVKNRsd4Qt4qmLWmw3yBF01yUsingpOlCLnfCZXSrmlk7Or58RoYb114Rvk79ZsN4DRIXflpR4dexUf6soE7zV6i/g8OcNXFtjYTMOI0uqRAX5nmKC+7sHK5wQTkyUJjKR82m0jM/7AbDem87WnhzX2s1FZ1TmDx2PVcR78PjFTFnRckap1YpZSN/jVmD1Viw6yFFKlaY7CUFxbge8DvzuAXsABUczvXJ+Ay7MY1s73QApQ979rGgED2fALrYfPh5PonlNdhGbIh8bhLU6zQuGYkEWGNelKMY29M1eNVpWgxTBBZBWunNs7CvZDw1GHgrlVRkoJwkWLb0bzRCDjjMo3bHAZOyyprmEEnGGqkNigwpKNO3+p0raxZ8jc5h/MIjBxcD67mdtn+hXAh4sQNc12M9FyIUpZ+//y8MHg/jslaANL0BoJWn0G/bJRGGZRqp6I2+yI+F2NskdEWix1SYnmgygluuWzgxav6UkFAuafNkoyRhJboBS8/8Caa2ttZW5ru6WX4uSrDi/QCGo9AZhQceosREbdLhFgR779GTI0Gu63wEKNCv9i9w/LsCmZmFLtbKaOPa7nwfzz2db/1KCA+35E6iYknUpp7zXtS69Rhjk2gtPwW+4GZ/0QAoZQSSsvScX3en73eXUJ+6GNXu/4KynYd7T9k1IaY6642NteHhN2JtKQHPPUVZ63e9f//7wRI3gkR/8CrfqSEzesA8yGHV78kbTh0w88FTKzY1eTvLrg90OZOpYJgaDKm9OBdgrWODWHD/eknIKZxa/hn9/7WZvPGp8qTrEOL42G3aTb+ul3nwRv+omTYY3tbj1DK8V5e8oPDpji9rudBPa66TrqJa3mX+mwEXfGo4CtRtb9tLc0XXEyu/tWKKnrQYGLySmLTiMqAPMY2ImHy5skPYMceS716jftd5qtOUzipHPU206573ymd1HAl2FM4jcfTF1TLkVXjny5GBEeVIuJOPbEclqSIySpeKH21Iq2MZfx9tA4xAKJu1FD38UsDUuuBIAKyWoyUf69M+QxMNL1r1A+KF86CfBDGFvLdO1ENzVr/BE3Op+TE2ZO2y5GwULEBvy82bPRoN3v9dNxGvdPuZ/egHaXlYRwjj6/65RSK8c4oiPPq+ajXz7IlHSYcV5xMKQh5B4sQzcOFmGdSl7SBT2dGL6X0Mn74EhK+HyUg5snqaEClTkzJbvBAnDtuhWLlMitLqLGOAXnuANhvO0YuG3VBRdZZDktkKWTAkJFTbelSVJXY8jsXgNnkpFtI2qukcZTq8XBEXV0SiuiYR9VrzGcoAVBPKpmgD78+VoQHHhmDANuIZBxUbggV6jWlFNYU49WVVqek5ZVkF+c5UApNaWmOGY3FCgjKUswO8rlgItR1rRuPZ25Ssyjf7lcgUpI5CalKKQiQbxlYoOj0DlPCfSyGNRtnGcarmduQUWqYU5ORV2rpPTLbtOlZuhNmUohIALiNQm8OhrDztlohNC5liQsjR1rLvgdHNLy5d3mDrLBJvz4ka5243mQ1OLtwSovYKpWxvV7ATpgdUZJjTdcxGPbmYzfvZ0AxUaOlqA1dZcU2mXke6L4LPh9NBqLT5gMuUowgiIX+ylYzEw85nfl6kluezoZxyiKdKFoPoylrEHC41E7GnS23JWYx/4uo2GfPR428hNRbwiBoR8ORuEgFYcvn37E6k5MR4Fd3tFPORlN9llKyOakbGDaCg64zIAkTos4k5QsRtn2BikBa6iM+CTRQYHsSplStHSksMYjKcBrOu/yNunI9jHn1aBgTU+Y9ioL4Ezds24SXrtGzWKzwbGELRaNM2T9k3ss5jE6olbAw4OAu8r4TpOc4XjitXp+rii+Q6NM2elna4H2pMfMEnbFWMyNFtoSuBLCyYQTJi6hi8RsTBG+6ja3mcvG6QNSEKDSi+Bo7Mn4uyeHIOSz+ZaZJ6BR+tH9OpkZA6eJDAyBh9JGu7PGiBs/Mttv9TE7dZ2nw0KQW+0UKIYKrWTNcX8YQoCG3pthtI1kTG7pm0jGK5sKM2CUobe0kXIonS7SjaQ3+rQ4nqQN9lziOtQWlIknJ6ThDBh67nw2YWdzHoIOxDOJ1dwQYAfyjy8PMF2QvbNk8dIjEUx7mXAyE48Q+mdKmxj2lIJotpznZ4alkWaAFfhPB0tEvhbw5ZS9HQi2trDnQ+SQ59cbUVSJn5RIFZQEbLd3KlPM+3HzuBcotE3Sst8bD8/ECsUMpZ/2LphtKU37RGlWGEWN+s6CjEEAHP98BBjefUYC38NTe0FPpD47CYDN2M9u+WrnXhft86TbErEvzwu0sTvmQkC1iS7buftjpB73/EMMEsvl5dlNCPBPC48QYBye2XUfOujglDzJMpa3SUR7ODuQvJgXftBJZiatIionUCDig1PviR/7HWKfGO6RJUrqPViDgOc0brMkfFTJr0sk6kPvUXP4ZV0IyHaRCb2ElNSD8AWE3xeKAjOcjyiPuC7O4NxoYbTgBAGzqpGCIFBxjLji6TNuA9olglMMtFO475l2NmHCxiSmYgRVb/UJEpBbx5QO02iTSmWtgdxoGCZ4kVJjRZ6Aw6jf7/V9reZJYBzPURiSCEV89kgoUawEPL4IjIYSKHxjeEKuXCwUyY5P5CEY1dZDot5/2PVpCnxA5/uGQDbw21NLv+kF/s7x9WDohKzjcYmX60eC6qhQj87m7ZtEIinNX270eAMBAhDhsoChqGQqL3k3ZqJAx87IkBdWahhQwnh4wWXmJjAhOdnVx8cLUfZWnt34UkwM3CxTO1gmdN8DFUHioEhVzEqeobHp6sJizGeCFbrkRcViUMKmbChg4Jn6lYaLXZsX2nZLEqAs6pqJZ/8xwAGHqsoib1BlcQIpjkbbWl8YWeoKmAeYO3sYKEiJ2ZzFW4ZTjGJukCpAk8JRBE2Ts8qpBl01auFS1dtA6TxVaimrZIPlJ5v19vIJGvXZu2ivo10fWaahKqqczuhAgHCMeq5v0hVs505guY3uwO0NerFrNTS+ikVm+tgzo+mxQMCni5Q9mmFa2RUhSUUZeB2+YHEhpK7IpRGdCyaCw0Bc4BYY6AvIA5dKMibdqFQqVM4yAbyZ2Cuh31psudUksT/d+ZWUxhYu9MSyNTE9NmaZEqyO037cSEaT5aRumrpm1NPeSZ5jKA9sX5qsBqKkPj0RDSC24QwjKSbJe+9vfWpP0z/am73lyShpxP3silEhOVFLgKrtiwiYttFW2nfYRXWWB/52ynkGPD4KSHLfiu2kOd06wsEthCnkpiyGqWkXT+pO+Z/blZOLVjB+V19Vj1mXlgEN5HfmAmgwlBHuPIdht0dabGif8rwQC2KikEdDplCIi1Yoft3DZ8XczCr1kjMbfkgta/A7vU01PuqwQYt+zrMfnLtl5jOKIKYCEMCzQBpGESSmUAqlYBoSq56+oZaOgOlEnStkaAdFBSPBeNKClXxun4OjAFAzKWvy5a4QUY0mSZRDK9U9dVr40W3qjd2BPwWZAB7D0XD/R9KZ/x3DURS4Jfc43B6/df5JYYwrxNG/QjE15ptdBrePB2A07rahlUeKwceOwxQZXcKtYQS6ZXlMwwhaWcQVCr6+15Pc29bWAB5qSUsBEhQLWPFuNAgRLgemjPXoYHS/GdGmvSV7YLhS5vVYVhAUJTKIGUQ8jFQhCOHeLKIBtWgfbovnSEzdBAxMhWo27IpXEcUIFezzLUNXMxe7uhMR2RgA9wg9f8wANabJBmnAM9/B7sfsClYGC9YlPBhde/RQhIpdXD8/0iAgd60NJ4n0iIh3zsNWr3w14y4Z4IJ4r9HNKyJGZRggSgDdP3nGROgspJ5yhuvDuYPcRQJjTqBXvJ8ogVhMaqxuGqGmqtxcm6NFMYcoVFpLGnZaM5mEiBnF+55FrzGLHYJ+TevIQDMogkbT1DHrvwztIGtl6FxmR24a0hHFg1wgKqP0lR5ok9xMY9F4/YKMXZ6DAyCuy3BIcOQcDm3TcTwkgmRIQwR3lAT+LoMgieTrPQlVT5Bz14QxBPC1v+5fnU6Dk5H77hwSN76W72aXgD43NmouH63bxjgMOukh1f3/z8f4dKs2a8M/BkJ30nD0ukao0pmJIyilXTfr1EJQe/IEPKGuAtd+5rgAAWjtJITTjEXQ5BB0abjRadWmrtErFBY3BorWseSOR7/g6FQPr3TiqENNZhGuMVjDXU7si1XCJt+c5jyLWr3QQXMNQ/DBrSUyFpY+VxiFTbLp6HfgfRdoOKw/5asXuKkJ8EDQ1mOd+5rtIFssC+yeJIugrYupshxCPpI3Lhp1v/+REz3yQNBtk2+YeuR1n2seo4eO3zwLb7i2RspRIWo2rn4wwiri610gLCUmcq5i2j+1W0o9q5dlYVn/ybqiNBsfHRiqO+vS3P7o5jBofCBxBJUZNVMd9OTWYmobRxVPNaUKay6Jm7J1or3shoH5CR4IxJNq1RO2aBQc8OHik3RCw9BKOWrYXZ0Zrr1JQOB9e2oGNvebmUhIZVG/MtD29R4+e308vch/NC+wGZ2RnQ4M5OjxrMNqwgPzOri5Gt0jTGYHfisIQLHwqVzAqu6JWlHpVEPVdIz2USIdSnp8+GuOTWdspGJx/zZHJnFZ5BvswSF7Zi6RuazPGVUWTdhidSdjp3RtMKxr+O2fTAqRULxmy0CSjxW0Zqd2uRyoPz6uA4p4TL94ly2fULbHurHLLKWxIpYaFEMZnCHZju+/Vh8T9Pcmc3oowXyanmrS8HFsPeAExvpYW2QsHTa4bjrxIWj5VP/4TYu45CsaFKy9VnRdcVer3Nt6r2wsgTQtR3PctisE2gbnpj+57N8Zy8QvH22E01ZKKINw/3E9I6YZGUmh47qlveLdHDOAOIASoElKYvXbuY8zBp1PIbsU7YR8bsO/epeFFd3euEq98CGf06PdN14EC4IqN8aNqf7h76kTYQby8Xrk8w93V+qw3b29ZO7MUz/1U6PEGDHwicdu0DV0oEbNfcev/HcwK93xhJSUaI1PkLqDEBc/nYxywOEIOfp6EYwepL5zHsko5iXZlmVFUWWOgpf19RoYyl0rejVFqPABHMu7hbyW1drhD8pZmyHy7iLWrK+kL/YWYliQP170UZlB9cpHJstthGMhNDjaZ70o2o/dx6kb63z32Nst//yBYwg1YTQP+4w/s2cijra1sLV00m0eeHi1zvM0nvfBFl1G+88eZYGnCiLAhFLPYDQinVVqcUs/f1F+g0kIEKPaVY+RJbH+/YfcGGP3TNZkpLwGjSL/WmFOKlh431stnDe40fMRK5AGYvnkWJ+JDZ3yIGE/+Nktr4uI4yYjUUHN2pGdTMx6/wTPe32YoXwqrCeJXvIiTza9DeTEyfr3zwE9ssCBB07sUJQlUSE786J+HQ829vp6Zirxq+tvzvvK9G+P6uQsMWHtrI/GLPPjLJ9X1DdRvlL5Gqj4EthJSRJ1dJx09tlBPbAa3tdYZDBVTDVGW1SaDjA1yzJM14+XI0423mGvElkHMnmrs1cIUu1SSSjKwmmjjCoHQMtNnWMZf2jUABDT7vLAtnRyG+qj0MLN+bdoEIdGgpdmBUtZosbR4VTNyYbiZx78Z+c7h9KTaT4EbVowaE+GCrea8xUWdIRJKsvl52e/UySSkNpecCnxHmay0gzXgoIJXuUgyIDW4NnEdpr+pvhZiaLuVUO1Ow0accvRyTVEElq3PRET7N3f2SPxqweRSCn0giopiXbTFkoownRzAzSkIboqQu988mAEFiqjNBmGrRYEsfFIDIYr2644Azh4wWl7Jq6RiyWB1y3NxcGV+X460++bDlbaox2ZBfbEo+TQU0VEuZ94uwbH4EgJtHQ9bWlkFtvde6RRWtnGz69HVX+z18rsE++RZVSUHJ+EY+f6AmOU6jdrQHixKCU8pGb58kaSeXdxOv9fPsXrNyJBkmNu82e1h8fG+PuG2htA9viIdqTClRGeTWF36oyBpksirxZq/nD3T+zsPkdx7id99vtkEShXYccfDbWSDtpu4LnZ3+kb8ld/+PHpD8cIYq9BDz9oJQ6PnsuvA0wiuNnBAHggUygqSTQFKypVMlaPx4/3Z+JRw20MVjVYnwD1v6fEKVI6ahlUz6ms3IW4Ykxao36oknnU2uPZbp/ibQVW8pGJSPwakH8XkooxETQ8Fhh+q3Mhv80PLytpe77gc7aoeMuH2YPOjVkaGnixNT2XGxBXFEmRQGTEkFe6KUABMoTi7N1Vz3HM/W48wpBUmnNq2Fu8tJfZn3wkQg1/dB1N06mZsaAyFFC8BeRYwBkGN5fmarTvBy0jF/8npFTQkfqll6oJ3MgjScJdfi/w2AhtfLsADXyBZrgVKbquFxGStUzAUGahi9xAVwRAI3f9muM489L+N2QZplLwbGOT8D6/4n7f/mnU5We/jQLU7IyTVQooqIKolaw6Jexn+u8sIEBBpna/QK3s/KHo83rVDL/kISVrX0Heotbz9BkNpkmOfzurfBBvFQNAHJBxn0hhL7GUl6bAVGfuOE1iiiT8ijtuDweNEzRD5KSxjbIGec2jIlMLSVGrhiwkuHSoE4QJuYiKksZxjIjoKeoRqmTX/8sVJTf7kDuH96eqFevVu0trM/Njo6Od2+i4W5BHZchY2ZiTpQyswiZVIJO19jm54mh0/+OLZjoaQ735ZWOOWCGO8m/NEJA1tsGnXNOlNQfzPGJEvSr/RlRDJLlW4znP7xRyOHtx9H5IvprpzX//UDX0EqXXS9kLHgr0nvtay7l3JG2Qnz5QLaXSKYqlo4/AJs5b1e+cuez0m0wIolWRSv1RfOJgtmR2eufD7OaVZCW96A1xoFRJDZaOeIWqFEeaCmb3VPLU+fx5G7wDgLKJysr5kqdBFa7NJdZPM41AJNEFt7Vy+TAQQ/wCovtZD86dDPtIzSRofhLJVltSUGwnYIl8SAwfNht1g92riXlXpNPFwYEiOA2++XbP5aNPjT4wer3jotD53Vv5ODZ6l+M+JAKjtfnc6ZauG02MvwAcFSsDfNwlJPdlmmx+56Vh+hyRcuGm8yPF7uv+J8Tc3L+GM/cuDGAj7luHckwSYpc6lHQ6J3V/I0mutnqOdEWlj7etGpVSNtrw3NxDAJ758kR8cmVZE9qpj0QF3n9FBgY63L7MwdZM9vRkl0HMPntQm35PMqqJ95dnEGLLrqw052Njune2INbVMlW7H+bg08rbbdno52Ef/Hqv3632MGu6LuV3fO6aqP2ZpwwEjtmYhGBXqtkgx13+6C0Gj8UMhfnGCegfyLSRapF4l+WPMJXMbDObHSN8FoVoHaO08HCou2x+DEz0nNBtxKc6D9iT2fcHH+j+AmsUHephdG8rlPz/CTTw/+9Pz7KYniXAyGhTBbKFLb4QGxOdnS0WMnFkH+UKPfc7uxWl9AQFLk4a8m3UBGGKgnlZvmSltoiDHh5/NooPRcPa7TjOdhGw4K8TscaO2Yj7+xn54ZfEbWrI0y5Q+S9s8mOj9K1TVf9GmoLUOA4rm8kMH0hkeIoU7+bdoJF8yy70mdrAOlf86yUXdHXFI6x1w9/HGCIbNpzZzHuMGJf1n2jVb53tgPi/xTTHQS0poBsEjL8jJfN2hJRXFBQcx4e2YfN6DjMUROORaayNCH6/O7CGdUoaBSQyH74RVox3Cob/c6h7X2UeB7hTsJEg3IA++Bq5dtRz/Eun6ND6XxIK3pPpsRlaHfUbze74+KRVszbQzkmjO9hdTuarfT7k1qUhbiqWVemWzqhYpFLWEtfcLdw39hThNRZZzRv3T5wmuhTluPypFeOG6XjeA3gxuN97HvnaSRfRbp4B1efZ4obsBt78V87XpTH0+th2UJqVKHKm96LyWmiWbLK5mQqigXu+bLqsJpXAptPhnmiD4rINyIlHWcJhHKl4r6slh8VGnJUBruXVAXlVfB/v0iX5fLWOudBpSqTUad7pypowx5TT6ah/Uke914ShxMfaQGGxxXP/18uKIQWEmOoyaSRx7V30jhOWqhAPpkW4yWSkVmW4uHabCSZCJGZ+MF9iK1OwHPtRqADLP8vO8cdn2g/DuyOw6ppw9C1NTAQyICvQLkKG4OTBPVtACwVdQd/QmX/zpaY9k2oO3IkByl3FjP7v/OnVESHHyWd+f948awGS3Ms0O/rKYWicNdoNndmNhywpSoM6E8dzGeOfPgIXIgDSMwNzysep4qVl+muDxyKhsFUzjLTanNTXtvbUgI3EG9dzQOWYCiWuuP/puwj3yqf8xk8AuuOEVkAm8PnxVICxFHPc68I6WTXs+fY2EJoVvdW7qpE7Atw+Pr0ZOoZLqaAClCbp50dB3pFOValShlJnZqSJDOIlnQUnkEwNVXzCD3ZWBF4pbKJcGDzTlGWRpxDCHxPf/9EdR6K2XA22HSBqkvHZIP60foWCFLuOsvArTfvlQCn7mmrdn1wzBcwyR5K/hyey7awcgZX0PG9zLftbOlEWfIl6pnOiSMnTjTXumr+t6ZbvWarVbCPr4ptTpFDOCDpdoZdWuc7JUJX2B5IFYuXlLTZfZ9E9ZCvD3hCYdkCmCAuCErTbue+aGnkSLXZQA1WcAdUxfy0OlxEI6hrDaVZZmB8k5mWNUYREnoQDuf1zEc+uqjrBJs5ayDoETB9H0/O9Kmiv8Vy5G3aFSY0j4+iPVPfNacCgWEpZePnv/JLYvhDc7LbXgZ7i8Ii/8Mxdf0l4S0m/G7ixvzyCQjIkBatRUTUqr26fXJot0ix3BrQb902TuW6JjQuLwj7FOcvM2DdeKJnKSRHGrWyYWuQF4koeHPVZd6Z5fotHNfBioWdDP8hntG1bquxWfQYJBjiJq04sIPJjWeV1TtDh+ioFVdfkkLxMaQHDUpbJVEidK3ixb0aN+5RUwuCGxcoFGEqMeAXCcb40wHFIcB4FSYXXe4KZYNRz/ah5sLcTm5mSPzTSZRe3novVitTm5J9GV7n+ULYiY43ubFsIB4ZUAskAaz55VsPnzrUfRIqBnVY0lY6cx2ZrRqk21cdqNoB5tyEx4Agy1e3hzf8Z4hSck0IGr7aKzZDGa+gMWWkNraMVtGrs90qxEOdWqrbzeqYeyzMjisdDHh1N8Vh+Or1K2gq6kpTdpDczyVPtEJ2/AH4bD9UZtbA18mCkfw4RlpSOukXYfLw073ZO+gh8R1WOxUClTGpLD/NNVDjgmBpTNNxDPD3mmte0nubBm+fjDY0Xghq9VtI7Dn1saVwXPpn+X++N7dbPhjgajgNpKCufEVNXjB4sGXv6qoG2vqD33NKbgVV3Cwg1+QYyPxsBcki8NuTeI6OnKtO43pCvhHnYnH6psv38BZC8PPFMhWGpVyb4lQiTC9zt8i6MXKEA9pclUngERAY2qgFdYkFgMXMjk5RB0N8jZ5sdyDKZ4HvdhuyypTNtj1k7yMcSJSnDnxKfwFZFgbjaUSliG8YEvE/HK4WbjwSeKudAZ62M93weCdTJoCLGY812VaGSDY++luAwbQ2W0+udodDIt7mObI+tFeyRAZNHFSsBIPRF84SwDZItDJ1reHFqLzKiNzIlMm/gSuG055YfbtvAMVBOo+Q/MTWIhTKQB4E6dUompQfzdVRwp+0G2/7MidxGC2pk733p5EsQAJH48nl3zHy9EvVxr0GV0TOyFFJD+qwiQSm/xMJlycKEbaNBDF4B3b7OJHoty0YYJWRbGhnYmy8LpcyCAC+zlYCBLyQS94hjS0fHgXhHcwR0LEEjhSXTgg2CaahiRgSHqq3MwpIwkIOinjIqVwwHGg84FuOJBVsPoXuIh6xMxIGctUEySTHHLaysjVuqau4mEKvlz2yvKlN22ia6aeLZ7tEHJekIPdcs5AVDa1xp9pbIGTSIo/kBiqQUstFcWkAzaN4AnPn/iaWiYS5X/vQ6+syZPTUJ7rUO6FNFW6PU1Q2Dzdk7fTaCqA/n6Fz5GZP8zB8BX/Q79bERWAq4VOmIPzEz4noyCQMB8gIdPYZtSdEYKOWuwVl8JGCWgdwHkNXs258hquttpfyB3QHMtnRd02DHV9AWLZnK8/y4zzRZOJLk42aM/CtRqyPa8genvFO9DoDW0qiGm3OnoPli7qW563MXcl9875fmHsz1cmfVDHbdjk1IYD5KUk6IM4HjZAZF8JYzxLan0vO743uWJ75efRW/QKCIx2VpGhRDUEZ8R58j5erpyRpkCZo6zYzA0kuScwFw61w80BWzrieay0OzU9ska73VeGwLf31eLhRmOa4qywRap/FIIzwzn3nlc8tcRCRkdqqMikiC1y82ipFUoPlYbNBZp6EoMnXwQk+7yWmgnv5KyQJRf5QaZ3S+5+3p/2b8VtzA05BVGagLK8YU0zb0fg+tQy88L2ZZ02u+/6ttuDMRMSnmgujInhr8VtYZpX/7DobYaAay4bJ8R/SbtuNPAvn016cRdV3FHVVOTb0WwK4Cq08Jkla98HZiKVeelTsyA/KYXa/dfhIC6fXueslabPicxRYuGoViUUjrGgNRrx0KyXhAKdWtRlafUobWgTTAdsN6iqYpj8s2+xTV20Nr8vH0q9HziNWkWQ6nNJVg4CLUiu3uJct37w6E7IXlwqxcHS833W/wrCjHx07u5Qoz86CwLKcuy1Jz2wgpegyus0YrvTXfESWgap6TMZfp6dxYlre4waele0wS2/lyue1NMjIPMs+LFTpK6ZRDcRRPG2lHTHqmkSY1HTpQb7XjjIItKsQBarq9FZv2nx8la09dlqQS84TiavieJQJBbHaTrkQxqooiiYBzLlcAoK3Uy6MqSUSQGLdg07rqU4UzeMCaPAo8OlccUjzQ1bxgdYYgSBRwEXJB9O6xKaiwdIdWNROtrSWpRcDtZ3IeEBK32yQOYR/j/QKN2IpTFnx2uA0ecTD6S9BuO6r+D9GNZHnSousvvoSjCWL0D7CztftqGl53gOikCSf32frbU2xnSzo+tmrznPN4puqUue7H421diJn9MTajhQIxeJ8JVJQR6QSo4M3dYs0cpIKFmXY2lgOuHS7EGkNNIS+j3o8ywBSFklHNGl9Z1ViBS6rr3v0QBxRhbBp8QZR6SywMBiP+kEM4+a5Goi61TDAQD571tKI8iLkHj+BbdPLE7FACo3B1iUZ0R3KDRiUY7i8+UwuqrECTWidLBLMCYNFGkaxLiIuNaw35ov4gr0rXgiRABAw0EkJsYE9KDGyKxt2upm+TUBXRmoXZAyzsoDo2FCM9doeGwNjjyipFBV43WU5h/WqYBRVM1B1POyvxKPEbsKiTZfSrfWlLqNmybzZkTL4/5HJNBBnJaB7s7vm9dM1EBz4Hvp5qbEZMZVCWxacQIMO/q+UHfCRBeDePXtDOFT04BDySkW6LkPGtz4UFqzCCrvuTiyrv166m/JLk2qZWVolagMPcczVw0Me41JUE0IRyaYHQQkHwoEOxrOEBrVCV8ce4MVYGmI5kdMdQ9ePMOgh4LaynWDFjZ1E+hmj810LruZhBTAZIKiDglzeNckFhhtw+IQsplmnFwKzb+kq7GHZQ0UhKvNIwlWo4qvX6hIrFjOfuvF+3SAawxZMwSrxWVBY6xpgTbxpQqULJFAwd6dQVfM4SqBsS/Q8IxiDbv3G+RejfmjAHRYqBgDqIUc03dJTSaBWtp8W0auD7RyIS4SGGJzkFFvb6IoASSCJmSUTQZNgl12WOIul8GyE6wYJ5dFcUsMaDfBq1KjgL5qqtsinyVx7SrzG80BK6IslIpobme8LjnIW1Oi2AipVa5jvZXtBy2z9+ztBekLi1vlmmoTZPZtn5THYxWAoPWjYGSZ8hbz3J7faN4CN/vQMgM8DRGIq+u5L4wRiQj7XYXOoRMFCe/JVFBxLbh9+/AXhTgdBM7gE/Lg19L2vHv7KUmkDrsfMP7FEIUaRqaWVA5Xym72TYpSLC86pEAoykgN6AhMeOCt30U0PsWzvhP5XvlMh0UHee64xEjPmbQZ2ZHIUyZvi7ZMc2yXYY25RK8f2r2PGQDinMbJMxSyo+IRsvxZ/U3bbO5Gi505xmwSRujeEtI1qrggIsWge2JWPjJtCg+ZlUJPxOy/Q4VapLJI002MNcEiRrR3igzpvYxHfh1iyWmFAIi0EorWtUBMvEUtVapuGzNiimkgLiYu9vQN48XWb5tcLA/sbk6MuLr4hjcvmGC+82vsI90Tp3FgUanLpp+9Oy3eNYV0Upx75vx1qq6RNiJVDfo7SPoI5QHeUA9+cCnqNyoqoCATE7GfA12c8RYwLHURZGWf5WCJkCHX1AcyPJr2G9PsKwz5WOHyBzhHCgacThJeN8cPCkPSqslLCxjUAtfcVfK9HNQVcl8jUpE0ODSmW2pEGDW6ThgWbZDsdBm7RC6HFKMKI0eHLFJLjzZ5zTEq8c/ffXZLjV8c7Q5bVVH4hYFV6y24tMUSD6sIQLkGAJS+hhKYB7fLWhSALg/655On0RnwJoNirUg8wPVxxkaRvx7w/nM/FM6oT8hN/OP4fQR9cnTOI5BOQpUvhDjl8bbBxc1fL9ZL4UKWgFXQqOW35nd9C90A0qnKGKJ+ii1d6q9OEmeZ28vKmRcaReKxqVsB8+FteUP2wszQ7sXv2nTt9uW8fn99ewWc094ReAp7rpnfftAPsvLFblF5TsZYE8e+AlzvVgpRFQx0yARJiMd6XDR8XLtJ3s6kuTTy+5mC1a1FmNtgGx51PBZO+4VLdXyTnzbwgM6CDBgAEKfaqSGcBdwXdS90ykbO3kYmA5aPlL+9za65Y9iyZfei5w6Ju+Bf7rs6tLNcgkcwrvZqgghlWoRVMXQ3zc5ugP7zuffxPoONKvOQBYf2xuGgKTSe4eBGoBjAHwZ72GIgXu3YfiRQ6IfmQHNJZ2KPV+1PQ9lrTp4GLuUiQIXr98/Xdibn5tzDNPXFbPDx7dKAMuTwSb1tc58MPPjXjGa1tcHfg0uQ3bHcQMqLm5zmWyhhxlNOwtm3HSX/EZiGMPiAfpc41hIPd32smeC+ToR1hv1zR0htyG+o3GGGD4s9QdWNHhSQB3UD84VX+uPPzcq2CoLp8k+77ZBi4c2EkxVrxj/7/3YD9TP715YxkGzRGo4k5yO1f3Aat41qRX4iYQL3R4o46YtqSMhuU9iC/DFyIQX4hn8Aye7oCeeqmpVxXPazJCcxsnKjgMHl548tVWCk825xlWC5cXwU2+B+uVuUf0zt6FBJKbdN++aGqzccRvHzr0QxdtM+NmVbZcvIsOB/SxvFoTCwPZro9m4VJrY87Uak1HYJ4ogjunnn83oujNUB2MqL20m2uK9aZQj5RI3hEtR1F+zrZPWpqz43U6nqBxq/MZbEcr4rjYXvfHo+DnCW09cQzrSojQ0o1Npb6Rq9+WgNU16EFp4ao0R89dSGNAySEoyJ6Xxw0hAGcYl8RW+JS5KSOAEBW9gUnHnro1P60RMoW1VJ4mDTqjpeUl6cqKm3EESv/cPxXh1oxr6Ba20flm6tUIEwwwi0HxOgrWsaf2kZFX3BrM/HDv3/yURByctG4+scSuXV7dy3vOVrU5bl9fIEmu0Rcf25gcGsFsj588NkkCj8ceM9l6hpVKl8N1Bhp3X3mGrhzTX86cA8eXW+ZegWIG7Zx/Xj9nkKZFXWuj9ToULWKVK/VoTa3sp2cXHJ+0bW7LgC9Wyk8zH9jTsGDMpfZXGDBKsC3NR4r4yQsVGVn06d8sPOWZBJ/Pyle5lOAMs844FQiOHnz9/9qHR/MRaP6OT7+2jzHsJ2TAmCgDxoZnDMswuDDUhTHeIQdKIaSpwv/K2f1rRzv1SH+4ef/g8JaxB5Tqo7mm9KjGePOJr0LO9vPmIRfyL9Enx4QnFM8bN1G8ib9xMtDB+EMfizAc1+eUZ9u311yUyfl/pW8St2PxuNhTrrC/dfVikPcpM+S0eFjWgYcuoRa8j0NuMDgRAQ9OCK77zEg40PKL90/zSglV86NBTW9OfNsmEEicnI4yLeDHRgnIcx0KaPgm0NxBlaoo5opWVrq+fde+er1B3eH3tJ8XWZWLoz/KOtupN+NYKSl+xBlBjx4HXNyA1MrXTcLcIOQ8j9hpPN7E+zvZQLhFPlXOakyrtBb4AyjbDBhzg7xlOlMTnahwdNgVxTkHqOxn+k++Lk8q1iB3+Z9HL4KPdx1vpNyQyqRgfH6meFqUdp4ckMDqkTq4VsCEXXtnJdizQwmpQq8Qz5IRmcsqChL4vJwqxpxBiC6NdBU80OEBspkT7t+NfVDjN6VP0FGUnzb+Er0IrH3Z6/GJUiceHL0Zgjw/gSTcq3sXFnMPCp2LhjxeyPnv3V3n4ksdCuO2AlbqXdR/R6vT+pZ3czSEuKg/ftEi7NH35OpCaJu96LRdmSxL3QADAqGMsCA1mVKkx22z0CvVqf45ofRXxSB9qrwA3nEF4lEu4Gd8HO22mmD9sG499Ze4e/2BvVqDnQqlm1iGzbTWQqjbmcok5DVFsi2CEbjuA1D2LleNw0Fr2G/CloHDsImkhGRTjRj0RiczGA/JdTrjHY3h1TEspUBksrlSObtrEqkUEkjI5wswX/+h0kBnE0p3TTVdf1ANw9s+F8+V5eNWG+HMOCI99XZo2rc8Oxr3PAEm5BujQbfZOD5mI+PQjrmsKoo6i1JkWZmWJ8TB/v5Rqz9+ieM6NjgSXzd5Z4RTEgId9ns9tar4YeB7W0MPoY0ROcy7EbX07K6ALyAYc21Yi3Zw3fXxeDTsdVpIZQwZhiYxxxptwoFs2uLOBiVJAkffndram3ciOoO7+hVq61z7XectOJuotMeSN9GCeRhFKuqqtsSe25uitDibDFi2lila4Kzdh4xZ9oyphbtdq+QyI37rLlUl0liwIKh73Jqeavh8Xrczl04lU7lKJIFGrumFUqlEJOQFvZpimvP5Q3+e51C/B5RhlwGoaqtox09LYtibbpQoyUmN7nNl+1wWRwRmcgLfI7Bxv9vpsO6inKtaznFmSYty1rorByVx0mi0Bih5v6zIkvFausM4ySuanypxDE3bU2dhfPuPJD+EWze9i3vw5mJIYgKH6NBjOYUMWhwvSLKqCeWcCsF5ae4yNuDOdSM1Yima4fhuY4XtsmFEfTP177FbFVgS0Zn6/kvXWyvMhHYJQ2zVL1u3SktEhXIxw0uKquthj22RvudJFaEZsBCRMjOUjpxiX/+/jXLdtR3X86X/mzyI6jGwHyiUslCGyZ0leKJpIoVoTCgOdV/bGwCveNmMUuteK0qKZsTAVPPW9UJ+KBBfOpoWttHUZPFjy047/yIpSKLpuirxDMtywtIfThSTg2XVDvQQbpTh86vO+mKoBdmKsqHHcukq2PJdZabgcJKn/M5Y3M9ECnW/PRZNF4qpYKyVzKRFTRE4ka6b6G8pxl4OhoIe21GFDASooui+hpetA/fWE+nSVXf+dLGCU8KaOpKIx2IJwhxfaKIZy1UFfjXNsEwarRQNk5H5sMeaCXHJajTqsaWLtcADT1ZTM6TAqkZBkVWj4e/pFAlcCv6AhLuFOufG3zSQ1U+pSjXyan58dHQclhwNY/FwrCyeaz7L+v06zrgfx1R1Ox0OuwP10jQVGnhwdxSCokG/N7YPo2u2y5uDVeK+bgyBbwJBUNTSCQxN1xRJfAiNBr3Ftx9fCsmSi7/RMZT5ZhUgTt6+/uQtvHyPYfmNdGkSlzyZ8HJW5BiKJHA06rFGw4W7868sXGliRlR0tEJhBmPTXr8nF/WYY0mEosJTdf6lF2NHxV78LaJDjT3iZvmcphPTailsRDEETOViMByoFTMTBHrbirEqGDuWAVRF5ol+446/2Wsm5oRmZcMJoqgep8PpJtgCMEZlFIy0GxrOu2lkMLDpQgOrPc9uAfl1o0MbaWHfX4/baa/fN5B4JYqyoqiq8rMYoIH3HZx6S+PxMG1Gr3IsxwtPjMMuTxq+I/HCRrPVEssTmqRoZmvoIbQ6EEfDsri49GwHoYyEO8WoisJxBmPXBLIsKVqKjJq64JSyFNyKSsjtXhR4UdFdP4rEUIsU0nI5xyTJa1406/wklQJeIXA8l+JS05141jOlVZiSZCGntWluqiaKtTKDdbodlKYEPQgeEFqSSxM4JQPjyqjc2Rd8Tw0H/SFK8gLPUdiYOwm6BwCG9roZpBMGZ3vT8eMUMp3yPIuQxriTCLW0FvSB5xhAVhR/QkKwwJLGuogkiWmF4xxhWI57Ro8ougoq0cH4MHVBktbSVQBCPkoIksDnQA/hFniGgnG7GI7DwGg1+Fi+cYQeFIR6E5o+mdqNqNdvu7pZT7vtOO6tmA2RYCBEhCDXsunTk4GnC7yg+aM2m6Q7zL5zeWOzM+1VmoTb0JWPsWKz6M3wjaR7812pHWyhS3fz3EBb31PZxNANP7+HWstQC6dmFKTd2FJUv5U0wpDpLA91Di1XATCGG0zMOFDIAMCmtub09BsgG3B5SihtDLHUjvZXiHEWoJkrdjehcSC9zkSe5zjdnxBuyw3wyQX2wl/5eyUQOE4wvHReHaaMN2jDxFlRAap5RG9O4qTAOOvCiHgIjcfAiffX6MWlZ36ybWguxNymtuq+aquiLjAOrASKKLEiSJGq8NoY4mapz+K5knhmZfUqyr0aUjdctwph3zpYcGBsovqwm4APQKuzMoER3bSak+yvg2EZt9L2jcTV9P5MAHu6jvB6Qbu+dtNSdnPIeirMtx+bnmFRfwzX8KbRQhp6druT4DALi5EfNuq+omv9oUW+P/33mzPwUrTj7OkXMe3JbyBtNDm3J878CdCrDOsqcuG8CKBxv9pnfr440VWAL5yAYGphL1G15mwgnx6Qd5bPo52uSoPMsAEIXV8OelsLdWO/CRbUTiaeV+NvR6h/2BlHUnzVzMhtqHfS9eKIxvGCkQHL9U41GBu3H5+0oXs4Aawj4qFQZUxp6742CPXZGsqNcnAPTszVV2kEtitD0R6ZOx09wDq5+ECvARdxLAvuCdjRDmoVVyJs/3uurVQtlINN52rhwFjFRwhM9ipqQHatJbHnORO9g+7jZDJKGDHookYyi4L6/XWdLQMUnpr1LHGjeW0ekWmNaacCuhrfnuXsvDsblNB/fIPGcjrxkoNqbDBgTj47chhkkl+4zdujijnptZRMv0e/R79Dv3fqxZbID390K8l2dm1nlj3GHklgekexOB8Ox62G0qH8YpUmxp1jtHav1emdtBnJtLAMTGX5P1vQ/8RACSYAUPpv+3v+JBlaCQ4/sNkgvwRLwmv8Ft5oMr93PQTO3UNhbDSpHwDXOGtU1zki+q/MP0aJeElZzagQicRDeipNQa2cBO78WQ4BguZz86C9vdt19DL3+X05EOCXOVcazz/o2kCtW6YVfvHOOBcNhCMzOWT2TuWeaEQz5Q2R6nPNZvARM6hQg/hVTxQ196/vvBhXUfnsGdbk1IJ3r06u4tz9mzqF0epdNIC/EuqhGQNnmiVpEBRFkhSvSkkyFRyvhkoad9LwTkVc/GNgtP3QZ9iL08RDog1yIIm0aQ8gh7aDr7BA1E7wDySx8AJ4NR7HzAsNcIQTCTx1k3JW2kV5XFYwRdgd19cwREflKUwwpJ4QvwlGH3AiMTfZCv3niNeKtoba+1durddwSV+idPO3Ty6/zEEfAnTqOBfxv5Z5/bAXjqWG44tVD/KuO3Fg8tpRxKqz4VbWOwstc33b40jX1NxcR85g1utTHUlhEEb7LhKzEzxyjAp9vPuJoeLYuj94MQstBu1BIa0VHrS4G8byvgYDYNMKAsLBvrfp2xzKvNMMMS8Zv7UQQbbCEhLrrZMmc5OqPlDENy+MbCfKzYUeVqCqyM9ND4ZrqsA0NLVMA5xiBlxwTJpmpiO+YwRTDR3sgmnNuQecdiANlz3wF0RluOwR5grY+FECA9REibOH1CtNFrpccQTzlMTY7Lv00NsFwQgzhs1jrIKYDQUVWDB0F5uIBmE+LFfaGmANkweiZKDQUhC/lqoooy/QSMbaki0ehO0KzX0FXdA40gETz0Kx4f7neNBPlACjnCqJqDfy/c0mDAK0ibFVpRBmmC2JOe1Ut8xCwSj+9ERzVGEKpbC3Krw9KZRCY/XPEWskIjOBZ2uZE9nFUQwj0nyWo9JpIhWLAPe/zOLToNao+UBViAJ78j9fG1kZzp/IZKXwHmvkvgtt6ZbCtojpqrEwPlarnruQPxCwLkhOirKXQ+cyw0KugQlhLLJAF4eaqyJ2y4JGJQGGMAv/D2s1JHO4jVhEtxsNEQKvI1oVGkHCFBblQEOjNKaYQIjV7wWUGpbC4BAIHDxbOrhKygIJ3JjWmdyYiISCiNox9rUz75N/11Phj0VLuFyRjN01ytSIIzzFG90MV4QN4OIQjOy2ZPh1HsuRBaKCfqYe2ePdjJhyZQp45OIvGc3UpA65YABnhFD0XRm0wrWdKDU2C6QMcGNGcRcMTfbtqMeVfS2FLBw8f/KK2eQZ19aT4zMvp62jcKPYBEIwgF7Q1vHCyAijtLEg+DbPABhQJtEeozquKfaEppbnWAIIV1sR9ppGuqqwtBOHyFeMhMmZGEOiWq6cIyRh1gC6uJS2fWcqPI+ouWEWivdciZ2BFq4I+8m94mb968c6BT1Ln0sBb31mNpeeiTqvDkkCmM0vh/LlZ1dT+drh8f6NjXisUvNUbOSmxXxmK3mkaLalJjPFZDXnfgC/+fAQE0581wjf/yzU7J+N0c7fn+JhYLZW7Jy9FAHBvVP2yM3o0fJGpIkvju6FFhiH9pHSjjKnJrvQeaJSiGlGkzja8iDQaRpYImaaHO87WxllgdmjHac8jgW07Kh0BoSbmtwWcquMXGT9hlkQLewqRSPhBhJMjXQ/vs+QXpvKbQM7h1pDpJ5G1+TINA1NMnqaaf0pAF7GFk7gDWqHMZJDsVWjRZSV23MEZ5lTVd/lR52EZk5tagcEvlo5KYADrWJHdOaEGyArpWJ0l6kxU3Ug26hy7ggMDF/2ctnEAV4rnJURCkHADWzDQO7m5SFyWafBJfA8c9QS9OqzU0nN7yPfppW+M6MoiqOVtPn/h6lPchNCNaqVqYHfhoKIafHJ1jXSOU9fqgvXjy2qx5zhWOX1yrVXRkQs8eI6oGCkTTb36dzFM0HbYIFt3/TaNu+7b3TVu/tSG6h14Ie0ICB6bZUDueV5K4q2rOVL5YyZeDecHlaPcrsq0KjSlYfHp1lbgVIDRgl0arzu91d2wUdu84T3uBSIE8v4dJ3GMyQS8zuCnsT5aaeGaLiWyqJKOQ/wNUfhUSnZQNTxYjnb6m6KIfjIaImvY3GMVhqhBLCnY+X+Lr2LYNFiE6HAh+QshIqJgxEf3CWZ6GSmUNtRisOSar2h1RhESn+yMDgdDZGHGhKp8QRQ/zcNjPBGUc2pmq1x3ygOJWM8M2v/yW0us6O29X4txQ2L+MP8sKFzuahmnVgloRVoiwXXqxiYZ4i0lMsN8eRx5E3ccLZqLi4YMyLjaKGqB42wuZEaY8AqriQHjJstYiSTdO2Jyxyao6U2y8l6eVBATYMjutQZieH94kya4ZVHnAJLYUEd8wmor6aqdWN4Cjow+q6eDQSjuK5KBcNSK2OE74SJ5plzVdljHVZCACIiMTMOLJ9JxjyWMT0mTEdSGbFvtqZg5/OzOXTe0QWXrNj/64uWilX78PReerMDsrWKEw30LQGofiR29fXHTK+Ue7M8bnJ6p4G3XtyE01PzFzsQkNQ18D0rYfChhkbqRU2640tCJkISB85s1W07vs0uoAuYSJCP4EMS8yczs3yxG5Y8J9c0BeKBhkaMGzHd3jfzwGsMkC3b+3rbqXTYzKihplvVfXgtaCvRNSkjeRq1eIlIu+Npjk5GC2WPJVEhKqQpAoWfbafmkMAhZtRnaSei1Vnt6lFDGRQLPpNRpyedkEiLcrkiAGKSt6HdbdUdnuMYwUjXNmXB4L5GMeZDTe4vY/EUxRulcnWi4UHB4NF9myeUqcZIJklG8iUa6UlPetK7c0/yvrtugw0PTt9Onyn24hr4a/TfcEmvC5KtOELtpZOsOw7/bO0Ae/sf7s9HtgLsl0WGUDLVKneg0p3N4hDAH2nHNpZIPtLETq4or9RGctoVgg9tZZ67iMQsheqDSiGUATpK7iX1QWU75srTVLVTd09NSThp91etvRj77CO8IhVNnsV/nQ93lP7tnUz4oiDbmTvDZVxoI0HlcDT7tF/hmDpgYufjIUrPVpLKnynLRB0fx0UWtLMtxwuLwi0K3xuww2ReIig2B/1UHS1TiNYOuszT+QDXYSLPngdr6IBGFMr94wPBg1IzNnu9hdQsjZgoVkU8CicJWchCFrLoSuNhi9VmN8IOf6tbvSlcDhiFfKXmqbapUAhAHAcePy4UiqhEjxB5nS/V6VqNWrfSOvlUwAntStzr9AUDbDDdZCZZeMUS9pgNCKKXjujJsGO7uArCCYyOLOpzCSt06hf/fBGGHujmE1xPQxVaOfc+ajbXLZE0y0myQFczaccG0neebTphMYfgiJDgVkuODoxSfz1V040NdNZO5Hcinrn74tEMgdwUprPm0Cd7tOVZDhvR5nQPBKbMk3gs4Z199IGK6Rt7uR7ysV5vQvk/PCnBbk00o6Q7czkSYQfabnis2zjcWUo1hFWaGpAuEhPftgjKx/hU/aVMQRc20nPjJflXOB92Q1QbugFU3UkEvioUJoywCoVD5Bk1gmSRKBOc7qqrOK/Pp4VO1JBuc0z+qEpkri5aVZSIEa1nDWhoX2u6TVLhBOPUsRAGcIzEyC1RiO4Hpf7vpK0LyIlOeOILnJ83XYB9uYYvLuA8zuFCzvzjRuWKYQo5Y5zcMKk0joxmq/Qj5UJvcuV+9iIteq+cChKuvhIRTOb/fhegLewcgGQmek8n9J4XoCEubbXJqcFmbPGL1Dzzl5adb31KF8xKF0Z55s5/reppxTjQrrQ3WRbicohRmwcxzdZowCUa92MgLmYRFfbvMHIyWwP9cCjDhGNdmuS0ZDuUDewjehMZogTGKxHoCAEHFrOBmDhIX6Yy6RHvubM+DkwX0cJITxrmi9lQzninkC80CTWvWcd7l5L9miy1eCU8ekWWFb4NS9nMHo3lgsBJnANgyQPEQ6oDLaIjNx67Pq/kesEIhpghDn2Kzgcbq835KOHzJWissFNRq5xWgJ/Nz+/r3f4GDrNQLBn3HVlkULdv47pLx8uSpF1p6JzzJLWOiwjvA2Xl0NPLYEulhSVH3oeyvfEhKHDR3ytsHSdiEgaaif6CEapqBzD+vc3lfsvgZYlVRcUKR2uoXEXddZKoSu3s8xGCWy+QTgBZvdrgC7HVOMHMDVvLmXmdcldh2YV48Ba7mCO+QDXl67kD65sxwyIcwYLYnqJi035oA58PbmsVuW8VmCKnvI2zyAgZIOx1vFJR+SyzXS6gSXHvJWsdK2hY6XHjuv+/rDkzwOQ5gvdtUyqjDZ5G2NEE82x5OXb6tb9C4w5OdZk9obWKrp3G5UuGCGCKfT+BMz9zr2sky3KE9FSGAHceOk5y8RhbbAuT+NxzJv2Yw+WBRYFzbRqRnR4TSHSGXSLosEqt/s7e89pw/6a6ynD/95bCMbNi28YFjEws8AgBCxpZoY8kyaZ8V8JG6XXGoGYzmiV5xky629KacrdD8UBvym6PloZn7E1tDjlflyw6Rvb7nHeWIiBbtZUvZUoWPtEvVXM9cjkDHOlPzNhLHKq3e6PxOUQn7UCCnYMiQ+KHA65YgCCBCs4G0HQDlj/S78KruhCc7U6k3+MAnNjWFFmUGEkLBCR3kDDONPXJnmKgbKr08rGoyXBeP4qsLjxjY5hnQsNebn9aiRzfpjRqR4JLQX+GohHCFELmC2BxnIkfzQZZken/1mjrJyd1NjjYHU27fYwLc7+Y0eFC+EK0fSgs9wWLh7M/XEjwkNcKU1bgzth1m8C6RwdUjroIsU4Vrh+8uWkf0z5Wdbvbq7M48nN6ufibp4VMsbbl2M27P/J4R064Vnzlknt+FGUR+LXXTh+VDcCxcTpmKc6KqiFUoEOUC6ppl0yVZ2HLyWymHLlShnGD0MC7IKipWNklyhSVhqNiJFcI60pmJwQ61yqqLyhOsrJokAGb6L01kl6UOAZhrQLbhcMao2zcGnMYXcHYrIyIaprR6oKSorZShaVT2T2ZlZysnEa1lYuCc15wGqvYQvbRaBH25i5RRedbFbYHeOI3RtTh2Y1YrwKh1HJzMnTWci0/BACbFtepPD1om/s52EGEgEFg6ySXrKC97FN+gtIsp0H0FgX67w3or6oyHKz9AtXtU+CVt8lJjuzvUUiODtUxvXfsvF+dYMeptqJXe+rs4ILcCY2Tk/1+hpvQTcXXG4KANMBFbiC/7W6HTujP7YdY1/xzN0P5s0XT1YRVYoS5YI7o46AbAC57e6I/Or5QnGjv2rf+z8LnWyG890eu+UCvwNcLPhgf4JFaMKnb9xRMOOT/PA6phj77guUEWuvEaqFDoFGmmm6IgKUOcwZhEC5k6Il1i/7hyGLYQJil2Ne4nDvhjXtQFMZpHqbzqUnTrdTHkQMTYPihA6+Wj1crNiRNK2BfRbxMZadBXGk+DdYabLmWgpgH9llmeBF83ilsthGzP9UgGIqpbhBj4ME4uJAsmlkpLfj2Hqzy2eqIxEuHLKAPCT5EKfu9myr7LgnPg3tq8NxzD0a7FP++kElGaLu7CqGrVcfoy6Dd6wBVFSQtFslZjdsFVEpv3tcLZMpBgfETV2qKRCGytuqLi/wzuEuSMG8Pq1tOcuXB8vG3PgtDMMYppSFIZkH4ADYQMAswFXgFr+Evl5nguPH29tOcfnjQyvz/4gIICXqAvPUnwWAmdkkek9l1r3D5gQCTeu7EwSZZbNPWBO08K3+eVTUxyyz0Ad5b/dwm+o6xhVlYkRGEZi/SnyuecWocUAF9m0Vd7Q+KavyayKhx1vFusQRXas3EF50ok52gAl7EeUWV38Ihhl3ohfXG5pzZQSNM5p8VnQ+q8bvYitoqwBay+S2KelZ0SW7i2WHzsq0PStLoKyxLVziagJHX/CG4qioeHiev3mDgoPmcXplXiN6MPbhj4qdd4m92FRLkoIo8/wtL4WgsP03ZsD2g+ntr0Ujofc5+fPyRiSCN6SPQfkBODLZsa1YeRI643xH3QzQv7reMzb5Ofzdn2/vpLMDPfPSNj6RRKQKRQyMshquCP7+OfHTd0W2ZPftHNVEtE+rwZfgot6sHbgHTgfJUwkMTEbuwEYyJQDlUNnB1XBPoTIJwJDgTEMMJlkkiRtvqHybwj07SIWYIGjT8UUC/DPCd++DQWmcDQ7+Aq/ByyNTdQyn4wH1vc/jMGSKQf1JTSP8u7oZ/fnUdUCAHCiGEoEwYTm0fiUPwI79QhCSCDU7qFY6vlulrGIMrEIXsxz9s6KAa7MtUTPzgvkHA5Mo6XJxPAOS4EMKaEKhqfTzwE9UKdBNIvfqXHxHNg/qzvhdfYKkuj/6uxsE9xgfqgRDhs+ZQ34Ie1SL/lem56V/h/4BnTBDwazj1xZSdTiC+eDXmqYWZgHqIXaZEpob6Z3QteAXuGgiYb06hhSFAThVlwVt6qmun750itDMEGM5QmA/rW2D1FJ5nOtRWbwk6YC6/5b/a+GGFhDfn4fAWbPn9f/9po5zrOL/mG4p3RvkAnbUV65ZP8K4j/5eK4zxNprHiaD9WqpifVgAEo8gCOge0cZ4Mkhal+IngHQOxdIQMR1k5ou7jgeCFh6IrjPu5IaAwPqgROAfFxRUfbP8FNBAj2k10AcBm14A6yoHqnkDq9rDVmWDZP/GI4yO24bCdAU87e6pgDvCY/Y7RzSTaRaBWny3zBzKpzrCCqLzLzTB12qJjipcGhYvDmsXpSIKsgdBSC9iFQrT7/P+hhhH1ZXbaJ7RfjltYAzYo4NonegAbwwN6m2/lXl7Mi/n2CV6ONxFJaqTkPxgvJI4wwjNkjpQhNdOxsRLCAv7PrUVot8AJHCBuP4PxNDPqExjuLzxlAXZo0QTZH4xudWBtK1/aZGXyZuSthHRlkfv0m6a+015IScTBAg5UVQqTKJSoHTs6+I6nkTG5ijFVHgFmGSTT7T0vu04DMvhRR6gPA7QpoxySvy63OE+BvJAckHmEZvNwqK23TkBdrpzkgtC/Fb1NLaFQHL/qAl8I1YdYww1d4ieGQXn6Jf59iy3z97uAiVDkJCXltwyreMQyTAvHMhHOgEEZtghUZSkhkSlKUfYwxPJdlkh+ztEpGQ3quU5It3w/UVwbcvRLk5iisuUZVJWESLdooVNHSIl1QoFuXakIUT/Z0rF8vq29+XrbmB+2XfNrZbiaJYOtr1Wg611QSpXH/xiDVarSpFqJIsVq4fHCY46oCFtBgRJaG5mjjlPeTakRGIcrlSqQ7CMh6haleK1Vm4b0LFLyQ/QGczGZl8wKke6Qr1SrktOlFNQjTaqkdGSA0mFQzLNSdIuUy3GHWZjx2FoHMomUZclsncoggFVqSUZxXbrMyOEL8aOZqiCFSInKnmJ8kNHhcvHx3Sked4Vbme6MkJpxqZWkPFgOz8SsNDOYNsm0DyarVLioTndx1NJCm2WashAsyVlCyNp2nYcs5lz1mehUkgulojMiUbmaJH/KaMzViiJX2gsYekqVycdLDrPwwWc0kxVH1V5FjKBqXbGIGlipBorSiTLVagkmRGvmotNz1JQkPt3sHYYXAAAA) format('woff2');
+}
+@font-face { font-family: 'Hanken Grotesk'; font-style: normal; font-weight: 400 700; font-display: swap; src: url(data:font/woff2;base64,d09GMgABAAAAAIcQABMAAAABJ3gAAIahAAMDVAAAAAAAAAAAAAAAAAAAAAAAAAAAGo5jG4GUMByBFj9IVkFSjXYGYD9TVEFUgTgAhhQvbBEICoGSaPsyMIHVXgE2AiQDlXwLiwAABCAFhg4HIAwHW/kUcQXd5iYPyijdiVyFr/dZEaxgujkeuW1QcoLP47o/G1G7HUih/A4w/v//PzdZjDHvHrp/QEBLdVVtgyxBDlEEHEU1yNGw9MIFPgIxhTXgdax9a7PSXaV06wF3K9RERfBNqIWcvGA/5tLatqK1tbXz6ku37reyJ3iWa147rlGELq9OIhc024XNK9qARNEG6nSMMtHFEnZ4ctvMS6YbD524eKtU8v/k7WKZnu+Z1yvF62nVPO+DyxuxcHRTWaI6V8TKEZ93wmmdEGQp8UsyRDL0sD/jiy/9Ci7Sn7shmRqCs1iWXu5wKojUfcmw3Erhf5bdIBIJ0hB5iqDMdaH5oTF5HYjVlEzJlFIPdDz54GClX7zRyDD+zNVAdn4RZjWdeomg2q8+MgsYmBVzfd/NT+Jy2v55fm5/7n3be9sY21syYMKoETkyR0uIUagIQxHzKxYWCCIDZMQssFC/wsdPWWBiYGEFP4yKWRuiOWtOsQpQIC6bzUZlJXFCEpKgFgIEk4rI9yrqUDGqcG69vtVO1X90q14SQoAZxhkxVsyp20/Y9XLr69blXCotarP+bvg8+yZ5ASv+jplPc0973T3xpBPBYeukYPiSodyqKsFCEqJKjAQLCdYy0DOr8jqxn32ewzLPzz0+qzJuLdB0N7QpgEFjaO7bDhDVHACwsNUDB2QcAKipsQtF7e4JE8MwwsZr/zdn1Ze+xAbZAayqNPDSAOB593ZvlYcuh3134CvTADfCVFNSkEoc2wIdzjpaxpix+vpSZD7b6itkVGBk7ZtKEN3LL8iVz6YXJBdkrmuwDNqNN21SLdUm2MwwqUulayf5fgsi2c6lADBM7ZqZ8YEoif1Akv1/Nq1+VXW3Wmh7AHfZCwzhXRRckI9Gfptll160SOdZGkBLMgibqgu6eFBn+cAFnDpsK/B0Y5mSZ4xZBkbJsUbY1IU0zJhz68SYMzFmhBkzZqQhzDvvxDvxpmHWe+c31d64WsO9N29moTohOcwLve1zVaG0MmVN1hDQOto0uMf9PmYuSQlOABAQY26GNI5EIkOtpPh4zWZtZrI4pgNyhMLMOJOkbQo0IkXwu4OttSgq1GlJwtGW3rTNll/J6tJ/kSXZ90tyJdDlbZ2GvVlSKOhwGOn2YFCMN3VD1/mJosCCHbCxCyxs6/vuBFa6yKrozQk9Q54xsyLyBa7h+s30clos5S6PA/KBF/6f369XO/us0LsndOcVbgBVAYUjWaEqXIR8mb7AzJkpvfAr0Q9SiYWrURU6BC51lWUfryqUqhGif2+q2e5HEONxAHHGJB0hjzEDOoU+pNDJ7uyiAf6+xcPux0f4wCItSVCAjgJAMYFUSHP8WFAHEdQNBEee7nIlXaNQuSMphxjbXDQptC4au+purrLdhVy5q12ULrre/2ezMq2vnXmn49adoY5r1vRl7IWXGzgDjuzMQViiUQ+6tpdaWuqBu6vVUUm7816tjmlMxL9bB3XcOyaZZcTIIQCGGCQOQsfZPUcQpKmDyP6/a582yZ0sTBb4LVKNWyFHVugKt+mdz68A7IgUUM6qyO+rHClZ7ev/v660fffrBVgQUMLqpOBC0XzrGcscOVDGbbgcz9osA2uDymxgMm4UBBlQwXKnm+kCWIWlVDMOEFetnQ6ohKIoAirRVHJGkO4K9AWaDZvFQKJuqWwOSxTtn9e1S6aqF8Mdm6bb1eEMeeG1OUoopZwt5FFVjFMdQi6Fp/XLp8+pmrmZTTA0PYWIFCLShEZ6gogECRIkZJb1a75n/3q81fWvzWUfGulAQD8BAQHRZBBgVdaTgTUZGBhEk0FQ222XbLqwMDXq4ME8qT54xe72n7ogCEG+BKAXwxIgBISDA6HRECEhREwKkTGHWHKBeFFBfPhA/PhDgoRAwkRAosRDEiVDUqRA0mRAhpkI0dBAJsmD5MuHzDILMttsSKFFkCWWQJapgujUQfTWQNZZD2nUCNmmBdKqFdKmC9LtIGTAv5D77kOeegp57jnkpdeQt95BPjBAfgQBCoVYgMJBHEDhIlNAoZMNRZw8KLIwoSjCgWIfPhRlpFDcY4ESETuUqBBQYuOEkhw/lJQEoAxPEZRRKYEyJnEo+UlCmZkuKHPSC2Ve+qEszXwoZSmDos0qKPVZA+VkzsBlYRbgRhaFO6RhqEMbgQhR7DkJNkqeBcohVE6mL6dyOmfKwpEQOUyGRNQGiYAeBUUSIiJEIox5FIwqkAj4URAMRPhAIkzTYC/0sOnLaqmPNSI7F6yLAWwLvVAfPvrzEPwZLwId+u8GVwEB2OUXKquqdbV16xsaN2zavKUJ3+WtVKFUqTU6vclitdkdLrfP/+LlqwNBUjTDcoAXRElWVE03TItYhuV4QZRkBaqabiDTsh3Xq2jNuJCN0sY6HygyLiAEAAyQzwhec9xAfPN/LzCO89gqLR0wBIFpbLhN6UCBfHiV7mMfHLsy7vt+O0G49UnW+/PTt7xmIPwSvHQO1OHyg/1QxkVJQIrkm/wf1Pt8eoinJfpCyAmHGZGRGI0xGZ95Cwj4EAQwLGCIgIwaEzbxUTrRmf4BF/8TSrCwYiV2oiZi0ZZCstTSySgXsiGtTNVnyimvklqou8iVUSNmvnCNFUeccEtXdcuwCaZsTtm1/Ve1te5zZ51z3v0063Kf/FNPvfNdP/CzYEM1iHgmVqOILi3Sv/V01nmXq1lkl6eZek49c5ZCRX3LVLuUsmuhT1t9m7Vu0wexh8aAWBQCKRw8HvGQEsmpaNmlSHPuButodjJ05OjJdxjOi43dzdLlK1brm2hVipKOuKSsUjnZPnR6LK9jae3MrPPZDzJhlM2IiIxJmjxs3CykcweH8+vjfU6e+fLnz7OXbz999wE8Hbr6fJ4ZHq7Hi+niYrH4ZuYoXibL8fJ8uTRaHq2PNkabo61RbvTShmUmq/HqcrW8sb45W8/XJ1tBlmTLW5tb21u58WWeGqfHmfHSeHm8Mt4Yb473JpnJ0mR1cjjJTX70jk+TaWvam/ang+nx7Qd2VOWqMCOzaNaadWbd2dbO2Z3nd/61W1JDLY22k+3Wdne7t6NrU/s67LR3BruGWeZZ2O3s9nc390/tn9l/YH+UVQyW1vZYWlm3YRMviIOAYCQKHQMTCycubFecfp1ePnz68sNPv/zjbSFHRofiBMORUbHDGa7Yn503nZlnvaXaSkWxVK5Wo466ape3zT7Nnr36M8r0cHYyMZ6azj+KyzBIimZyccvUKgpRVt/XUa6RSls2v0kNiUJjQAiLIEAIRqIwcKMxlOhgbJRgKHrcMZMyg8khKS7DIGk9CrWkqx+rbsvrmLZ3yjnJ3Exmoap6e9o0NrVfO/oz/vOZ77zW7/Lj/brctzKLQ3U2MpFt0bbuQt3/l2ZQw89ce07sSkDAcva84SOPHjwMeDdeVjADeBiASQFyw1WzZwALCBAMGAvGWWUTlGhq4BVdAJtcONzrY8y8m82Rr4G1c6Fzv1bMhAV7n2vB5ZGHlwF157JPly2mz3t/xVLB8ux7T64A816yyZUyV/idO8JeaSa+BtatMoG71e6llawWrxLa7M82w4I7a1amV44++2xtuefUyk9eXYVL+S7MJ7kBIGDAhISNCZYMwgrFuXaGG0Mpk8MticEdL1R44yO/jxfzV6JK0G7mxBjNWsQnLiSStDfNO7n8UB98N8zPIBi3OyGHXCaRp6kXopoReTT+SLm3sSDViVuYRJKWJxmspEJVH821KqV26nYbqq+19IPVjcX6nCoacuYf14hDN/2kcPopcUTztKvxWqY79QXap9/9ggE4MpnTH5Iyf5KkN3P6+ZB/sRlw9leVsRtG0h8VocVH9rvic3euQjelMjVPgWwtUy5PG1LG+hBDu6o8uoHY96EBmJF8Af5USt3uBdG6akk9EPu3tEXbV8SiVlqkABROoSIQj3gZc7Hj7o2y74QLTbCuQydC0ez89Z2okj4spL8c9V8KELu9ALGfGz6GLVwjnKvzyRxku7M8sOBkV2Xf7XnQFBhBufjNQCe/hGz35Fz25MzKHtN2f7fex+22d6ReWDjGRF6hbc0oYo9aNOFfvoJ/ib2rLKkRYayLWKbFYxE3/++9mwxVBZQbjxgG7N1eiMHk8Ua0A2UEmsqSg/76oSk0qpLPYCQz8a1LqYFN0QpsT72GvwrH+PR0wFxjqqPQgPp+xYB6b5ECsA8iR4tMRmri7rkYYU3suBKXsCVuCM8lunMTOm1qmvXiHlos4gHaleKpHUkxaxepR2/m+O+l7VHrStepFPN4EXpH8m+VTxdkyxAJh3KHwK81mAlHtDJ18gGSMpNGekp9UR4VenOLiviEfyQAZKXFaGEYxVzWjyfzZQDqgVD+8d6g83OZ6Pf8Ys2elDG0+LW80/gr+9FAoB5LpTTIuUj0/uTDKchM59h2qNSDQt58da3YbbNwWxnKHxbjif4xa+fyNl9Hzu5tlKv6AjDkbqM0nlwW9ZPO8LbDUqG9dWUcYK0t9RRq4pjD5eEZDgNB9HQM1LL3zef2masIt+GIrKIbjO5vtMEB/RYQPVHcQ4Yyfpb0ZB+8e24nwycbdUDUzXen33WHjvbWA3psBOYyk0Mje1cX1SfvAkS/F/I0wxa79zFJrNrTFPZ2FnGrRYuPl9sj0Um8FQ8XdNOie6tnRhTaUGYRW08WmR51dpCd8iTlQ/JPKrsrA25pwtiEPCDzEDtUzenthg5yZERUV48NK8PxmZkJUrK1bTdslINm5SWN44lsixjqzH8wWed2dLOFTFrkBNm0Oe7q+sAMuqvIH3O+guQ39xSmVM5r+6J1zGcezyRS94X9xPwe8mZQ5H6GAb3PANk9gIb2mGxapWCOD00/yYUztGVTbiOPgeZtd3tEq5sRgb8qSM7pt5hCpjD5KIoyk1+UpdS9qmjdqUu931v3JqXIl69EfBKm8C/KaAIN1qywos7/yn/yndD7V8m+sS6PcpMgY8CD7Q6G6O3ihmhUHw/K5vsKczIAHWSO86Ecqfo4GGSFa9TUPc7xOvifungKN7hvrz3/Tc7haZs5r5E7KLlW+GShuoDBrrzMmJF5BWqXz8QdHd/bfVS0crOy1OurKhyjstOFa79QkM/k0sAXe+MFXvE47mKNO4W+uczn9r9o9OIjS+LwXTjeanuSj/YirKDej+SXrefEQhJEziixzJsNbIXfsbOt4MRdmhRa907yPu/I/4FsKghnfvYZKMtcYribue1BLWWJ6rhNLb0YdbVGzDlk33YwP+IVQJjibJyq0QPhGbIiCO2N/KckZXM5gqADmhPpGaXlGRixHMl3ufCQhZNq67Hs0JYCR/1VlXCkNadOvQuqcADCogsXIAzwqkpBVqQApP8Sltxyr/gT81gQKWxCfkdNobhhgn+iO1GJxS7QsXiPA6GKbVZW8ZvgnhQa2kQXAcoABAXD6fJBKIeljigcgNAGpstTH4RDAb9XDOf5dNtUxZ77CiZolnkPNYEpZOkitL37DUSnasf5FIOjoo/gHkbLHqWtAELX/KTjXaIK1LAHO/mKlbHqUdTo8kXQO0DIjOVUy/vaX3sssPLG3FHqaAWDaRUSWOwdhG9nOQQvXwmEpnuARuH2wyOxMZWlE+ZGUnBgE72wiFDcAuXYbUitDTa/Erud6i8WC/IxysUblVotEG1+3v5ErnBWsd68KwkT8tFWwc9qHl/UaREAwfPKIRWFjqjqyiEyXRA9uHoxFjsTd/WG2KaSMp7syjHKccVaNkb4d01i5GAxUCSzXOJ+gRjc0wV90IGFZ7cigzndZEQpD1pgDA8WS6GRE0pPCKrGYLoBSsEHcozPhGNuCtox8flF2Uy6JGNeVVkTKq8K0DQ8UJMpgqDCos6t0S89ngrC0ZGhgICfei6Mt92NGnDhuM3G0zHYC0GhQUvLNyXL8o+mHu/3BghWwEnGLR8HAhvcwWB10rejTbpSjxBvYDXQggTMkZWm9QfmjxqVZInUwDgdTXmrCmlBmfhMhhDUnpamodKm5KUXW7Kltc0AYZUvg2LSeaLR21xfObGiKRlMhG6JugJXiq+fg0Z/8/hMGmlUcOXNuZWGgDBceocIkNpckmRrIaozNWP2K7PCVqnpXazswEFJ23tUEmYQ/uRzpCrzOy4g+DQHBavaT5S743WUakwyeg8mVJttHjWonoH8ZPIFksw0e0CFLDz7vfO6du+S5hqDalUtIjwXqESF1vnGvALN1I/rQzfGwB9nXEu69xYje0vpVWU20VXMptKvd4OlNphrW0WMeCKkLjZz3xJ+Isu1R16H6tYJI5YB0Vvl8xGvJ6fOYWmajaTkqjiUFi8bXQE+1r01fAimh2bh3awnlbu+tI0ZsOcRUPsTc70dTwFP2bFa6rUZ1o9nhaH+caDmjh6N+iNAOSC5ZMFwljekKSwZimkKCtV5hqhAFwmr6mCEQKiEzqK14jLv71VlGNbiaqLeyThPMACEVDJ7Jv4nsQIHK5CL7ACnkWDAAHx8eaHEI+DvEoey7CKG0iBfGt4rByWI5polnN6zWbIhgN3jyMBUzHh+XEJ4xBrAXmoArIAD/mD1JsA5jDPi+SN2iGMxuZFeP6BdJAPIgMH0crmTyNIxmGZcBTMuKX+kBIiDWiimyKUO4jJFB3TJ1XwbIBjt0hZN1zuiqMkYovSWVc8gsYaK19Y+igU5EjgDVOL1MDrWGcgw1CAwcomcmsIMplDprWiOAyP0E9CQ9e4O6kFjxX7pDRaLFNXqxRdT2tstdT0zGnQIQvqOtGbMaauXwi0CJgID5p4Qw0lJZORiDtzZBYOq0vkJbtnX26ZsSqawZK8xY4e6oMzeJLrwsdF5Xs9FWUYzcL299RlF4/sdKLiFGtFIMHf5YJbsa8Pz2Q3mo+a8ZveRlfy/qgBwymglu5wDOcYeV13DLYc9aK7c24k924ZQkMgzsg9nb7wDwV0iwIfHxvtxNYLDl5pchV8Mv0ci9OBPoPznaVhqwL68uOSVbLbRNNUdVObQY4p54sBqtngghvCuUgdHYV/qYCBEDiB5sE6tTuTZ7aRI9jh0uJNpuciN7Dmy3LQwYINMo/hvYOkgU4d3Cl4rB8uOmqkJELAVm2DodNC4iD6IirIQ1JBkpqkEJnE8FJzu0D0oVzSxUAjJ+6Emm2z0WyoPNVSwO25NV9BJQQAddF3sVTan7Hyt9Hn21l2ibOp6Kh2FokKsUOkaPRkGhXXqKaWhj0IzoQNADAGpdd0iaKBnVRlbdzGn5PegThmUNgU9T2pQQebHza20TWvbOEp92CNgL2pP83pFCOvw4wAXvc74o7be0tkFhwSbtQEsTpwDKZmloYG2KcS9iIyp0aNXp86xFg6KMfIvSlcDcKopctlp37w+580epc/gskDgXApucUXQY5a+3nLH15tXJqEpQfbI8zAbnwPzRQUWSCkdunaHklU405bqkbBvvXjrotxKqjzA72+9Yb3/HIm+iHsKiN7qygQ4O4xJ17IBliE2mZMs4GnoJRac6VVRHDtHnAjGxVKR0kMP4+erCTE0s5Pn3X0+kb6eGNIk6kztdeVmw7SqF8/7eZEyy+z3q5GkdxOwl5Ptj7csp33iuSFHL1NWDYEFZqUblvW3Vkplc9OYrWraNoxXmJ53JXCHY41KL8qVMDOmniWTl7if8LNqx5XuBr4xAHHZyuwhN6xYB143y0jnUNUiGPAevXiqgrhWi2m1PjOt7Ul0W48/5464Gl1c5MBtJIRJjpsclkT5vaNtF0zGn3aaowHUQcRgY9qsNtlgWJ4nnFRY4zkEdyr3sDLRjdabXwhC6FRHuYtn3k/WMMQMAcPgzZJ/3QGeH6vE/WdnqMUzkFDeb8hl+oG270IIECS7kE7rCqwMCQlybYi/HSFJbOtfQKzzOXRcmmWSCYjQAN1yWejYr0HLTAVMb7lX4Bmg3Al0uMlNMFjuT4MDLcMiom3AGnMZWDIWN3LR0QsvYJIxoJINaAOsrwgrwD9RxotgbTQIBbYM/H39wg6/UmHP/sBeOEdD9S4p6JzoolYWKVzjewr6l3ExYWc7wEa11sIduYzjPvcpEjbPL+MGjyCCM8HkyXiKVDp2VaDtd2mOF3pX7XgLJXtwTTp8dhlaRndDXFADfL/BJzC/8INzxq8VWt5LkFAfnteGFszlCxAsos3PV7euEXbNmWul3Cq6Sd5+oNNY2fMKOl5NPf6Cc6wkae9DS8rQy2KoO0DdReCmYBlR0NkmCLFgPHwZJXb+kLBJviLjGxjA3sbZcO+fJ9Aw2aW5DG7ZMN3JywZFV9y2MvFkSoWL9pLCiwjnFe3VXHnpGdm5QhDYb7mO9Evdg5jD1ZidVENHeVfVkrZdoV9qtEbrlhWDLg55syWMrdwGS4etL1qGI11hmZVVCRLE0yWUgavLDq7Lxjzjvn23I63aM+suAlLvyWjXQZW3VJEN44IcvPBmRcpE6phDYg7MBid9hsAtXDzPhi5sYapTsn4PTGBo9057bEPcVj7Bae457pmrKOdfhM0neymFXweKwhZ/hGJpewe0z3BSSNrWdAIMDItOe/l3GC96uoPjfS1aXehM+w09JSbpoqzYP1GW1UvjUzG1MCggEknXkL/tT5MZg5SJgfqivK/DHh94eqgUzEwc49NBN6RiQ4ts3E7aP8culVem9c9sqc8QAaMjehzqFMKJtjMIuw556Jzz4/SGDXuNd5M87xLQMWG4LRRO7HIrnxxk2el5PkMFiwzR+B2gi5kXmbgcFNB5kg0edbjQ+WV3B87k2OFUSf6CWNRYzSEo2HJ93RmJ1ilFRrvnJ3w3P+Z5MLtJ4BVgyqW6bNNcz4IZL46D9BouKzBUFWXVUqK9zeAWzHBkJA1shu0/Q2UHN3YB6osvcf9WQVr4NjCC8Vgr6B14t+dYLoa3LShTDUO8Wp8L4IXyzslNnQafX/HvpwHPUe7gF3fPbQLAz05rlntyI3sRDvcWT4+1FcCXNXTFVtwDVBiUBb1bFY7LXIsVbRvfljSqtlWi5IFQu39yjdA+Z5xUETo+5FV4PJNNHNerYb1hIGr1ykEImV4A5e3XUbpB2VGtAEhYH4dteKDCBWB4qY0VP9mqjMFU7l3XgmL89ztRlYu34quI5QXdAcmONFUrllw3AD3fQZcCa6h1sJ+hOfv8lwSrmqhFnmqZfLPVIq3ZqfcjtePitrSvgoFtHSDmmjpyREf3VGlBnF9Dp/oXAF3NxVC3IOt3eqDXsxqP5K3BR72XS7AaKgIeDDC58EWtX0CwrZx664mB6jxPbaTNiwtHWwUINVkbTkwsN7qXFDHMGqm4E3e6gjNQhsZgd8F2Bd0bQYLAomUV7pkJVtO9+TyUMMU1Ha85h9EQKhjC0PNU8rNVYv/J0JX7jAIq9aJagNTbEqwkbdUedEs4Bduo+AwWlRLt0OXog9YDL8oF1yvO9FCLbQnk74r0LgcfED9954JjEp/xgxu49yX3fX2nHtr5DuBHvl/Dul8bLdRmuvEU/HGUqf5WtbKnx8vOPYU7dQge6CQm/W2J51Jey3Q7ZyeKS4d5Vrv5+IU4MQR+3upEGqD4MjG+ZPVJJICydCYtwvt4WiSdEPjPyHaFA7yUBea3K9Io0lWlzaP0rGMcOfCyNtgxAFVzGxziHegCDn12DhwVa/bY8R1F5jDNbVBmm6ewPemRqxyy5ASGwpiG2RPs5R74Zl7LpfxT5ElQWW7nrTGfgODWf7HnByX/whFtA/jZis85pPy8tTzv3lr+1f3iezLlEHCjdN0HBHAgY66eNw/wNicehMTNJSteBl4HM+by5T6NIi0WTtqv1in9WHsdVQX39Xutc3YnmwhT3vwt42vc7M3eVIFTkLAYntZ4/fNpR09J7YMfqcmpdrfa5MJNeXWC3PpL40Gl0ye5mL1nwRwQkPfsC2E5nvc9vUtx0ez+iw7ePAvy4cjXr9ybbnDr4NW5/+6xh+071/wR17//8ZIx/jNUzAdteuzFb89KGU92NMwYTjLD8+M2vPDBFz/8CSSI0Ij7PJ8kUkgjnZGMYhwT0ZDLJCYP8t8NgmlfwbGYpSyjWKU1zcq5ygTEIgciQlj3GT4b2cRmtrA1b8sUOtlHDwc5xAlOcnbPhdy8FFfztcC1So92vT7V0R6b+I7AYDBYuJGMmWcGy19iR84Gly0HYkouGO8OBgwxPh7EXrAQJvQwgRLVyOUpw41gY6QxaJLQkJCQkJAiGzKpKDMUZwcll1cqtZKFclVMCSOBghI1txOlmeyoJQu0ZoG2E52068J573ul3pGZPtzM2Uff8Bh8Z+3HKZv5udfaL2DChCnmxzPZJivZWOTFepvKMnIb8sijoIgyGvy/X4CAgICAGBANBZGxBTOZhVsqCyLjb0ie6tQZlPrECZM4dVz/p+HZZZq7vYQO+4NKRIhO9MjSrMJ+PAPzRgrb3C7kuVPwc7qQ516H/6iwwgV3mbEUBgwYMAaMbTxhL2L0c2wPGAwGgyGC+HsOMFi4HwI/MGSSHTsWNs7EKGvkjhIEBAQEhIhxEQeKLYfZggDDhQcJCQmJEj78pzqG8HcEJkyYMGG2D28g+iZ/7TF6YNCYyOTjZJ6hhErEmbw+klMFuRSiKC6KFVW0TBMQo31ycEzkMcfyc0QExfr7D5WPHiEsRCBYCPBADAUFBYUdbNjyH1c4Ly1jMSSOfb0eTuedXGO2x71plwLSphewaEYB804o4NuJBaSdVGBQJxewamZh3axC0ZzCqXmFX0mFcymFtIJjWFZUcbQdovCurPApXLhUXrgWKdyqLuTVFLbVbrZZV93R5lrYNMw5mIg4P0qNn3R7XpBm41JNPHlcj40OMrvWGQSPedQmYh870aY+SKLHJxVCnj27wmxISYYhTl5O/TEkP5kQwyFcy+vgc4CZQWtkwzn0Jk8OeR4S0o7ggR3xbGFSnBA5DAsqrjk4mXVropP1MJasdqqYrPLruVhYGEUR+22NR28LupqNM4G7pPJ64FFhAs906/VSUSPsML6bbOluNeepxwtP6szSHbS9XViiQTlEPupO84koJe1jCU8mb/mONZnacOZGMVGYaiO6CmSyuniCsGWVrdtyJ9qiHsYhDaPFjKO2ImWh10K2Qy7sMJVncRMj3THusYdALsOxZe5k5Ck86/aMwkHbh6zoWYSQ4/wd94S5YAubs6F9EuY4dQ2nYgbIYwTk2ICnIxrBw+JchM1Kqj1ibJgDI2gsuOPUxDFeW7Bt9prbvKlDo9JMkpWdVgcBFPnm7YJsecqMrhgN7tkyYpEVYvtB/KXqIWZBUr5OHQg9VHERg3W4YqK5SyW36bOPnu8wxZ2ZK2KERNuZSqec8mjlUnOF3s0cLMka3RcSzdc0mpFpzQ7t5nSsZltdqNlaf80cS+zWR7w22cdauOtYqa9nO7V+zxCuRADtOyB+HbyoRT49a6Jtak7S1DrMVFKHVOvVo1z9GnJwRxEho4scm5vS4m7Yr5TDqUzXwNP21nGmkmblngTTuPN2MzmTSiTgoYxdIYZs7LZYflchtpNnDZLIUA7DtTmeUlO7KWyimRaZ9WyGpXhW22ZXKFXPqejAehDaeo+/MdwGhunDzDtgGztfRe59sMCUj3zDJcKJ3fsw5awVpLglX7qcxqLcfbvjieOEPvfsrO2raNtTpSntnn7b3z1hHa2sB6muDYPr6ULXrhxX/gwt7FVnz37oopnDj2dlMG2PiBPiHOW4aEMrZxaGrO/Utuk0rzrjdUrN2RwRF0QlQ3bxSrRv6hctT4WUmUOH7JkEVq5mzqg5WX9kVq05V6dlVqrZQINrjtGRmaadnlLfZnlmx0ElEaOIQ2i31abjpvP6oCIQDNhgACZEmNAehdozB9Ssod01+8QQ9mBvzuJ4duSw2ArZ9BwFx3I+e+mCb/+fo55/43WTJ4oRKFwsFYErmBrT3F5MzpZTbiNCh5Y7pw3K3ILHdzVb5t7lVBBGWYCbUylSDsVKqDeotTZA6kdaE+RODf/VH9lXOfy551TX4uJ3//Llq/eQ78VgD/ohmDytNv6rLVuy4j8rf2gYvSW6ZXBP297Kg9MP+Y5eOxU4FTxbcP7ZhXcvIJddl6NXcq5Ir0M3WbfItypu598V3KfeZ4292B/2qvZV9DXNa5Y3AvTizQdv/viKcNfuv3B/6f4799+9/+XNz2+FDz4dyDx86tGNR48/fuHJ4oJ5e/PZw883nj/0Yj6+9vLRV5PJA6/Tr68tn+9vrzy2ur56spZfe2DtkcHu4MbQ0cfzk+G1UW7jaHN7a2AfjLPjvXF+fDI+HT8xQe5iesk7vrMxO72/jvpzst9aHE3ai84SL5NyNmtV3RrXSfAhhBFmoibebS3S3c7N9d3u6tjGwebhxrXl69v3rag7nP9X9QOGYAh43u/g8h/BrNc6u8zLCACg1QJV1VyaBXp2m3AP7uodAtCAAM50726DJoBohh0teUsN4rEATdBOtx1IsuIPd3UknZATdUsZEBudCBDCyC0N7KHxqXOa3ZZGG5ZdVb1gsPfdH/TaDIgajY9fK7XSWkFYQfesgyEw2D1eBKC/1zRoylZTqqq59EzQ+9tKdXpnlR/FkgwBaEAAZ7rntFATQDTDDhOXJw2ifnq7qdyly2WxsqGWjOeCo6xglDGpGgWUSrRPBdAwcksDe2h86uwWdqDTa5dd9e8W9JQa2lVBVZNnQNRofPwwrdW0DYRpelwDZAgM9o7fT/WH6uZ9GVPYvBPx0FY6OZMCZuQimxt34VmgFzb33g4YbKf/YBjnfnVwm+a3PFPTwCVgIjH34TGdcvmN1jUV87FN0drKaF4z8Ew1yTbYEmryAHhdiIwg78Xc7OY2p8bq+xLmSJdCzSw9m0b0d0HbZ5UXgK8Cva7Cy6SzPl993VH0uUCWxRYW1AfgIM2kkM2iyGGzlzVQRX6z9dMTAhDZdmGnnIaTkPXX2f8F2LYPdRpGbbIaU71P66joCebSuZhTxOroo/Obh+IH4NgjY9Kgl2JzIfH/xw6A8ft4As8H5C/tATZFQBAWDKyJA2wJ33NNXgEC4P/w8umjdEDEFNwESjBMlmkWKHVzRaPZkcIZ70BuZPgaBqrJ9hNecR59YmQBj2pd5o8sEgpriShNJWjKBABTr2NretR4GQO+nRuiEbg8BVmamZtKFBYKK4WdQqlQKYIValuh0cKmvATbsqlbIVPIFQqFg8JLEVSJvFr7frkmE3/gYz6D+++/NxhEDuyr9/08Ymbntlz9BXZgHg5pbiPtr6OWQpU1p5VNxw5Neyb/W8HFmta2vpklIJbkbCkFCRZFLcNwI40z3iTFSpQqp6PXrEWbdt31LKmKtlbacwZ88JHBr9DJCjm0SCOPMvoYgqUiValOfVrSkXkpjTYVqa97/ZU30RcxHw9paQtb3vy6eqbxud+AtlRYT680qfECHLyvBXU2u1djRF43ML+hb+g7FhDCOGRoUuas+XDkwkuKOImS2NGYbbJ8y8xqtSUarbbOeh2WZ4rn/nHfW0+99s6XcOB3EKKQfRhhh+N7IhIIHmfK4m9NStKfzvSkN8syLiuIvUT4l8Qrg3yi8JWNb6x8Zu8HBz/5ZQI4MbJbUsE/E8E5AA5KjpBki0ie8OSKCVV0KIZEIi0i8WFKj1hy6GIjNCywEUGiMCoqY6IxOmpjo5UZnQkxmhiLrJhjkhvUohTJC6EwMUUZa0WyrEy2skykjUZVJqvMJBXJVZfpajNNTabameW2Z5k1+cOOFNuWpf5MkdaU6UyVLj3RO5g1DmR1/aqrsupqqmqgBZ1ScimdCAhYFYaIsbEOugQacIjqMS0XKABtpYG+AjJA2TGduYFk5iH/Vhb6em502RHvkEWAsSnIUip88ts/WVYB9NOA+YdBtgOrfhFg7XsBlp4GFjYFoJM1TWpooIVAFQSOPIsmGdYJ23KSdOa+aWl8p6TI16JlOStDniAW8LcghrGf5fwol9KLQtjPs14mJmzHyxOiK097Lnp66xvj7sh4Kh1APDP6NBjqGRmBXJG26flGPuO5HYLltvcVrL3m/ZShaFUHQ8Jx4IRnC0mDiofmZoKrJGAt2nFgOSxDUFMfLCm2FycmCE0WUmkRCwQGuDl4ZLQjbgg5hHBCEbDt0aJm51HYNFs3nF0qhZF8kfPkNGm3ESeHH7QLViByMRNjdbBXVAAS6ogsrDWpIZjDXqSWTI0W048OHGeO4wKTLFyoaEGBgGe3Jt3F5y+/4HcMvp+q6FLXetOAzSglfamLt+3tWsqIacuJ7ekednJBrc8I4slHGPzGo9f1ZiMCZ6Lgvdo/fqD4aepJTWYm+ABonZwt432Xq9NOqgkRWRQT8SD0hvRCv6bSYjPGMqoXwf1dRigmMShbjpEa1FVclqEBVfj7wfGUkfsWqYzvREjREgB3ca8JVDQWwUZAwoal+NEqCkJSFCcSdH47CkWMAUIuOZH1AF1AEPRDt1AsInUWUbhBQ3h0SoS8ETFMlZr6lfFjjbNIxGZGEolfk2JUajG0GTtTo8ryRdwbqrlSz0Ogk2w/KMNIJJ36HA1NTyRy2YY67/sKkiqaKha/fE21btgcZEQuE9++xtjDJAESZSJCX4Ukzmyhchi5wWExpKEgxnrKGpQBTemhhhYX6Atnz/esom6YuuXaS5tIjCu1ewG+4o/69EFK9FD9gEvo4bXnmtdU7snxUQE4STfn6BgqFR5PkmzYDy1Mzpn418KSK1nLXcKQMYa/cgMypB8EoUQ3oNOVsuOscCsDvjozY0eXpmEnV3CTRBH3rbg9sMDy5HL+SnmZAOWOM5S9tAdEKJTYe1YJOk71hB4eQMvuuhW/KFb/Wp4gwF5aFt6i2mVFGKPZdAtaiGQpLI4GIu/cqye6qGVhxn7KCipJUphlp6llowr0VYOt952kI64kNqcK6WUvJPLLXs7LS48MIq5wTm32s0aCWdwD9sHdmcMLH/9652fz+vlunEniVO6Oe/bqLmxULj6qpXkSWGEsRUKhYizf8MpNT70CBBKzbNdqdjO1Ot/6B5BNFCgz3XeYhGQl1TtvUPCPWxpsNxLiBfAGwCyV8+PiQII9oQcLKrqEthqY2CbSnUCwMD6aKrg0hBxWwzZxSZGzIu9mDRSqKiw5OSK9VW8z6SPDkTqSd/XuB/tWcduHQWimDFeS8BcwlUwtOWV/9YyOqiCqtjlR2UTXsC6X9Co99xbV8epM0imv3hARdLtosqDWBIWXPhqG5Dpiu6KVN3blUTwrbZLeKl6v1A3hBbt0Dj35jumxLI6sl45AvpKsWVUSZ8cYbGx8xw1vU8GGMFU/V6OPD0it7R9znNd4E0yZ3XdyipbMdo+renvILN+k37PlODpKX0yk4ktSWB4td4DUGOSsWkATxnTkddBqUivn6a43mKMJhGG9SVzoBwqnxBReIYzvMFXv8Ic+JqQ8baEFvCL3UijTaeVL4Iv9oPfcrDDEinggWC1/WM8uR1WsGOvuO8z8xPRdSooKob9K3UMyfprISaK0+/TgxyS0f1F7G9GowrlQSS8Z/pJIpsEmaqTwr1uZkSTNp3X+os/6/iI0/zPecS1ZlqpdfWtbkCzCRRuq3T3M7LkrwPppvY4utDG9ykU0ENrIeoZ7uId76T4a5usiknQt4spYxEjAfw6q92rb4AwMGkl5arWjMonoAdgjEjo+1rh9sKv/BucTuCjgCqp3WMo+5pxaI+9XwhlfhAEJ9WY5O1XjvhL22Btxs/8QdcwzR9n+9Yp/rc9960z79GEoXCtTtc/Wa0NDFnV15W6hFfA5s3+kyeziilnb0YJQPPu95Fkbsnj09LwLw9SPAii9N6up6hS2RfGXeVJcoxZF1rFILAA+uSsXBBYO8R5XzAJPffZkZYbJrWEYto7XkaMApS7031GdhgOruOYo+9iqPLhzV3FpjWOmijv5T+s925S4klEXouCD220osU7XPd+ft41Wflpx97qVB1MM8gGdwJ3UERKnj1OChJZdkh8duhKUhFUKeredaZqSIrhnmUo4LFcBUuMXh7S9g4O1sB6DCalDou8l7FJmsWeQ68Kc3mEmVPh7APkASa9oMiAueopHlTxJha08JhkLt8SRiYXxRK2Gf7PqJ0bx37ytIPU0+lZ8skbwPxBwMjiWmxNZBX8qP03h8iAUYCGW0sdesFrZNPzLFmpoG38l/MQFSagQet8EVB9Ly+mjuyNQjenRR6KjZPXRSjNLERESeCZwCqDl/UIp9/l9ZTFrwVZFrTpsBYvGQQU/7psXLm4cyZhIEzKrrf5HwHEUeRXklZo9pFafoRQ1KYqApzwtmwI7+Fsvod3CzROOcuWU2GsvFHUXP1TpzM5lPp1+mkbRZake7ehNL5Azer6yLkxjFEZrpGqJEd2OREh9Six3mIRo1Zo7J4Stw8fFUruRRPhC1faxLfHsyxr9dffcmGwVLx0BSitXfs2FT9tYa7x4spMjWhAGqYRFhdMavNb2NczB2bzb0ROMZcO5EY72qBBStHa5KxuSYECMtNUgVLaSpO6WaIVRbBkDpxUjbekG2rs38Ry3Y7rRcVQxaOhsOhfEMrvvrCx/hZXB0yU/W73af0qasdJy35k7xrvWsEeNfQx6ojfhwBm9wL/GmvgROcJ44+JqRD7oDXvqz7NB8rq2wMuPZZmuw6nf2r5dICHEdAaHMOJ4pzNanPV6OvenijF9xONl3eojvM122KceV3Sz96mMSERk5Oh+tKlUMhQ1TLvYtFWplCaGv7WId/zvdbQGdKVEx8dpU2sjHk+dKHJfYbSnlkO4ir2g+QU8m4+iQOaIKjFHRAlzP3YerWHm0/nn3m9uLabe5a+hfvoEnpjWaz3/qrcaw98PX8APK3IiLAjpRYxOC4bZ4ShA7Dl0aYINenYUajtj9JR4XEMrh40MxYti5Juny75yBaO6NDjUpVfsyBLxJ/pouslY/7KRIsiZTOix6MDPESCcOyEKG7W70m/tLIq0Zq9c+9njesorj1emcw5ensbgVvNB4L3FFn39SMU12FE3RnN6X5a6WrJ1vLLJ116+Tv/ZaWN6Vhuy0obj3ttnjZteNan2UAv+lKeC9v9R+Qc7/o2G0P91BO+1GT5vle6hhf4bBsGRL+o7yws1cGDtdVups6q3qXV7aNOqQSNqMx8NrlONqVWY3rwIzMnIWl0a2t3WFtq1urQmsSnOKQ8zKUSrL+BOEIapsZhhWoJwB1r9FDzM4JRtSoDgyI0jl4YP7R85eTweqimdrkF7q6vR/kF9rBkER8aDPV+Eg+FnPUEQHLkf7PoCDaIW0J4xfmVp0OLnwvdP+U44glCbbwX/npGasfIFizCX0EFwpAR6BZOIBXTgazUCjKim9b08qSiVkex129xoZUl7TrDtZljTU28Fa293lrX05w6P1Zc+7ccsWWc0iBaDe9NzPxZmviNzWsdGaj7IK/owryaSqVQ2uHLco9+q6jp3jgdcbMvUqCl79qSpTrAmoq4aW7a9ZKSy1pJlLbkpY/pxOHvDu9qSybo1trtEsi28a40V8TYTxmnRmErT6XUncMO0ojCvFAeb2oZP7j90cfiIJlNXKQlVk+KxIb29v7oa7Z2uwd+fb3b119fWDjR1DsmmdnpCJpu1wOjrBHN6wvWLmrqbKqqmJ9r7xnP6vCGbDQ3bPX1+vX3ucSal+E9OH495V7Z8YxhqlCuLrcX1DVWp91xyQoj8rLE0/aj6X9M75ASpHpLVOfLgDsDjJBYkJ42J5aQ7KzyE6DMdTzDLxXuwrkiNeLRadbhSbsMbzY+d0mZMCnG9nzHZFoLz3Z1ircKnNxvLGzXgt/wXQVnwUQtwZSyeu2DulZIzdnbMC1ksPhknZj9dPDx/7mLgKBmufRigfBmonTIMHvYPV+xUb5846u3f7FMxPlx8WDKJBLlvKp+UJa7Rr9IT5j+ybyoTo4ybDPC86We55mLkaqThh1ZTmCXvNF5cF3zg24ScOBUEy5nZbxuf2cRO9sujuoTMXpuor9B+m2IoFMqccknqjhp8gsNO9JW8X+hnn+WItikluECMS3lRdTgkAw+o4eUxAuLP+LQwcyDP+JfZyc364J2HTWI7HlN9uyxdozeH+JPzQrKJGealz8c6Qrjs96u73zyLT3R2Vjny0+V4mU3nkeBsKaFO7QpgMiHPR/5oMvfoZZUEHmZiwEghPr4KGxteGx2JVs/Yz/IKEFuj1dxV4NH3NOChAOyQCYMajTDokMEwIRNYqZJJkEPpoyKji1GuUUNC2kx6VzNBdvroH72jVP7AHIIgzMLvC/X2x03Z03ezA2RSRAOu7/EUmLsarTbEy5evn1UdHYmuHR5TY43F7ICp88Iu/L8BoFOOeoOmAbNL4j5frdjIaVyws+XlbN38uc6250bHX9T6BMs4M8Nh/mJ3Y6se8+gjalWxkzL2wjIJVmqWVRsQAYHxsj+Zl18zD5hRpiKhwUkvU6tpFTp3RGIwFgo1BCUCvzjBov75+ECQgP64uu3oWTwrNtlscqps8stKHvQBBxMhoPNIEx5HDTz0sYi2SXJt3/pJiv8J0B685wjgXc+fFnC+xJdOLRl1Fr1AEk4RoU3vZvJymo9t0tyJUmolvLTuQtJJ0pQDMs3PEX4kXSFydHiS7cZiSBFQaVQFRZBWE4PUQZ0a8UckBoeqTYZsQhQXYXjr66fuxWN7QcJITOt+L5egi8PlVZXGGNWvcxmseFH1zxD/LPoM+FzL6tf6fpxDyZZyddF86wDYuO2vrMnJrx4lT54b050biY2AtcPfYGefxZ6Bvyj3AWt+1MIYykmLnPG8PAJ4nsVmZc39avVkS5jgQI7e7x/ALgdfYfXqOGV6WZQsz8FGhXwe1aNLi7HcaqeKr6G5dWkErz6he+/HUbkk0M+pZAEjZP8ZNF7LytU5342kSEqYc3KXLTzPl2QtTI1kfx97HZv+XEip1hSqKIkesMYBm3K2odYen8/SbSKXq8WybqlUK+bwIQ6ZIKTTk3ZAiMIJL6jXSUkF7vGR6NrdYzIvC4HtFt3egLn79cWh7euvXpW5mV3x8QWxquf7F/mZEqyMkB/45BZousosZqmf3br+/eo1Ez2fskI6PTP0FFE6EV5YreKHHQg43l/dvw7ycipGdAe8+u7vGQLxsmRju9dGRx5mAl3O1f/u5kdbNaiLxyVtKpf4z6XwZQ9iO6z5ov+BF5R3kDEno8nBp9AgA1w6qydlX8ln13jWKl/AUCHfXqxCmSKRnZ479ID03x9eMVzksDMiANspVSF3yy2CuVFSwlNI2dTPvz9p+uuuQPzmE+U3H+TmwR1M1X8FT6Gs8ZJx+ZQitatWUmCt5GhROf+zJ6qvPiblfvC3su7va2LRRwI0Gzyh7Jb+4fkx5jlRspWbfvZjtLLxh65oOQ5+ntTxwCQ3wW9M/Rw/o/wCUnHEZohSlWSUKZAsZATtP0VfRxO5rnIjeHD2aeWqWatnVdx7Ctpqn5bVt/W1+ftaGlrK/vW0YLD/5QS0jl86PuUVXZx7senUj51f08u4PPcyWDBW+dW1d/X8I6RdAA6h+lkquWM6qp0j0TtBzZEivEiqVftLxFr2lZOKJJs06Lv2fmOGo0iArsRXHokduXjk2SXv5FHN0kNk/QFEfolcZ9a/12LZXG0+KW9a1yhPQ2iFk5/x41EDK10UkbYPQePU7i8ot0HLH5QpZPFNLXjL3XmjpJ8CgSNrdB6WxdMWkEsmW/vzshd7f5oU8uNFR+q+jvRXFvpDKj+WLDKp8qMClSZAyps29zRPEzWx38HfOXKujL+5TlKuA9bfqYk5KrVW2IA3HIkeieARkUnpDwuV6nyyJ0cHpTlGvS4neG+s1mFUavOVxuQLPKbfBYng79SWexhHRni92DtwBoKjco59Emyc2CI+TqfuAGSWKh+BggolVBBAlMp8uWXKxKBfzhJwDvP4hzkC8+85n7dZCSiUKSRVe6kV6RoFklZPLVd5glKToUCsdtHLMnLVmoxGernKFRDrwhqLmzItEKZOt7q10nJG/oQcg25CHdPfBnjeW950DDEfsbWxEeAVB1UQVcFQqbJea8a8KPKY6Zuc8ZKKUWTEo0K9vVKjqUIN4rinsjKS8LZXDgRBNuXv0Fnr8MiL0eX5+So3q1Us+LYtMcOFYB1+dITD+W6q0uYkXsx4MVhfUqdErRVybVjHZL5wcP77QyObhHZbdbsWVOzPJwrfKLjVGezcX/p+ckLueiChrE1qvPxw4aTclTgPUjnlfD8k5TpwsVLmFq0rzEObO4PhUcXE3mQRDyKabMaEXcUrwRylQtA8fIq+tZ1FwZqtljhKYIk2C4G3WygDzs1BMy6PeiFE6hJJnbBM4iQFQVgmGbRTBJoji5IXgj9GJQ4AEmVrlzsqnDZb5bpC2KM0m8OVkMZQAesiJqXMWbfOUTan60rKbUHIxTwKS6e72HK5/omWS+HLbibk0+BmhRq16TkJwPMhLOB0J31rFRKcSFpwItlqJrjBCXgvyHk/sMTBXCbXc61Tjdva/30JOQYeTZyeVuLIwj+EDW6nWcLzWbEC/fr/fKoDn2huwncztamEjmgYmx9df6cBzJEGGTMR5xR7LsO8G+wXOCJey26BWQr9wnVGGSqEvHkLmV7D4sUm1Pn5cZPebVVyE5v6EgMMU6EbnKgdtq4ZBrqnwf/1CQgBhyPbDoKeSgRBrRuFPRLedDG9xTrpHUcmeh4yuFCzWOD9wqvV7PzBFcbvS3BGQjIKHZdJLkq4XVOpHOZr08m899j8/z1/3N9n1XCXsDkk7s9C/bIlDFE/Tgeu3oZeQFpfIauaIwPO2r6GvvraG56yfhytQZvyR0gAfxWM7s3sLemdbwxQfD/tzfB3mHFfYfEG24FP4EenjeL5ja93LGVpXXo77nHY/ADVldbIbeZKoTZog5YMXJmxmKWO3pXdJ8d+/yXsnTB9abXcju9Dtjhs4/6KsMWfPZ1gydKZRfF5nO9m+KQt9E1deIkezOXUd3elpwfMdntz0LqAe3AWulx6wyG9tVVyS6gh60L+wbnWlbI3iWp3t0nfNE7canNwK3C+mhdZjufVLwfPr2KSjAO81EvbA4QFDb0KtYCIb//VDiRZ1sa+Z2JWPUgMW4eBlf33oDbG4KRCfSF1r2Ztc+CyYQN1Z8AweYg9iLQ9AqnjBb95TLOyowwBR3r6cmBQvXZKFeqn5Qa55VMLjn3xC8Ct/1C/3M2xcXd9SfnHpse0Vj2XN8z5B2Y9TXlJywCnm8fVA/TnGasCGf0k5ZU1/I+yahdJ2z+UL09l27JOf0n9x78WHBi/fDJqnJGYYQR3v/xMGgWq9aW0urk0cNXM186mfTuU8a2Ns6mmEmr2XKqxlAre31RKqZ1DeZRIb54CuBungLA81vt2yMPrD6+Vz2yY2fh52V9zVsOsRnBpLGQ3KD97L/aOHZ/1exF4orQBfAJ324H3RpqHVh6qOhjAkPxK+UbuSY5DXfYuKPkq2JtfsFjf1GBaFCo0LG1qWmwIhemvsUG/KGhhlH6l4psuUVmprmKVUh1WIEUmM1JsbvzUSp8CXpiahv1it5kp4rpQh7wzEumGHXi3PBpFelyEojMW6ZJjRQXyO5sbqKYfuJ4fCkUfIVwO+pFQ8FEQTGGj9SJDQA/zHWc9UvV6p3yDgL0TgV+BqNUZH0dsRT3bBEqFOyJShUpDuMEYKrE87nfDH4gVHr21fckW8nJfuqCveseq0FskXSsuRqpBxoKjxkbYXmy12YtOfRpVqqRKqQK00/ZmHd0jSxAiCUfyKYP/mpMVoPM1fZSHKSQM55Lk+lyTPlQB6fG4Pt0jc2FSmG18lcl7zcEMyJzso1wMEdNdm2fNzzPoCysgj2WrVDTbxXuTtKqX+drtbObmNwafXPwNNjISZ+tqanSzvV7dLPKzdeOzWjCLzZb2c+OejRZb4QaLCWoqQnFbhW0qRnn3uBhaSfVKJFT3ckiyde8vQWNQWxHWqYhGFV0opugUSRNDuzTolLyiSwoBDEfcvZijx+8PUra43T0isV0iS63eWGtHVdKwWOo0j9olg8nycIpVT4Rs4Xv+OZBrunQG2OFK41OpfBoE3twmQoVCVCRSjgpEoprQwgS5qIlEboyRSY2NWE1NoOavZ+j/zx+udye60+7ehG4CmzU5M+wzxtHxmfaZOWC/ZnwGOiOt+YfhdPv0tMXo9HHAmtVl6TJXtlnaqD/+VjaQJPHG+MxcF1dIcpWPfXPlWgHPmffB5a/Hp+d5eNw898yxL177gN3iC53k9xZnyb0ymV8Gy7w+GQzbgk8u/2UqBX/OnGXpfOGEc4elI2f0N/WvVVWq/yiJSeYNNHhiTWMMo6KiTGvzJYLZDox8w6OGRadoYvrYgtc9N/o4DOHGfTlzf9UmgK+nH3McKz7mXHy7tfpc6YXS6tHWBc7DxYcdh5PgJ9ZrFwjEe8LxeFVgzHvEVALMEKs3bty0Wa1qkyZKq9WbN4LIoe7jROq+eQ399abDoT1sIVYQy1+XDKDJff0c9fpZz7f9XpBKvuO9n4GnFVAzCeDz/Ob3He/vd+xPPgcHKesc36qhfStnw+m6C3nUmxKHA48ZuBdG6zfkUDNgwkuUgw2804uIq+kw/vf6Zy3VoMoOnqUcOAuiDq6P8kUV2RBSl1ekfxx9Fg2UBCAV+8Phd0DB9WEbUW0prg6xxIMgYrfhEOSU0rBM7HFAh2iHVzKY2wJFPbSVxTo+rC+AnGMHueUKSU7qeWDIR0gPUTevoLM0lXpwG3t80zAoPpD7Lk9x/YTlkUiZ7suQ6D7PDcs47pEEe4OMTqdSqBl/Xa2JEFEoe5Xl9qWal6Sie1y3HHu6DhUgOqNA+5NWOHkHqhByqfg+N4BRAhw4REqh0P7Z7C8qNHJVp4wblbIPCpMB5aTmE+lALRlOvtq4k8ZHfpXBo9iehh6GhkDxe5DgtOuc5WXx5cDLtW15+eLl4N6g5OayRZu/ndYQmLoZeD00vFta9S7wsl2/60o7wyWhEnBXvn4LEYlR/wS45xrwOd16hQlGaIjem0+A9WaMT47T6Mee0OmfXOF/RVc/vkr6h0T+mkz+hkT6B9Sf6V61KHtKP09lVeMwTbxjY3bWEF9jVTmAYrB6shoonPvWacPrgFd/6JWy/ldAdX+m8JuLNz6hZea8NWUyKu7JtsW078XW8MQXQWW/oEzMON5jwp97qpygmpJTn5UZYm2I8YGCaWQagcKonqsGirfFn50oAsopfijhB4o3YXFXqCT483XvYcBH2K1ikkRKFlmwfCySv+ZPyKBZjE4WDfBVZjUK572ZMIQmC6YJNBYVAZRbwUjB/4qB8v1wyLfDFGcBY/3Hq8Bq6JEfU09kki/l0f+poSmp+irNtEzlmtI2DvP44yYB4K1BAKhW8abzQ0/J7tjLAjZr2tczraWIUq1kWlVP2d6GrAaettJCwfhy12bIp6siI9UamvYaOR1Um2i6XhGyr2sr1zc+ecYy7eiSLlXOi0eF8vJmVGuYLk1bzGiZxwlyrjaqlWSLnsVxFUhDcP8OWtnTsYvzOw30BXFGCLpR7GwyDFRMMJUmp16QwZcI54RroU5udc3ovMHZgg+9GuaFOvhXoc59Pj5seMtNumvIUN06dPhc0CUjyzUbO9WxAVpk363x4KNfmPiu+b/fDgEdPw6/ML6/hrLGZgObAZZzh3TSfsGesreDXYA08Xe8a+wj1Uq2yirOR/QQ8Wpp6wXtXSMsaOn0uORLdZRGKRt2aPkAzvpyZKA8NO7nXrqZPd1euzWq68c41T0blKg+B197+r3oHeviIlDk9dB6PeZ6PTZ7faqr9jZwJthspZMabsTt6bVcHWKm7RPiNtqzprVd01pmaveAXm80Z24yXcFxHWDyWICBrHaCFd1Eop1FKodB0C+ony747MrqDklZP0w/ZuMgPmY1o5HGI1TnsPh8CwAwTFcXko2NjXyZcP2Vg178ymrH21AzgXxM0M6sM9O2UVI5FIJ+fr1BV3MhgrxkkBXdYAhrj9YZrul8ZNXmRsPgy/u0N85HrlLRAKSqE0jtVRDdNRDtTViurAboKBNfA0fkyoNJ8J4Dx+vvA47vU/Kws6yvtq6GTBraUncdHvMNy4GqVj9hDefr6phqmgDgwIG3/UIquuY3fxb4VODDiFzF/p90PoEUs+KeUDhB05b1AzQq6fzlKi4tma9Bt4AkK5HKqWTVfqJfT7Z0v/xh/VTgCL9Ge47twy5MyKq2qNT8LRsaak5RrEVOVtMJaRxrXtcJQPMXeu1MnhV7XBedmYpDmJnVjraiG0O0U0nlQJBVqwX97PoJG15TQ91eYgeGlF7X0YZWTIU9qMh0Q2ypHav1gg2oz2q6d2nFbpx7o0c79VXeIJuf5XHqOqafZoT/1s82O+93ARdGPYcS/ynYddO2J9++d9MsYO656T7b4kcO/rZtTd+bBbj0sHH8LZ/d5XGjH4Yv9BWTJ//G/Xc82JAH6hP9uSJQf1kVrAZ6w1hgfBxrmk4Tk//aJHRee/Alz7bynipdP/CxGOFi+2Sw9kMG6D0dkcbnWnZ9clScA2u+jMl/bRJq7UhmMrkACzWLWJF/YeecjEOnd1OGsuW+KQZZ85kpDrKG+8zUgqwgz0kC3kXbNPbNZv5lBjGY6SQ41x55JhuOVvLz+dzLmBUaNz87qZ1ft4YmoS7SXhcxBa2z+MgMTULT4aptD8VPTmrlyxSDR9p3fkxV3T/T729NT5RTtRQfqxEmN3FfK6gVPugBChoSiz8JLT0BPR4w7jhZgw4ST1CSHxHAJHfv+FZmYLzJxwU9GVitRNFuK94w1aTk3/ZspM8hRX4hf6HP7kfsMCO320MHyGcgT943qfSsuGKfv7w8mz4XipEnFeepJz+iqbvP3RvYQwTyi/7JHh21IpJeL9V4kPUcYvCl3awu4r4pCuEDwMuXiJh6s7BFisr/WwRJ2hE3IKv1ypT12a5bA7U03CdhZWO4R5wlGwtMRKPqAfD3jj5WFJHaiiYU7cXq7OXQxIkH+QysvL+0bNrfduI2SmbrPxOlA4nmKMjQHw93NJ7ISQg5EWvpy45Voggo3j6cPZV9hjNn6C7RO9NA2vZJtqYtUuQX8id6TR7Bbm0tB/1O+5hN0/PdVIC2Gt+TA8i7wS8F/RaF34wU39mAP0VGOgfXyymZYSdIVVcKOgIBgcH8C8q46SXPiE24C3mrJ2Ikcr05iunMjS7/6bFIfboyKyvSmJbcyuO8R0a0VFG1JRpGVnWTmOYs6VqvbZgSlp5k6Iezunokx7SxbKwfO8de8k6MK+PFemiCWIGT702UaEALtEH7dEY3BOS4r7u22piDMLDSO/2FG+OpM3BhAkudGIKfpDK35mt1rv/f19XqmttqdtY8Wsupln8ttTOchYJzXVKrttZm76rv+Y31k+aEyaqVtX1rR2VIJmR+GsloOf8LeRkDQ3HE553AOnE9rLNnvNS3+6Vm2IulIPHs6qrqRpgp592fziXOmnrb63XV652L8//1q7+j/u76x1bZwLdB9KbveGRN20KUO2sabPcevFUNG72Whvsb9lX/cLDplrQD7UfHNBpCzoRG07GoqrLR+kbNjfY1OtnoK31SY2XjC9wFKRRSzlr+ZDfHtBdmmu98V1iPBjf5JTFJTaaejwVhZZY+W9HxYY7kfB3ESzswoUQh8ZCESv5c13p3cf9T8YK3ft76OO9XEkkeRgqSKq1W0lDYoup1pD2kU6RrpNdID8kvkTHl/PXkQnINuZ08/f90J/k4+TJ5DJVRNJSdVAE1Tr1Cc0kD/JqN0h7SlfQD9PsMPmM6Yz1zCrMV4cyEH9Jv07JGnjTO6mctYK2d8QzrD7bmv0gnew57Hfso+y77AfsvjjknybnBeZvzkDuJW87t5M7jruMeRplh7g3u29xz39WPPJJn4LXybvEZfDXfy6/iT+Nv5J/jj/G/EKQIYIFLUCXoFSwAdbBSWCd8KPxVtFPMFG+k4R+LH4n/lEglpjP+S/qSdIge7AVRBushJ9QMLYQ2Oeegt+jrMy2DZTZZOa0PwCL4RwQm3u6d6hAHUoy0IAuQjcgJZBR5rGAryhUJZEx/o5WK+0qg5CnpSkSJKUvQHrNOek75o4pS5YJzcp3K/xNWqPagWWXqDfyC1nEQAAgCABBvnV/6N4/XiNLaHvzXvDwFbtPyyX682H78k+c3LlXf+jMHXef6D+LqGflp8VogQY4SFVfMW1gyQ6C7ThL/K3bz/2InIxPLiSj/JfaH/w2CiJ3JCaHkdiPFAmjYhUoKHtM60Eu9t07Aa51fwn9/+JIYcmVgXnm5JjQkCTRpNa+zLN8wvy8XzDmLoPLAfabvFdPH238ttS0pTeC46JK36DigteT7rHRVeym825XfR4HuOT3dsBSWGo05M9a45r06TgtRxLTrGNO72Lx/IFM6x4AjshCshIJ6JoepT/H81gZb5ueDI0u43yhZe7LNK+3IFYYRi89xED0UJ+pbmaZbMaB9ZJmOaBGiSPvUQjxSjdk1nqpu3q31D5bAEu2TOMql8ZgslvoTHgNVNzGy0T7KvWCIxrBQIxJGwKo0gkSHS4uoQoNJtEINmNAkhY/YOocOLbI9+QEbIOc3oH0KoreJExED2tfuMawHyoRiRW+1y6jvgr1vdZz80DU3F5W3BtLmQYmogY4tMRFjRWSKmgQc0kpoR1fGyxnYK/F7/OGqGndKIgHeBet+2fmUWkTgOicYIi+5QBx+Wj93sN+4U47p8+fArgiocBZSq0SQvauLsG5oXWEIPSLfRQ1w4IkGTjGq8aHYOHXYyT6mBKEff1ORI7vJ7mrqtJj3/PT7ginFzyHPHbAL4rOHVt/t0WC7QcoRQZQXY1TUGRfVicW4SxzlxqJJAvE3tkSL67Vx8MSvNDl1TZ7Du+dh2VUesj0pzZ9LPFeALyzcYRd2de/irbhmUtXSnecvkte0of5waDsSCjJOCOar1fPLrncYJXm4MEIFo61mYEnRZWhWSqnJJIZ/bqainMjPejxnTEH6xqLaFQuRp6HXRjm+Z/yLS2F92TXYn3lbD4oVMZEpWiVgj6FsCJSV1/N38tfhL3Ab5JR5cfjs8EW5RbaLHqEc5O59mDrtmMlQH9kZAA/2ARk06J4yZ65jQLAkJevFGOif6ySxJwDbNgKcRNXlCBoicUxMDHJC9DMr6owWxQnEIk8WjQQshjll+PKHX1muiZLkv03j8njtaYriRrmvoRYnRFnO+Sq9SZjtdHqC5kwUOcxy9uqcmCz/ItM0j8vpDBA+runISd4CLdXOzg9TELI269BWoLZYIPIXl5Z7jr767Vy+rf2TH0ugj7m/WmQdxztum/fqPWYzG8sLSyBy9pQ+avP36rULiOqP1wwiOJYbCOI8rHa25l/ASUJ6USQvIMxDwDPBHqtiIs6c1gd8OTPp4bRrZF13CV8hC3R3v0LLI5KUKDShKZvOmf9/W5651swYemn3PthvSrM3ryK5acif1b8/n59J1vdi5P9SYzd6ZuvJZUDP77k2+QYvHhjYz45oQhDBfm7O3MpK0t1+/hWGAXXuLT65FbHdo+fHkvX86SF8qjS8FsdAyO25L7Pz4xvz4NTNCBZ8cVJMDHJUDHNKC2Ae5lXVdnkechWpnH+CQ+FlWsJbK+E0+qQagqSIFr9hwP7GGAkcvplHHr0RikKN06LGdOLIiIVYG9Q09Rt0hc8fJxuWCnatZInmVk7WxUR9Y+CHPzySP557gjPn6WjnPzHMnAAmgxB+tgilnCxdb8xSvRy3dR67zUb33216kRFRY7VFTPzDeWuxTE8GYM+BeaBlkizIKWUOsrlzjnic5+LZ/6PVmG1qOhDx/A7yxug3wff9fUDVZhKsHgIQQlwTE1lWRJojE5sVo0U9BFwW7TxNTLCmUZiJOZRxzWzkT4vsPNo81Q/YKk0LfquL8P02C+nBQ34pO6/znDtVvi+Dey/vyYmLqKNX7xVr8inUlL83V5FLvEpjXn5XmvSONoQIKPCbCGgz2yQeslfhu11w+YVvsBMRk+Tk5VMZdE/2nPiiLaiwp9m4F/ePd+P8EojMJ0gfFXgAHqfjTvnUF+3JKjyJjj2UXlFRByynk1ZTrZEHT3FMTkvVVxgkBwGgkNF3elA14Hnsby/qH/Pn2N9gRmd07oHbPPzB3TQX+vuFSfGGSfS0x+p7vYuDRgDTNWCwGODMGVmxPHybU9N1uwY09LOleaGzN6VlVId6j85R0fjgFth5OzcER7uLfwy41+XaT7Ufo4Dfqn3B8nCuPtoqQH4HLHdqfPQcJfm2CDoshIXjfsaZ7FYCF1T6IfawfHeAxe1J8HSbWb4LTJGNadM1FEUi1HPdGIy2zBTWrS5Czh/To8bQ7tJV26/2I/mpUozyvWG18UnnISDuajekmIlQBSq4UgSHWzw4aPVW5kz4Y058AAj4J4uku2kfyt6ZE47AEbJ/GTn6RldNSM8pxMLAJpYWtSgPpWM+oxa9M1CHEylaoKEHU714vKwmgxoOwpp2x7Zt8HiHNxoB+kS11U+Rz9rC0M1QCo140U/7sniprmB+wYLsS9gZCtpEJtPMoTVP+7VLoEreDnyb1hnA+l7DJumkNM+uJTbND1hGsscVFoogLuM12l0xQOOkI4k82bUi2NEBiqeCOy6QRBenxcC28xRgiV0hGYP8ZbFjKLq2AT8LOt74b0oOnOG/ghJvdLsYol3uzVEzBGUjSNBjmcR8Xg5IqjRr+sPHBrY1rtC6z4clTrQ2LXnRn7mMNb/IcJEE5VnoJZ+N48W4TXkfAajnWu3aQKpXXVhYqPCp7ajcyEZBbQuBuqFabpcncVlkOTCxeTFe1E7BuRCngStrC20uobhQ7cgY4evd64dsMDHQAlc1Bk44P5IdZz8a6eCZAByaPX+waFfp2wp4cu0CpX7RjhELL0UEkR0lVf473L0xP3l9lDtY1dlTIh4Sf28xYtuGzU/V8lV954VM9mplc1OaB17WPf+z+k+bZ/fmuc1sLg0v39lX6jqN+946+vHW6w+27gAKgeFxExgePu+4lbn3gTT+IMGyfvw+8BL6Sa70c1E/wA9/pdNi6R+ie+/gOFAWyED7+xjunWJF32dXX263QWGASEraNtlXW4brjg3a8yROhUwzcMUv0mZuiKmUI3rc7Mvh/57LfUB6gfjhkaQ/HblbLttDVYd+0zxZec8ShsDnAiE85vmdv32223XSLsGZCAfw4xhJrGdL43ACJ5LBSaGhFAv2WnqemWp6BF9Q42g0UUnPtnPNPkfgxMo0Hl5pEscxicegvs6zc82IinvuHR1WgBgaXq0t14fdhxWBhsUhTvHT9ojOkGJwgoLSQOpBUKTSMh3Dj42saK5ljjgu8ucLlQaxhphZaKJe48G6p76/smNM0VVO6QQNGMBd4NrmLDmAXcKy6QUzjl97OyN/rCoXYeAmOCgQwcQVkshzTWQ5PLF5Mc5F0cmGSDAQTVY0Bo/hYaQ4oD0XBOVq2D2yFOaiMOABqjmRjeoORZYi0OfoG23T9OMuxUhGnk332yqpQjrxvHSGYVvXVfR5IqG1FeZ8Da77EiBLsRAExcCbn22KsntunOvOHe6HPugTR4mKslVlpDGYAyYc6naNxO/NQXyKVqSO95u2vRE0jy1kRlTzgtjZ5pYD9OKOpo+jKAqNx3sL3Z3udHol5qRyDi0YqwSqmpWzdjGjrkX+VtvMOvfVvdsPPtSTbhdsC6BLtE2SOMJjt2qiz2Qg5JMFN02wppCgCWEmAoXeJLGO2rt7l7l4selMxyyUs4quNQVBTc9x1go3pxS2wBaCjhnlTGu3d6nRrqieBUoYNa43bLyJ1AruD4dZ4CXkXgI0HV3sVzO8NXE4tAZC8V/VUQDpsTncPgmlZLXY4fFq1WoUjR2taimwOILUoiTbO2z8F71JQjwsGgoMInmEKtngVrHq32tZ1ME5mDv32kJAQClRYcHQh/TEgvfDCljRaqzjJAOaiGu+Rg9qSVfQHbLS7kU0tkb2BEo+IGDsgDGACKzXwybySSimGmldMQlYNKKa5ogONDYt4bk0xs6LsT0KllMuz6Ie433o0M1UwDRrOWZYxsgDd7ytukvZRLBv2hxoERWQsUkSUc6LToYiykGjkF9jvFZHS+BozWYlpxK+iT9PRwdUdqXMSRZsVPmM2mvHwU+h7V2AlIC2dnwbcsGiYs6v8+gaMwJS8V8UdKR0jmiU7ty6c+efG9b9B/eer8vOPVEHTVqTaE0+I8w1nAfO0QTDZ6f7ueT2fomRIgnF+K2JAJLjcAbOHEQPkxtXTQ5ywau34kq9MLv9NwwaOB3CVdIthI1WaJD4dp8srPNsnSOh0Q8CAnAbmDL0szpo3PNOquoO096p2Cr8XxOjUTg4uYSzwZ8VZPPgLF7rD1fWqkwGCGUWv/P/J8RdfHzWpGFn2UXSqim4VnlAK9DvT8wipX+8I0CgGIQOEEFfcvqJ1+auZI5kZRsTyOSKNe6lVsMXSfrPHS6naWQpv7WZPZkMF3AgN2u4HLUv9IAcv9dD3KFfmKkNOMAOmOgNqWPoWoGhs8E3NHM5Hcy4bOfaThGZpypl0ov5nKvHve4xuNDd5XALeQSZ8t/BBn5CUfZ+Mb05mJuApXEWtz3OSSRWZrEXbQrLcSXbnWBUSe6Imx4WOYrPxvzTbp/eBB+Q+GAUDUHadwfHAaQyBJK9hYwgXIrFoTcJGhcDGiys/2G/XS5O8n1BvxjkrNNXhnr6alAXrZI4JObZWVSlEONcEJ1MaTpmYqaZwTp8L+9pEguG5Sa4WNVHfZQsj0TgIDYU9xKejMNBAYYebnhcL2NeY6JZyIuSMeI24wCs42EVpWm1Bgg78j+0YmmKMQcR8mGrQZmFTI1fweO5x6MXsG6WG/1AaHAR7B3HGmYaFWciib4Y9jFvOpoCdeEbHOcIw40pZ4YV295x4mqTdCvJNis6QWbAEgBCkQaPHdqR/EEvg0EX7a5pO05e4ugk7jF4u6rWCFluyA0ZKgLZFQChQca5qAy0reP2MIJWsmp2eFie7gdQVCyntJeOeNLRv7AQeO+aWhhs+zIWmdxxSeRFDpQBQr7xOO4gOhNy+x1uL7K+zOTx5egUIHxg+tAAweYoaYzdyrNEISHnEs8xrKQ5MzezE4dN6n6CqD5vDiHymAaUBmWc6zAv5PD2uI4XPxfRx93NVXq96BbqbgQLtrhEEmmGosk2TcYABkoLjrqBC+yIoMhOaN+Fqhl+KyDRVhSFrCUry6HJrDdtiGc7ha04G9fi0CuF0ubyy/7kLwP67NVV1zbIvtSbtXGtDe3tRCZ3MU1hXcQaxAsWShKDNgGJ8UloLK4EWuydHlD3yjlCPlZpDHYDJN/thkmcEYNsn1i4nXK//cSImxZonhUyyEkBXOG41gBKUaNIfBMbiyRII3SRJTHAhEagHe1l6RkPiEyatNV0py5m38wBSOGbrzN33GMKvKBJwd0E8XG9UXLmvBet93SBE12SWc908jRCr8edCIPZdsa5ufL/rdo7f3Z2v3x08MK3BwjE++mvQhAfuJntWm3yYfi8yy0DYc782X77QX8+a/a/gBi/BYSdDOvs/tXd++oxoY+GiTtRtP3+5YXQ0tzpSeYhb7pdOhJkDSEzhi0Cf1kO7al+Na3VQdo0TYVMer4ksPIyz5Md8J5xoUtcUl9ZtMvC3MxpFylw35cnCBq09RtAT5P1gSuByzFN3Y9gIWhPgl+2XQWPuYB710mdHVGehRLsw/4FfXP1JliGGpEU0W01ozI3oUQTTXkfk2DVuEsHx8BlxraHAp3OIig4PyCTHOAAr4oflO1oc0BZSA4VvtFslfByp2+234Sp28VqyXSiBpKOPMXwStLAZ07buV2hjcb5Rq8QRUgOZM2bbiqVtaa6HCfoQKrynoXs3Khds82pBaVNUurMOnFgCEMLikO6Hs/QFDUMZVeBnR5r7G0E5CzFbCwtMc+qeLoorNfWdAvGfjY11KqObORDi7rqkBDJczLa9zCiwuDei1i8huFdF8RpkugJl7ABG6ra7vlcawMsaj0HoL6mfM20l+7RI+Ho0cv8LvtkIPOACz/+NwKkuq5Hzdt23nbY+g5dil1Cv8KKFG1cmzTecpZBDLBnkcRoVPQNtCeLqrGX5ddj4QLPPhl5bC6BQD2Ytmsld/9969GHjhxL5H4EwkK8TO7PgEZM4iy+XIKgz30aYV6c8xXphNjrvCyfgPQcIN00TO8qvZhGyH/qpA/J0ZZ39AkopupFz5O+WkZYMvfJP2n7mOahCsbcJ6pVwtlw4tjBmrgOhCL6+IwCQa/VamQwONqeZpsG0pFhkSexIpKsiTg3TGxaHC/qo+Aq2PX5urvXIsuOZoE0sGFgee0Y9Hg4PzT+hf9PevX9e1DVAgf1PksoGANV2V7fCf4aujlNwYgbPgDuv61orSiAqa+Vd3x+fj7YM1Wra8FKJfQ4Op0lSdsKStXt9eGWbg4OM7iBBHQ/vpXC3XXw1tNFMWDeWT81IoD05GLf+ZHNn+VkOxFSJWuNyBWOTrwucjeFbJj/lYa2AAZbpOhT2JuQGF/7t186DPaw1zXJUPzdcOQHkFVEHFESuryyyLRVvVgcC/X/43sdupMtJ6VP4GY8FfDzpEd9SdMmmw6v/drjHo72bh7x9/LRbMBWtfVWL+PyiiOxtLacEw7VqrK+03SWMr6ijhM9wcFqnpBOKeOH5IQzccv37tx/+LxBcPrl2JAiKv9/+Hh9e+prUCadh5UcagyQHmjx9skXyTmLJRJKiVpwdlJffOI5RjCyoBRxe4nQQJpA90PK65zrPNVrJHpZkCayicSLEUt9q/mSoZn6tVLS0LNVc3TDKpTwgVXpRhhnZkl5LwsxIM1GfXH/UT2ds74oysLNoOMrQmMskUQ3p9ibz4JhUwFzaS5xvh8cLSwjKGAZUVAdLbVtjCyOOmAGOX6B1NiawNzyUsTJTQoLLY3Tvm4YmswQcY2w6owbOcSMXqlQgZrlcU8S6XXxbJxKSbPsZo4LrM29UhOikmzDnuBWWZxnyX7sWAeOAPhe6KAanyuH0DrSzEVeEFUr0ATB1E16NKJP4pbyEiJDYYRhLMM9DeZPU4OYr1xyoTbSUPxuei5YpID74D46uOOGjH1b6irWoteIRUHuI2EHyqOOci0x/fbhMdgTY3h7RtXvilu3zo/2r/b45iO6P1p+OOI1G+haN4JWU7qLmUlMcCZKPE1usXSurdKeWVsgrVn1TL1XjQgYDt5BmI5oleNank7Ua8vxaCkDxSLwkF0bvRhSFFhoJrIj33aCYHIpBp9oG245qjfYGId+0C/MXxEOb0GkeKlhn70VBulHA0tmge5bocNSrZdsmwbqUpu04zqWHXBeaDxezqej1h7xQqE6occeUxrEUuN6LZxzLvptgaPILRQ1S1XPrOvUlh+3w25zgqDZmDcKYiEdsNKAQLF09WwXB0cbZPChHlRFykuYNew5olQseo6TV3vCVOD4NHQ43VjONo/0FHeMYzCr/1/AhZYxC7Oa5RXuekXLrq5bTuqpLbrqVmew8JLWx9ojdOjA2rKfush3SSWVctn3PFuH8ULd6gxU7zlx5SrHbziSVxftdrnLa1OeO8l4FHnwTGBCgNAsyU7imm6uHameajPx2ngTIKVgigGQytRbtdmgkVfpKd5IRHSMFCW9ME8lGZuhBXjt0udr1VRlB1y7fgx0sZUpdaDVTvJecaFtwXbBzNXV7TIcjJNFQ9xNDLCtqEESS0VxCo6J9ZwSQ1wTWRY1P+ywfzYro3+bbL/kgU/jr/esUv0GvvdoAYheY9QBFGGE+yZ0fh2drB3WRvHjs7/qzof/hRo9GgqMv0/06hVl48b236fUo6UGwLxGHsi7g81nuVTVxg5scbPaoL4JH7hXHT669z1QiX7TdfoNl+rD6E1m7YWlaLjfBS4RIidCu/0LN3yX2kfUAV5GeO50qT1uGEuZNZ4yRgFjIbOrWSQJfuVv10tij6Hmh9dLSvn8Jbzn5df1CweMMvHvtXq9JzpWWy36GPbz50hi+lpQKgbz4rY/q1Q6//XgwsIU2jRgjgZNXmNdpNin1XBUIMuBAQzR92TBVY6QzDMk2W+c0eSg+7/tVu9Eo895yXK01WGua/TyOtASGw/KcUloWu+0AH7qkmPZsr6wuW6hUovLrxMjZthhj5EhyQUpb3uBHy8sFsq16O1yFFIzoshLMtlg8Y2+7C2vAx1h8qBcWaMGpchHA/JhU54sW+0/2OU50cV5WjwzB/pyp3LHN7yz4/atK8eP/r2uurWj59C+5sSVlefPL1SGGDxz7s2Xu4S73FbwGGYDHtw1o7ORmgePQJpt4eIx9B1l4bgngXLBMbM27Jk3a8rYyXj2ffv6+tf2MRHc5bQC/NJEv36M0tsMdAePZJBchYelsDSWdD4432vpp4Nad/iwOX+WKO4+7pHc1vknQWXx+obN2yfbR7v3IG9uP8ERN9YedhofFNetyRYzcEDAPo72fqLL4kdHcW1S0tNlQkxrYUnz9PF9s9YvfLjrRo82SzK0tmUOTh6hMfM27avO7etXLVkyb/o8HEhzeCGMk5HmOP3m+cBB3ZqWzg18DT+Xe3CnBcCv540hpSrCtAw3EDIVstzQhvoStcgbrWf+K2qi0XNFGQva9v826BPEn4xkE2saKrkwXr6GEEkt7x6UOm+Av6ezZ3grN9exQCgcNpvBonjBIFeTsFShPsHQZ5ACGTH/s5/VwhQZ6okShGF9Qr97wz/a2eBJm//q2LOnpxf2zP59OZT5XHE2RbRZHxt4rcr+OshgkV6k94RbbbbfVMp46H94kSVKjsbvlDV3lxaHCwrycZA6o/cvcU/nUqqwEzl2GYJ51013IQ52wi6LLfXFVgPSph2X4nSlpqZK1Bn0Bm6mfktgKdJlFJYBbB3Q6WMljPCaJmtcTAJMQ8GY0xe32YCILI+dapZssSupiipZ1NHGm7TlJGZP0k03kv6nR3iHnTrW6SpxCrWAL3SgmCsbITKKVPtrRaMARDeIsVtp2yasrDJPmKUduy8qwCKSL2zYtLRMw6tSVLHG9XoId029P0JKCFPieBKGDAusq5KRgO7qJgpZqLWkYs4NIEqjZxAn6HvN1kBWSPxFul4hdStdyT5PqzWeunDDJEAC1kbgaC4I+ppkAlB1YXbSfl9XlSY0XcJCdSDKGj5FghHWoyJWkSDnDOFmjemoE5CguHSxFrTmaiObqJoVkSV/K+PGoq2Oc8YWDpV8q1zsNOlMkVUJRdFj5AzLUPAZpprzYn+IlQkyfafYcERkqdsTZRRdCXULpVSslCR2ubipBoqhVbtUJ2txEUQH650gAscOoQnICJiLfqjYMMlzNfP5L6QjPLdLAGKXeO8Q4gQf/4NWn1Su08mutx0uACthpdWYDLpWKaqbLiTEdEjkBZZIwMyzZFqwvR5Ti9iI/L8FKw46C7r65nyR5qiMpyObalAnK1gu32y8oAuZ7LR0mWBtElY3LSc0CK1jCUqxEQeL5EZBfqcl5qJ5XqpklXq6Y3oaeeqalwJk0lXVP3Apd4F8DO9l9K2OftGZhPot3CrlBgcjh4OH/NfePoPjStICn4jdufWIF21HoCF4X0AaUWVUmatrwwCygaaNkBmQTFuuTQWWPJosDYSpyiIxgfO6lp4UI5am4rAWoPoWXn7Ow5yTB3TLQfuh01fdMH2DRJzi6weLb9pqBkMScTFiemzSlt/BHalEyOOynBc43OYyVgKxls8dvs6gRVBGcVKaKNG0WVPwYR8ARxM6QZPwT6p+JPfwrqBX6JeLWfIFOAuD0c+v0tP+G17fwuL1wm/DtYunwGINh5++fZcOtrFtLrTTtCXy9yk0J/GRdmXyGRRvCXl64k6vdpARh5JVOGrpRx4gjRRLpnkf1IZJulEmbT47TM7r5FdZ0ePdYY2QBrBoN8VaN58pcLD7UzcT6YzNcWvd2Wcyj9cliQAidqYTHSw86CJjO/78nGgZkXs9NWkmw+TPDHfFzU8oPM2Tc1ILQbCJaL9I8PCiJymxSDpB9cooKAkoX6C407Xbb1E6C0CeWv7vcSbIDrjFSJEVV1UOHjksgGvlyid3H8XQOdxvXRfLJyDTCUopchWejAMi4WRj602ks/hsPfNHaUEtrTWbn+MoPI6fDh7FjgVPMiiF98KuC0IRQ1t038EN7g9IbXSLMK7d1SLxSKfTg/M7PFoiChzn3257k6XS1A23hhu5G/ETzCmteOOK2kEKjlYrgWN3MRmhBGTfRSoG1Roj9ClKJoJAVSa5w9EEIEELpMA4bedITSZQDjEgg9AB/1HBRU/3+pC4Lid4xXWXeG8RquFK6aJI4/JShjdvvXGQEgXRtTY339SE1Uht0iIlBjsuCCnt6VgEgbXMJj6amBrCBAlsbx044hKCKCYRyAfDg3uzUzfptHKODJLMrHcY5mxFlXypDVqbHVtq+8nLc5GCbrR5i8gYtNEKORbYPFBFVg4qxd5aIYJGa9WZOIYlu7xZmlQrkxw8zSKw0a2UuGkBAzFb3d/cqXVRQnMzMEMQssFmkROuy/i18cGo0RpRy/8d11luecyg1JKxwgaPHhFmbLHbGOtiffdI32ExLDb9EFjcEptONrlEM9kkWQmW0alQpNB33fy8XYmbkSFm4IttiehGIri5Zo2qC5q+6etG5JoCPSa6axqHQgUUEbpjWKq/RAPmqRJksagSR6SYgj6jDQpL+SvznLnvXythWhQzEeLPj5r+bOOBXzDCMTNZh64DOggymeeaAP3m/GAN0UjuugvTPAD4BvqdSQAZNnd4AkDIqsa0cVP8OQTDl1lFr+lS7ZH0M4vcTn4FKKelZjPvbOqCUZ1mErGPm7CD6tpTiHxF6HFoN0IoFa0OBfPyOpmGl6wwaXINfPbLufCODgRVknkbiSYhd+9SDrbjlTDwNgtZqQBth1hoHCo6LM353TqBd/dBC0TIF6koxGNtnxkkDGKj6El4kxcdsx5Ffc80PitzZytnodLqLAzltvIdaTThGCwoHkYF3NuW2eS+Boai5XMYfH6GRdqD//wdGjj+Axh9ZnWHG+9i2DKSS/fAn3XIN0Ha0+mLmlZ8l61te0Y7vjwA/Q9tkh3+QkJ8Fp8UDV2nZOI0DFm1KS9R2sdm3vNMo7JRFEfSgZeHPL8IdcPrNYH+1dYiHAfobGU8aYA5NVhh0JZmjY140LwwZFkj76o8y2nYEx1F0T0tN25UcPn2QZ6/cHBfdvESKQNjeCAIxVIY1B0MCO1EXYfTCbHUXGjvxwKKURTMFoxR39cNW/HCES04r3KRTJIj2YkDAQ/KQhDAlcgVab/xiTVzIcGmY0bItqANjdhKaBc4VoEQW1VeZfbg1YIL1kIpdcZpM/a9yDUhn5NBaYths65NCdjSy7NYquzmZEqXnKdKhrraj3DGyqOfBJibSAsK+jYCcz8qhW6F0OLnz0Wf1pxjJiARgDscfrKApFtx/sYV6Fx9sGXloA7SPDySQMoLtSzVSKBnHikvHE+nqS7KDo5AwDHxH37yyJPFaRQaVMsH1fWrsy1XebwF8IBnT2UzP1tdUYqG6r0614NFoeA/N/xl+aq2K2hC9I3H5/FdNWyC/s8ja/kHTnYARJqAvvLY33sxSJ4DqAF4/5Z4JwDY8/DH02cTv7mNwx5viTzQGjdNHBCClPLZ8qnxYxygPUX8z1v/xUsoADDBQzmBPBCHSqPHxmwy/ATWG+sDgFbdwiaO5enZfPyscullpiGFQzAUMehl2aN/rgJWU34LAXXeBDGqgwqyTOC6hwWpTJIxLNNn1RpTSDw9GtJOlgmKEyf0CVMpwrGCrMiD7isqmGpy7kqkjAK11hKxquqek58UC1IwWmaWvQeU4TUt+LXi+GBve5O++84K2ed3n7C9zpBBcIIMNePXu38p/EjKudeANIqUR5iI0rTQEx8DdSlo4VTmSLW6FbykmRadrY9wbBVhy4oVOkJTRI41DtinDPhJUfntbGhEE+SoYctVFDo5AX6kdZQ4lmNDtY7rIarqrj/V0+yta17uAXpp5W46twP1jR9a6bUTsHKc0ITPrQK0stbPFVI3MsAY6fiiFhyJ/GUFV0nftNPblkNTLk+j/hTfT9kyX6D9LIcC57h9BOgryqQPZjvIa0ult2K8hVS5EYvK/uDalQ3N79g6eoZSVXmoKDy/S93pVpf4h0CMR7Q+zzxWOJJDpumhGnJV7sRrWW9mHL6l+40ZI+gB7/tV5j6Ufy3lmExL95E0SS8wp6o3IHLgGClZbruPyFXEM0J4Fbkqd8aPhhJK+FbNSbCBLYGY+msX1AG/kwoZt65wIOlhpJrdNOfrvyF/8ZpfwD0Mpe/KOVj0CDA9s0JJkYGQvoLOOX/Tl79HId8CKU8++jEdCe4LCwV6C6j4yWzjFPtnXeYzl7D1UGz3l478dwM7e01AGaow32fmCTSdXaulD7fBVRJS4OunA5hcLqBIZ9U07R4CtHCm7hImNbqHA+OaeV6mPvELNgigZ/+EgrrFqZ9eQg/rdYCX1o8ShtLf3m9g/cG36vfvgTJSCFccKoPJUMGmCZyTsCPxshSJUM596ndiNOH0FYBM3tREgz56Uq+AkqRUHr/T2XCf6f0nPdVSpFgF+p9GtbymUr01QmXtiEPTOK9GKSLgipPCWzkpE6soO0Sa+DQp8CbM9+I0hTZKI6nQmwe9p7IQWgE/075UTooRQ2SkLlbqJi0OK7NYu419pIbiZgiG4pVrrzhiKXJz4hW2sYe5Ytu0xYxCM7SwuDPmGYoy/XafwBajSRQJ0yoWhFartvjhLIFhhKZMtcoGPnDE9N18PeBlvkd2kt44wmFnac7KYVFAK7E8tAuMbmV159suzA1HjmezidAfKYhvNm6zJHcMur1ed3DRYsGQDfC8NO/kcpEv6fVy33JhF7vbzdZt1yt2yU1WnMSkaB/hOIUMNCKUEkGlw2o0Gm10XH7L2n3Lrk02nA8eTqLNjRKDQmQ7m9z16tMw3c2PiE6ajT1OF/sYrvtZPTB+a0+L0SZLZKePPEoDLH3oLeU7L9KvnpzCZYKV3fIqh888PuVt+ET7pTZ24/wAQ5B3uvxsAO7OiC1U2vXpTPog+DHD+HkGB+9OSz9edugDYHvAoRlVsae093zkfNMHO/vDsInyNc70Or1/9acTaxHr3oegdwbfw5iC7/YWLldf8klMjwLXGTIsPVYkdP1s6eiHf4me3oihgcG8wcAM30HpHwMiv32fbQMuqD7GE8+Xff/DcGcGnb6t/OOLtEgwmbFDjzk9uwm3K51M8A6AW8f1/wP4MMbLv9TYGOldast34eZ3996ExpmJpUfbwq0LH87jidz9c3MjoWwxd7vfJ4rJzrBgtsKjKfxdYxeqUQ8Pilf618fjP/xnS/c/vaqhesax/B44/RqwrxRVPyvS8ybuOXeu2cv63MeZfbSd8c8NjFCjBSEIp5b17iY3Z8zw8VR/WFIQunl6R6Zo+9aMYlZ9ktF8TInX/Ph3QgSEzeZbOzMXcxu//Wv3/iKCCUyMf7ukLLusPi8DGIRcyvjNV4sQE/C/Xc2V0fogZ/IvmxW/5NR7V6zs7l65ohNaZhyPFZ+s/Xsutl1LxrwVQ4WesWxxUtLiZUMhaVbTUvNLcGKUwuxZSjnvH7zKXjdRvx9qF9rXGJYbEscg2Y1V2nWncQWUbI4iGIic0rgVOPJ824dllSGR6MRDwbCfWwSt+24/b7DT6gC/lx1wBdACAWa7lbkOMaJohseKq8xwM0dcSKWt8xWQP7e/1cqIRV6wraxkGkw94+ncE5pYMPXXUseYpgdqpOURteyWihRojPNYbqCBR44RZV1TT4ehZqq9A1s/QpYyYjByjdOqUHwocAjjrt5LJGPSTaAek7Fym0G55+l6WaeBgOUjlMZ4jKYlqWBNUyWyE+G0LTHn7QhZLTlSX65YCfL4fBc5IgmVbla/ARYPbJ/3/RLkmreXIjEj77RZwE9a3Whp/uEO3BHTW/Y4mJXWlmSKPFPfruIaPlyDCBcNZzmHeIEjq//L8LGc9vC/XcFw9b89OlU2iUEHrQSrKdOJMyOShQzaX/KTKNacNJQWOUbUTVNMif1k8SqM0BImBme3i9MAamR6lJZrridXZ5s+LuSlFQNpwh1rv4mIgeO9RgYpUY2NR3QiquOnK0DykxAEXGobC1XlEp5sTILu2YiTjQqUyLpwDEkQtEk6bvIteiJOaqcPl1y/UA6wsCJH8f/u4pBfZwe9ZyEH43ddIG6nagdPw9MpmXv23P3QINBYeiJ5DMydvzhjKGWKrmey2O+uwzuHROkfNO++ElIKUt4dDgec1ZdYf5KW++2zevl/7iccLfgx/CQIqzyZqTzvhpUi+k4prIUV3zVkUaSIfxXqSJ9szfs5qwiop2tdN0w3YBZQmFxR7yvTtlPylhd13jSXdCZpG1FOixkPm8TPNjwBqY8g7WkAhGzOgFRw6HhgWGHtwLZHwdKHYEwbh9Uw5tVSqcxd+WztD7Gjvbl29x23vRnYeAMP+SAOTf+EaYP5GZ2R3XZnj6AEqKGSsQAVK/lPs/Lp7BkJyQRRkgWGSCkBdZ6p8Gkd0ZubEsf27///qSpYMyJ1bq4JLGq/e1JnrnMQ9qXkvPTjwRIuOa7PcKOU8aHB+GiZzPqVSt8BO6fqCRzOaweze9YNFEPWk+L5YP5dl4bbbP6btpcG0oxZ/mmB9+8Bd0wn7FUWjm0a/3joOiD7YYJx9s5/vpSJNXbQjn/AaHbgIqmdrKZw1vpgQOJxUPsawkJE5Z/oTQ0OH30/MgT8sW5NE6kUaANd0bKzp4E7UcsIwVX7WgAwUTkfannjrNHCWBy3UQ5XYg2xlURsn3G0UibHzlfeLE568nIFJhoA4QzuxaxUNdn4jeFbwKSXceJY41osNoUgApSHoHWo5T4yXdWfWKxkn+RPxISsTYLVj78yJDtUsRXz5cqcOoNiu387irz5SroWlESQMAadNsB5RSKlr90ZiSAARzN9vgNM+lCgauu9RmRfohhOK7Gojh86r3jOBLA5FBEkiHSdl04JzacQKq3cGceRLuhkOBQDdSwhS7+n6IwM1se+r6EQTYH9DMBICWE3UITO51mWBzRZcEZvMYyWLpfTW5cQkepUj+oon47A+rZWFcSMEH/pgM4TluX6QQcI9agwztdlpFZ/rzW7ZnMR1kQHbYA5D2dG1j+B5ZWXn51k1xgdjb5aBdRXCPyTfkGz/qZhDMhe57VNq+mvrtX2YLnnFAz2vI+foxD12DXXP3lSg41sWwc6V+aXmjXLa179hi5nPIE1M9MjvvP/c74/77311EvyP5wCf/RL93222v9ndik8O5OFiXu44yAd+4SPgqD8+8zOBbZHH1CZEYl5HfC1ho/vAq3ocA7OGSOXwDJZlgsJGK3qXm18fI2RDFwKI2enTlS5Bn3d74MIR+eDepaBCmRDjnEsLFZJ2t3Lpzh5Fp4k+4oGKfJdkUGRC9YTGsYoWg+kjRwpZ3RxxDnRPU6QS25hncbQcrnJ4i1LMJce1Y7oiXEWqw0hcOnAqyxqFgxD+X2sTZqmLBdbTJrSJL3yqfFI23yiu7Eq078aWtb/qGVjq00G8jmchUt6fN3YtJ7oVTghqbvegTHu2o0YKHRiQ/OKF4p4xKWbebcCarMCSfFvpIoLTEsPKGmNpvSrmtU9Y0fwiYCCWM6pJUdioe4E0jTInH8u+X5w5IyZFiRDl/oHJouMDO2VudPvCn2fPa6kosNhOKxDQ6dZss0EpmBtKhAnc925xiXFkmiA63WGuddgPphOtUbUNA34qOf3TpeRx6dKpQMumWiOstr5Ta2iMtIbQTMhp9z8wT49HI7Iev1mX02sFFitCexO+WW0UMFk6DUxhGhSFYehqraqSj9+I8qHFNWnnr5ayTGQ5WCwgRmjldIIRh/IPVOcplZaW5eDVo1CtRL47baUsHITQDA0AVQ6SXCORulLTs/+f/GfPvhvxqvT6W/S+0n5xfznagGHvPh6fnmll7Q1jpJLU/3fXH4KDrLF7MM/SlI+lXp9sYc4bE7qqSPGvtg3CSM/wiB7djCZpdL9wXh2jDwosZT5Lpxmz6WOTpCza2PVvH34aWpwDN16FJo8PRfvJ7Z9tijvktYmbR0kRjH/NrhvRsYu2L7wNwLnm432oeK4KE1SygkN5UeBGDn9+BBFR1G6/cijxx89ilvHibtfX8SzjXOPzoLUz/zF+EYCA8OYmrSrku3ykS9Xjh9PVIMT8NRR+sVhMOeJeyKMR6bnHEh51TxO2vkz5UpfFatEoJRa/A78d4iJ7JHodhEUq2w97IzQImxhdYXdz4p8BbuUaVrqjdem+4K7lXTbJ6oNlgzBf5FyMDubTA0WRLLPtF52e36amaUHp9NzsG+tnpKrZxv9VUXqIEoksZFhZG+mncgYqgSXDsUDeajHo5KDYkRVb8Fl21DgGdIUbSUCuWMKMZegUSP1HkeMZBQZTvaO1FMFzyhm9gbsrsjYxxVKeeonQidwkZaHCb54eQw+OsFO1RlJib9afMX85y7KPCTe8PK6zvcn/J7/zTC03neBJexFK4MkCcHpVKsVxeqtaORRrEUyud/bLrHC5xRyHE6Xb92NVIRJEBzVD6zArTye6K+05k43q9slVuCm4LJi69Lb7nkyal/0lsPWJoZ74F67zZ7eFLwys0SOV1aUIVqWdlNH9Hm5j92jMSmTIJsVhDAuFEggOq8+W6CTMnpfnTSGXVE3IAwBbt05mWIgFM+Qihr56VIRUOpkGv4NrBBXD16A4q9HcswULddGxdgwsjRMkBdC6sdNhwKle3tdxIeQHIqQQ2SO66HctiykI9O2hcYt9Ma3poPRjqSGu6KAizWQUVTucrAeDXQ0iH3CNjgGNQrc7Q4xjig/L2ONQa06SgwnSFuNsvAFfGW3HgD3ZjFGnaBczGklhEa8ZSGNSqkM0fa4LMYXJ+XCyzQZoVme6yG1Kg/IISKVhNkY1VzUa11YgSAZwtF8wTMUbwBdFACixLRiyrxxfsAzpHsRdd10DnZ6QS6njSELOT+aUIriH9rHeujHEJOoWTN3LRpnjJxnTq7HIHJOFoMfvbvPFkimg2TTsKNG1JnBYqjHGWPMEZ0HsixRAwFNIgyGeh/pUYj6KrYlXJl6hSKjLFECK5VzSHKmSYufY9Igr4LRKGIj4XaOlARoBjYLxmRrgaIfnKia+5Y6J5LgvVHbLunlYTD0mcdt967z3WXceZMDVS/OE7aeiGW6R+f3kiDWoJ00zuDxQGFHglW0EKOGzii8+aLGaTBaxrv/mdeQSShZs5YebX/3UleLfI9djjsWy0bEmqQtCZ7oNBkKfKdre69qW4SA3AR3/xunaWmYMXpo+dx4L+gLYL2uTbbtneoB93j/14gnz7vuNftTG5t9Ydv/DSuYPzbGg7cRPz+gKE62DnfPLI7+Jof/Cb7+BfcCHtET40euchGYTKDU34CE9FbNesFmJ1Fu/dEqFna0wO+/0lxlv6d+v6jbHJ7lfoYPmwte0+pF2Hhe/ffVOfhH8zyzJTJezCbfDzwPT8bvseJ47HjficfddJgYxJ71IsNeDr8EBzhcMsui72XHRUnP2/pEdgXlxvDh4t4Fte5cXE5sgQf+vTdUtrwaXgPP4/aDIefXj/68ifdgUYiCRmjM7Nqcpkdo2h1VKqlYFJy10hvKov3jIaNt4VZz4kjM8P1e79zqo165bhTVN8i6uFqvb6cwAbmIkgJISOgKfWJIZDNczOwxyNBUVU83K2Vh0gcXEVuyTRIRREJsx4neTdKG5dlsWzn5/IZg6ShkYyp7Y00EtE1xZVKbxeWuQtJLXC5elrpkyiJGAUt6lnXhkiLrpKW838KQJBx5qzpzToeMzfqFYl2VzMY5cwc9CZWH1XjBsplE+aKztsaNIkRVDbwXx+0g4/OoZEW4FceROPncYrS8vKYr4ku8KECpSRSfiheei5GIKrNXErs68kbEoNt5avTy1NengrF3xplSTHsmyiATu4pp23fdQD/RsWwi74ce3nMHuUQ/VqwDIXRlcjeszU4xG7HcCaqlKhD4KV5RJGtOFmNiuWWwstdWov8Ech0lGOMsozJt/U7Z0ky+jjPBgjqSBM12jq11ZmknozArl0XkMqeN1ij9vis9ivRO3jHLGSM5b5gqt4sgcFhyKHAXHdwWkyMNyLQtSprqy5IVlro2rfx6an3/ebwMnd4kzQXvEXrgXYMyeco9NITGNvJgice5qr32TwP4xFtAeZ899ZLjbn+hbORfL/nd7HTko8U9Df1GyQJXYdLdiCJFegASX3GP571BgI94RcX4GMM80AWf/YBlUX9ihkPIzPUkpjIaN+YRvSKMYz0Uq1yzbVsM9jxH51L/cNGQAVqUipSWJX85FUJpLPZML3OFjc9KhPajUTow7wYfMiOMhhBUiVYiR7OO4yiHXUcwi10V2fK/P4Xp3PUPKEsN1TaO004HKXNFw/gE4NQcsghsX5PsKGQACfSlCXywO0V8sAy/G05OAvh+vJ8+uQwQWUQWbVVPNzJ6u0bxsNBbO4bMcbmF5qjmFDNeRuD2KSw1z89pCu3Z9cfr7azjugGjwkdFvViW+R5h6FGRdktJt6zwtJIX+Kyv8aqGu6rQ0+3kAwQsLoJjo3liCGuuIRLwJ/KqQL8gCDDGsFWnK0ZM4Fv+owjiGeBnT7OmmmI++Zd9rrO5seLUeAAswAAB/2PaxPwRnb31+s2Q+t300/kF3p1BEDYC9JpwZKMFFHPMtld/nrRe5y3ew9LiDEMSG9FOLXmSUkWf7FX4hDclgMqt/JukCRF50nxJD6Y8ji/TAUA/RMlNScpvSI35wpTj6kQOoNSp0sJzyTepNuIxHfFduheuxvbUU95SBhg7XYuLSKmSSY4/nGOl0jqgeJCWFEnhpWooMX3TCfioTD1HAncJsBtTg2unNcG4wgxqcOhyM5KW4ap9+qajKfhDUs90Qyqa9pt1ZKMpijnqre8ECX3ZXoh/rlVkn9GGTrNz2JcJc1xOwSkGZ6WELbbyW0hQRTRu+t8DEa74JdM/AKP/y1wUoMZPIvKFob4pTZD+kzqT4M/+V7EEFF5A0iDOD80Mm6bZEg2LCzJ1Bctytdo6vNLkYlRaBhg7XYuLSKmSKY99VBvL98hjTpUNEgJxfJ2ReZ+1mqLf7x9bhpNZJDmhk0k4s8Siw10C7AbVcgrKXBqY9embphlVCotg6UmhnfpO+T4H/thiSc/CGTRKRG9+9dYhIB8hs5MaD+V35QeZTjyJBaGJPREQOVGe3pWUcxEbc8vuZO4Pb0a60dvft8pt02b6zcAb0THSQfsksgq4ZLfgbBMEyFyQOGrudDLvxIFmN6sbgK9BXwTXRFmlwPTUis5Kzr3EL7snNb1i0nOKXNbTtwrrGE7i20o2x922pzhnHfBT5qeHIm8xxoIh+GNlRsE787Czh23Oc0wK2CXFPPZ7iFzD9SVEIC8ZfLQ1mhU39XGP64X1uIBauRfjPcxC2y3wdEJeJzrPw0S59Bx2WcFlJ/bEtVFUW6WG4N7GTejOgYwliSSKZzjEsVWW4FboanyDKma1hhrfgsqf+Mylh955Ajd6I+lNuZs42dg1DzvZt9fAYB65imxJFamLA/ptEEhBP3I/rQhbDiYEm2t9qDW8QEBzbACfA9aPyB33Yzx3/IRIr/wMbpH5mSxS8jCSS7ofBQGsmA1+BKw0+zGIc9JPACcnWxi5ScRMcV/0k0DnYz8FrLzws0CY7/1s4JShcK4r7wfJBDi18BGJjs6h7kS8uZetUqiU7GhzI9tT297a2M52d3f0Nva0skNKWlh9Uh7rM/nmDkfvUSbOyPd2fnWiCUHiie6t++rk9R1JJJRru0Vvg8T1vv63R5oneUk4vnFJSb3QzMb72q5ZqpYrlJxo9jiI4BmTGn2sB9P8QhoNWUWNi9ATQnuxxOnKjhRXeEf0XvSEVJ2Dvd5Ibf6qePtAY0OiLxmxJMnw1cYbDI7DJsOzq/Wt3i69tkESrPCOaOnUC/Xrc8kgqL9/fNiFKw==) format('woff2'); }
+@font-face {
+  font-family: 'Fraunces'; font-style: italic; font-weight: 100 900; font-display: swap;
+  src: url(data:font/woff2;base64,d09GMgABAAAAAZNEABMAAAACasgAAZLQAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGo1JG4GTHhyCDD9IVkFSjnAGYD9TVEFUgwYnbACDCi+BZBEICoGcXIGFGjCG6CwBNgIkA4QmC4IWAAQgBYpyByBbolxyA10BM5ibRfrTOaSS/KZQCgK4+78L2K3YzpNpLfzke50CuXmm3I5EmYkUR/n//99xLMZozW7NLqAKpKrIedV99ZLmYIhJszcMKvXx/SbMGQXVPzw4fFk3BBCOtcAw7UPGkS2mWBCJADfkZCe8IBdDHXduoGy4QGHUxm6aP0x1arwNjcIpOmUsqNkKAs5RiTCexAdViqDEDpOuGA5D1vebnajYYQvH54rPUzEY4iUcjji0ISKKQxjMu6MRrfT69YSJjLjgm/DwdAQTfqBgFiS+ziZmwqdvdRM1VwdRMvoR3MJWE9Zog08uFpcX8cridJHKLh15Xf8FFxsWkcjG5UcU7f6Vf81No0pqVSa8JGWVfGsTfbQV7AgGB6WBjdKIezHhyZ40gg0zDY7eXPCR0HEhzG5uFIfDcHdswYT/L9nFsD6VAcMLD8oqA7XJMOI6VsO6YOcUHD5U3+KEuZwHzz9xnWUmQZwPNIqfYmKHHUjtEjEsvwGfMJk1vj9VTvoywHbdECJlusjlc1Cn/0kGySAgy8Cx0yRN2xT4Qd7/h7wdzzcT5mhYbln/fLATjoBQHuC32T+wmiiJlAwRBclSRKREQAXEwpj2jJUuymWft92irrar3t2/ru12Fbvcn0FXm3+vhILIAgswxCCjBv6n6v8xJ26Spk07ajvgy9w9Avp//2u0XcZRAQNkAomPDgGJbUmm593d9vTPQ0go4CgAagCn2r/s2JZBwGzJ5jhAhRW3O97uAcKqx8Afj2HYrZA27D/gaW/KlInOmjRzB3fCUT3RPdA9O2f+H96t+v50z3jf6e4Zb68uM6oKCgqPOBYIJBAshARPwAO+97K7T1S+Vl2uOVO5Zd9ixtVMIlgvJ1rTdPIJX5j+kMAubJr4JSfuCzv/DuC22hgbYfXFR+YGYvRXtUXniMGoEgUMQND3vCquohigbXZ30CJpQYsYvRkR63RrI5J1ump/0e9clHOlbrMCE7FQBEXoAdzKovW7buXaE7F9sZ6TYWZ2a2fqQNAAIYGQQMRICKKB4DbDiK/MrLRd7Vbu7is6gJtW8EJt0ol24nf+svNnezVvzn1en1TWlioU0QQIRBFLELPw8KBHleHBqmB217J2mSzNsRbU+0M01f6HYFkrsc0BLF36GDDa3EeAHkGPy0kaxwGTLKAFGp7/3p+v50nf5hDLAUDUHYVKBizTpULci+DJVq/V3UMLR/ABUAR7MhBFcoShrWyfxpkjQo4QYCZ+s+ohZkQgEBKHOAkRk5Z02mVk3eqWZyJf5z57a3qj0mPS0wY88C3rf1NVXdVp8s7uvN0XYv5r8RjFwZhuBlApCBOiApsUx+Oi5vik+/7/35z/ZyY2GUgmSohgTXOzAnVem6aU7gEqz0TWvwZCucCltEG0CTGDuFTEX7liljf/NvN576BgwWt6YPsjYRs8feqcSHKVipAfsXmXhSNp6CIt6aB1ueVeumS5fzikSBE7RKSYTy9FXGbxQ0SKFLEiluUtS5cgWbIUyVIE3Jjdl8jAGuDfX6YpS7107I1D+/I8/0cqYMEBCJdS32vz/xXMaMSrBduXPnHSpaSiSdvYTt0Cnx7hAZqWJA3OVbUHQO6BhHx12t8I/fKFIoW8hMPFJG2Am9K0Q1TZgFW9BwkJXmAkFuHN258BOtdVL0UtSGuZN0UtrgH+xbXE1ZuAf/7XtPcnaTMpAtoVGtDo3jNVSw4QVRmWENKBGx0aD6dmcQkvQCVk0R8IdqESmGHHK9mSZ6ZW7B9LiTJOOpr/+X7Tgl9m769CAw0xIl5RH2BFfU6/792niNU1u5G2sQszVE5YT8DQavv+Ur/W/ZBvPh7WJON5tLqrwVZBEtKQJwOPx+H/v3t9PTt9ZtLatQAGsCuFSsNSMbE8gSeY5fUT/7831Wz/w3LlBXVhVxQ9WEfAN7gQyaKjdDqnXLoqdv/f/LEMIKnbIOrA4DOCZCMogCDPQxDSmBR1KVYOMQAKM6CkmWNwuBAiHUMbYqzsonJdhi7FonFRVal0Ubp02dj/3ky/cvOA5O9Ed8dEYn4biZEXIx9HJnsMhyOUJx1TmkCBf7qqkuwuFvl/l2j2FAr804VCi0QWOZPIGiWEpdQKfTPx2fsq6zP2IavFQ2FForCMThbbSJIr2JyVSnjuGuYa5ihp7a63prGGuaY5//+c9TZZ7AKQW0nCkCKya/z2Zl5vKU05p5PJMiqg15vwcNtlcvSJhTYv/e4rIvmh/35vzU7vIaVXj2BZ6XFiwmdS1yVJbq1QpGAUWoHwDotpSjOLFvwphigKxmtFRlhWvu6K8orqtzQ1Pcs7KU2IDINWFIbQCQojMHSJQCg+nSGXK707l/JON3X953MWEPe7qgIWBAQErKqAAIMAA4NRZWAQEHB33X4oIlDn7L1kQb9UA6IZJ30+5qx3wLlSM7+0XOvZ3pNsGIhBRFCadJlCaWqU/3awTVu6cKK82pnhFsxDBatDrY4yjaBudjHg538BkMtvK1D0PdAAXGReRbOM7WRwQpcdxQQ3glhJnCYctI1SntCtMUdFsFQXHfyUGuksh89N0jyn0HVgJ20SmR/jJkI30AWctjmJFdqpgIpRJXfgFBI+Iz/1/Ctv9p8N3+MqGll0stn5EkKs6m3SXvsf0hx70untOZddXWi9dzO/LcZvXNkH8EUfigqrI4ZzLcE9PzcC2Y3256tV21BFNUcBBfMbbkpYdS/r51NxbbJkL7JXZLAB0BOM3FkxcC1+0zRtkZkGP9Os8zSbE6du3PB+8M+anv1ir+RSSzm+GRgUUqCIkaNGH6Ea6zdrqjVR4qR70f7u8yGuI44s9vkkVWjoBov/AA2SsOmsNmrl+kyFUsrrEwwplBJA3q1y4s7bMFmo+P2Fk6xn+0DqJXvR98F/v41iEIxc7zCBvp7mKRLVBht6po3ej4HHylIGisw11VRcWUxDQcVpGmTyNpVUjVb1AZw9zVFd4+bgORDUAyT2LdXFESulHFkF9IZBWIF3HTGvF4bWphBwWeJm8+bcNDnlnaySmv6ZAb1TTmAcgFWviEIKkapYxBTDqhgRdbiqxmrX7+uaUsK9UHj1IX2hC+O0tC7PTW67IuFV0u6ii2tg3m/Bs0Y4cTATJJO4E0CrYz/HgCpTnFDDAej1kIJIpTyR30ranNtWciiF0pv9fn1usRrqLYGEvqh/cJzkwZsV0xg1G/k7A02H/UfilnIFQxChtyKNABqcHOOhzsNMkl+3RLFNLRst6dWD3G+gLSVbSd0mPTjK9x1BMUYncws3pNuEw67xezMPXp0r/dyU1IqlpguKY2it6ZoDLxqwbTKGdUotJ57X50+Pqbu7V3JTjux6bCSFbmDovawjjkjvYTZGM7NxKln8yaxuTKJUOnu15XtnRxHVlzdJlpACyioN28AqmWQbCW5aNVVl6SyaT76fYXbg1E1uhoKE8+Z7WbHbY8QauME8CNjB1xtDTHIb3hBSK5JD2DVIJ02qpji3V5C6RBOaLq5qmqrONIWtwYxtmoH1QTU4nGtWD5u6wTrSGA9HccEyqfhRG7hYSr9buqb5cP6qbnMu2BWzmkZnXjMN6DkoaLjIWc3Ixyke4v9JvpzOrl8UAztp/9DH4gMzj8vjxuc1GCNW/ConB+JG48F0DX+3/q281Hi9oKz1YZVdL+KBBmGY3fXiVi/fdH9+K1EyCHRHFpIzrkqZLpdF8xl7uizf6ZAjTyxMH7/88gsL08/Sblt34HFnXHrhnKOEyeQ6KGT38qv7JrD2US/BVhz2W//mdTIhXP7bIwJ+AvQ10N9AbvA6eB+s53RxBjkKLkMOavHO8D4EdlCqKB08Hv9zWT/KQqAKqJoLvxbgfBaMXBglJVKZXKF24NClR575+2YxwQwr3GhAI5rQDB9a4EcAQYQQRisiaEMcnUgCDAPRU2ECwDQPg+AQkQMBWCyROA/8EwCh4eFACZ8NGAc85QIM3pp7DZCrLsDXmIb6hQxuANTgwy3DYTSpwz0t8U/TJSfWMYKPoSv68K0xJlAw1tzYqBICNPWDguTB7DHtCQUkzcgVIQdVZuxrIk1+A9VB3KHGmTrTQEo11ZNR2ywx7qVdDVGGKWEuDDMLZ1gAMHGdZTqmwwS4GUogJIKDzuJNg5Kxm7M/oLnWeSBvDQLghEhMKGb3FN6MrwQoHPMMBscr+J5viUkO87NPhgBTRP+OaXo+X5gFTHxrgRSuHFMu+4oZMDJMK9sl+90RAl60x6JDl9ghVwGMz2wwB5hHmcemk2AShaNaBelfRbm6u0mqIBKXqAZDPGteKqwDXn7NklBND30AYzb8RE7eEBjCkwxMrEYEVrEtTlSJCIgKU8T8VrIbpi5K9Kzk7LiqxYzAUyEN+Q9sAqrr/BTIwzQNLUEQeHk85km/kSaahonkCKEYuFiCXatPt11ZyppDYT0jGl6dJbVE4IXPvN7xEGVulsXPRVjCJrzeIswxFgvn6YoYgTtMGOjuMeRryig7quVGJtHGFB0VRtXx35+plX4jhuyUepggQ0GYXKvzUGMHnNz01kiQMUb0OAPo+QrMzm51rh8zXDJ5D4q5+kqEM6k3GV1enM3lF67qnzm2pf0+Zca5gV3JZl6CDIWy5LX6WFbV5dZjttKT3bSWuVfKwsCDuFCKmXzcZbLe1kjOppU0S/Q8N+K5V3Aue3+XtSfFSTzS4O+xXt2pU+fruJlkvSdsqrK2LycbT6KrjynQZc+tnsUmZSPM4CXN1QA0UGhzpgJlvBmykqBiPUts0Q5KRbsRS2ajCbrykYy0pxbp5Bql9U2ulsn7Bi2ipZMCn6SGoy5nYI4Sp7GVGd+ckJwVXCthbQldkKFnfUUNbZCpXFffU4HdWTWoY9Pue/JaZlwuxXmbXsn0DCeZoxiQKfK3MN5M/tBL1e4QgfCQksti606zlA0rWcW9PVHSDDQ9OKN2sE31oiiMAorFnOcSVdON+qXLsSjCF0X45WtpHUk5DB55UY/qDkBVYhWZBoM/TXBh4y9o3kddnkWtjDfxgExgbfZCdYIGLRZW7iSqa/gTtOEehizCI6aDqjriR76OCU2xrwuMI5Jdco9zIUVKPk/H0dMpl7oJjdB1VjL3dAE6wcu63ibUNYnG111upBvbQ5Sm7K9kspGe7eS4j0q5U1ZEGASrey3PHQaBXaUHb9WTkc4f5kXaZ6XMrSKFxr5mPSNm5Ffz2pogsQjDhKsfT+m7rn+l0FwybdpixRlwkO1vXWsyN83RHu+YsuT+HuYLmQUnfSPBx6Nq8XASYMQs1W2++549SkrSV8iMbNmOOhu3gJbVyC4qAwCkq+FZjjprRDvXVh18BLVats5DpqfVOfckZeuH3GgbMrM32VFFm4B5op4YjcddfuQqKDqKFlGkSxKr2zTaLTtHdMeo3KI8bl5bwZVb51Usd8puvvaneWaDOiCZ7/wccUN28lO6PNvq94Mit3Z2VDnv6fuQD72owFHMBDuwY51yyLWg1bnVTdFk7IGnBcHn+SrN3J2LatTm9mNqkrq8YiNqNkJhbbo+GJAn/EwhpqJTs09mLug37cUtsLcB2HA/p8O9LIuy6bvtzwSEz9Hn7v9ILFegiFicFIRRpnkhmMMY7jzitj6URC6Uw53JibMrmMfBbsn+bFPEuoax95zCNvJht9FuDusZw+vemMzm3a/QKPxDSBPCG5zfBJmt0jrZlNt02xiZmXRViDci6Z4aJa4d9ZL9yZcTiGMcOuKnmGWdxUFxe+DRt7LhgjInJ9ZUruNQsbbnueZ4EWD8aQEovuqK7edTid1M4vaNgV1RxKn+BvDe1JwPoH7E/WniYWx/qnpS3J4XV83apR7m2Dlj9TfMiD0v0Ku+BA1OC4xl97lpX7W+KO3BsiFq0k3WkwI7Khm61Ri8Lzo/rTmdPQamhe5eXYCfPRRhO2Q10i90F9F4T9/mkkD0neUHO9fHc/r9DHH+8NnQmjq/YS39noDdvfQnQELdyCxSVe3JURrAaYv5V/XfMRALZkCwWPOZMQrDclQdvdYNZm0Ww7JEkOLBIfaAyOOkBE4D3ZN9ViKxc8R11BwivDNHQq4w1KEWz6fD6WRiozi5zEAVCtz6ATyVZc4xOtt9QjzwPh+1VWT5ATIyN8JBQxESUJ9PI0qkenjgooEtxO0E4mwRbDIshduagTPzhmBmyzi7ltEbg/s0KVfJkhyAqKdNaC1nPFWi4/DjkoisezdPbg/cSzkOD0rgxlvZQY0YD+kRtZlXMe6JMQU0bLGYFbZmzNoaMlViBiFXysRPoWFvv9wk1YpU0tQybdkKm8h5VJR779lEvcwafVkB7/B7gKQqs1F0y3xC7r19uK2nZBxDK7ufRrOdRW74XlvR0GKcNMOiJf3iu6eFiMQm4zytGVe2zHFLHq6reB6ssHXzbMZuvDaW8HFUnTt98JdcWpqIMebVaGs6P4kBUW8Q66m4t051A2qTpyPcsIUue+sjBbN8yvPkZEMRsXQfNH0PKMcHX+SCicsK8fs4rLsxdIxb4IA16Qo1k6lXVTjlbCLdy5wvqMtlrpL1Xf/pnbM6MS9zDdxsX8vGNILBt5WkvY0Ph5c/P5NwM+Ib4+gxjHF7sUx54nvesir9gHyvHMKLPxqAUA8eBQXsjmxD4xUwIvy0zdR6ShhZJPeFZd2Q8BiTK+7yx697pmi7/DOkOpYalOJNx02npL+r/cRroZej+N1ooflW4ReYOgeVj8zS83SEmZiL5gSYL5TrTTPfzGtNp++k1QxAlwvOxZ7u6/k5otKZGuULT4W8fetYyM8c+lOb9/f9FzmTllU3YlzsIXR0euZTltXIgusy5isUn7+gPAj9l0GVofsNPBk8+cUm+jIqHHchXJ7w9XtQhEjI3cqsu97XVXciGGPFRIb/exTj1SorwOYha/8JFG2vxB5Gd89t3tsmaduHdl1BUHsycXs38YdeqrfQD/2Yk0igN5w3kzPEyfN+LPC/QrFe9HQtckmIWp9dPt6mj+jPRj/EaczpYPyGsRnd0mZd+d+DavwrwVVC6E1EuQqno/jLU/xIav+pD7ZWI8kF7nbyQZcIPPZfe004+3IvRqzSTxNjKj4/Va4kz9zIAhiQQbL1loN+Jvp/sRKe4H8vSl43qRhn/Ebg+xf6PiRQgNCu7s+vzwPSb389JJCwsZJsGeS9+ar2h9f1Eu79v5n2zxH7L9/BtguHzBu7/UGekpl05qYLOBLP5g2u/n8PleoIZ3D3if7+F/JBElXQHZRbwkE5niTWnnH5L2Km8sqH/cld9+CQArglQoNEoUnU9AYpmC1h+hS/FSYFTVvwAeJBP6eW0lzXjkyQZj+YkrYIAOwCQNFyWI3he6gKcii1C7GIZ6YUMgwREywT0XRk+8/AJCyo1bn5L1WKW116uZjW7sld2Ob0Tzx14tSRYy+mcIbI2oF963EPiGqc0xfBHB1tCJqHb+5RxucKOmZiKQRgBordDOKBtikkpTge5Ib1gNbwG8TFtVxOw2yaboLKIKGYQyDjYBLyPVWgCLkexx7BkZISSEW1fxFOLL7EpQ8cFqTy6rbrtr4r6z8CsOXYzhXMn/ZNjX3VACx5jk5l0rAXN3r9/LbOUpzXrLpmObZPgYhGJViPSThrzhWww4Nl0iBgx8ZokJDwJ4JxK+ahpgpQYTMrSqlAHIIBgWLGhgLeMPIBQF9Om8Dp8SgETYijrYRqbCORkIKTmQLmXCcOLqeOxZIS5lCBqrxERGNIl2AQtDWfzIhpS1AiaUMR9QCgbSWCfRxd2TQ515pRNtIIoCJqTDt8ZpjI9gg5HYFs0QWXytqQE7Xlto+nQgMwE3QgjDNJAzdySATTMMSTCG1gJoSYEmwi0h3duJyqtCorTZR1zgH4IlYkUcYIG/Ok9BIhowGoi2RhB4bJ4KTRAmYLJdLZaFFMB8BX8Ylsuc8ScDCMqqKZSwGCCYC/GJsLoEZ0XLbwKy0ZXsn83VVHoq8TRyEtWRDxNhplQcFMZgjgqDBi3tBgXA27DhYrzngqiooLIQfT4fAK57OFIKqlBqAj5sMF5TQM0rEJ0hNNZIIo3QS4fcAAWBi6TRNXYExYicA4CU8KFkVmRrLGHHIOS0VaUIHy0ZWFx+qExA2AFvShQZasyunbpetx1RQaOmKzAivmUI42YWfLSAGcGmDSLleg7giAJSMvF9AmYoOgZQ4mLWcmlTHM9ABwc4jrQxdxgMWHEEHxlY0AyIqNTbCUkiCiwIoHWEBKAGoEQgBDHkzZsYREFKFDWhgh6bIUx0wArBxiFgI8wdTM9k7Mn7wwUtOF/sK59WoJSt+oZwKMHbbqPiCvlI1TMHgavPeRpcM/TMx9gg1mPonLpY8Cnz7mx8zHXWZzHHgwAm3db2udqUX1+alzT142vVuK/gBeDQBPg3NWSVe0W1FnGFvPMn3nbcPzZ8BHCFyXd/Ug8AoAEiq4s/EMoAMcL1bG31f/fQtnYK5ZH+Jqz6MXV4duQfW3qKK3MJysYN/q6f8T4T1WsUDvEQjAh8eYfVDdGNn68g7ma0Q+weGgvz2mh4sxjgMXa4EDHpt7/Dvzj9NsM/rP6q2C/QB8dDjvwam939qQP/ieZt9X1+eG/1X72tnUacG7R+Bquj2c/Ckfj/bKEH0Ob+ELXgFQHvO89t/QXHl9xIaEx/nk///cDXtsaarfycf2uJ7bz55kENP3ypthPpcbd+feI71oMzGNHRAhY3bWyy/VIgfMY9P03y/hh98zHdyyRszjnib99Z+cq9zz7JdvYwkvcFyzQczmXuH9p8c9zX9q0f+j5ZR93e3XmVNbQB8AdjCg1z3Xuun0N+xDST76+Ip5P0IVEBe0zL3qJ3Yc8KLmOVf/+C6buGhe7p+s3sel330oOftTQkH/3Z2iu4+TYHeJ7jpGsZ3fqvIcHSbv/V4Rf94YYZ/6D+/S2cuKwsi3NiwQfrEKvP22PwAIALo6Q7v5PdtuZtnK1zgyjpix4lFF+arag6ymA0O3s0e/93VWNddkiy19g4VKa9/AgReVVS3at911f/beukMntnD+FIeY+AEW7w45/uhBQfefPRQvSsSDejsdTyku0fe/z3WXJ/p0nn61nzKl3VzkitprWyuKO/KTJvm2i8Ps4pDnHv7+lz/pU9fWGMn8h9n46IsHDm7zccCY5fpscQvrGFsqbr9vh/XfOk9kqZxlE5OKKvf2kLnAXeV15uJHY/6rjxBRc43tvlLYLHcbF9PBT702dzxPcPInmJVH66c45VOM8WLtuK79j+MXnj6Fct0/EB9na/dyyReRHc/Mfi73Z/b14DPvxs4beVP9GT238ZdrVWX0lZzhTd4Y1rmbC73Fu7mB68iN/+25q2sF/gAThO2/X4Larv+9N7ZOfhy+Nuq1B2wS561dtXMPOHX/JnvtfPhHHyyv3HxWL84vP3mjAz/CuTJ7lwW1pw4qz13v8hY3kAsavxGL/2aXpVP+5Vvk2LX6SH55JwPi3GWjKfyw6itvDdgU2ZpD3i8QmzVyZYOz28bmortFeS9PUVDBN/1uX+c8CjxwffWvqgWz16Z96IsNc0OT+AW6+MHY8L7Avv0LE5tRLy4/fXfQYafIT7rPnu+w01PsTVfyrGGI37j9l6pgW7llr0/35axhO7vmzvSfKZUOzfr06GlkxX2N/oD2vTf14gJ7mG2xI7s3D3EvsC0Y155OA5xJdGgQgAAAoOxcNxsrv73R7zfnAkgAKl4HNNH1cdlloLpx4K89BcCzk+z9/rX8rQJRvs4dsNvbCFr+nEB75nwYZtvGM+ce1yNJtlNs7NgDmvYDMNN2pD8uoG5NdxJ5yPel+PNnw5+O1lc14Tde0AeOF74U7/x486rSproS5yaqziXwkPmw++effx4A8IaJDxk/uwbSLQtUAHnzp+g+7E4y9Maw65kvpD9ydVlimPz5T71V7OFi8g3so7nc0lSbAAVRsvX/ErPhc/Fc/Cq5pwUK6fZ90yfJEUDhbr1+eAAODmcToPAtrifbvR1C/7524RxveP0KqdvGDgEPEwtQDq94/VsmEhwEALvLVdbiC3X5oyNDcuVNlef2xPeZuE+03v6+9+R9OfX1pk/eriIMOhyt8sIOcYT0iT6VJachLu65PsHIoAyHKipb2qdLk+6ycpc/dvy8mDhNjnpOnPu6wyLSZg+6/lynb/ZMB27v7TlcbtNTX8jNXUl9T/r0feArHYUKF8l8Q0fpH76CmqnkBTfb3vYe7ZV06LB5pcMvslfS3476swXfvgS5GvGZT6XE58fJ0UqDKA/eJVMO2zM4Mnj19fc4BIBY/3i65gOm/vsF+yk5F6UeoxKA6UfOyteKWpaC8xjo9n8dizl6W1TYMNibPnMggONtqJEAoATHy4GhJ/2l54EAvj4XVUAw+OTf3RkgqBEP/Vk0H8ziduZyJYDj/UYAF0suiqgv1c/KDBfXtKGomokDdxsvaiKPXAJgGIApjJa/fO8qHIg6TsICRgRwYgs8AX4DBZkGcFRU8AkAowAX8fV8cBUNbAduB0DELGCF9gN0xTaugwq4EJyATKfxl4AOfv35rvjmdwMdWiV2JTT/H9BhaaBn+Ylrd4AU0w2wyUkvDQb4xbXB4xT8eYDbtmMjAxTbmO8D0I7VOrLIbuvjr538aV6fo0PLetaw8eSne22KjSD8OW/7ld/WSCyUI8W52mWZEwDXlpeA6MqPAsvv2lmhMLPKYbXwFFZ6HyYwEODmN5NhBdR15kCykLO8yRM9b7yv1k/qdyXFn+uvJUjIKqlp6YBYoXAObl6MhIyCkqb2QZjjQLJ1mpnDR7Deft+sn9bvmfhRqzI6cjSsbuFz3I63AFD4lACFhvhXhApvHThfhVJXnHXafU7Z5IjDjtpntx2W7PCN337gowd6MSvZt8K76XtD9IME799M34We+8KFS+mi9C5WNs3i9BrouBkYJUY8Laz3Flj10byDTgxGUzrfSqfnT0/d3mOv1c2kh7kPqJgpLHOEDS98+lwTGx1F63gBjMN3hppSk2mBC6f+mn4cIQsoAYAM2AeDxFCbIxA4BCIgk4lnA2hGQdH2xFImKLl3yppmA2i1fddkCB0CHZTwyHCfAze9oqLn+OAIEVz9P7tu+aWdXDP3xCgrADWYCB2ZtUEJKAzFpsQAhUAP63KZqxNQVNK1EBTXczVMVO9rwhimVHFyCIABik6TwQQEqkqaL5ZlpPLJev/hATl6sQfv66r1osRjX2CuYu8/6Wl97mx9RpP7neg77NVHFHf5/e1TeyvsvPRgQh3Q50REZmTyZBx9PY/IS+whcg350vc23kuCzw+/RWlWTGzdpN2vj/g/o/YgEPbUvVHFMRESIk5lydLtXdRh6vabSMRwEo9MZ+u5eckTb9wglQ4tLU3nhVq7OIYhdiHgCmRJCbLm8/k6YNxxQB9TomYCShppVycq78kLoB1lZGsDKAL871PpcNjVnmxFpEOqLK8VrQjRobu7Pg6UsKsok1XRPMxjQKgQwgTuCn6xTuwknF7118KlDaaSlUv6AZ7vNHVcMFMOJHBqXHremNBQSM/rGRr82Hup7mvWsPH5N4utLvK5JQXvhbzi3ZzO8ZeidOrGWJ7X+6YIXZuYTloRsRS07Q6IVbd2jbB0R4wbW9g4SSWVdRWUwIIUxsBCtYC8Vnm+NC8ObwwnCSa19xYSa5FvPx9XYOCWcd2FZ7amfaFE22O9hpW8eYCExO4rbNkpOUQZ8xPs/gOEXgmtE0rkjOK24JyNyTFDu2oafZTJYnd15nsrnE07JSb317B+YY1vZwxqgvxLafnAZ7UR663jicfNzZmRPuurBGDjG1Ir+5w+1gsUTCugrHG0eR88b46voqI/XB5HyjtQUIk9Dg08WBaBhKLRcCWxsruvqv8iREdjN6Jj5cvlwCBhrWhtFuzhSPnb+hqIeTq/6MSrRp5cxPxe1FSx4GMckFOrXxXdyk5pidGD1zOps1a5npz/azyqQwnEW6E+YW67q830POoQTQFJAKMmlQN837YbOFkyjiyR83jZlhxoZ2gInDxT1SmXbsRe6TxgpX+W9C9w1CrHV215+XinCP1MJhICRNr7Kn0I8mxOwlwbHBOQYxdtW1MQq8VnxygChLEonNg9EwRlyxLtyH+mOOOQ1vOwuTYLaLhEaUvqdqpU6EXYp31su20rsvYdYDTaTxy2RDpwDWgLuV1gOL4DpqLeYvHVxywpq21lxzyWsrQq58ieZqcQv6JTRzACbcfj5tC9oZ71nheGPuQTqZhOkt/T5xCJYbbu8S6xfDweaIHhajualEJAvav6wkfXcTIkECIfuxXSHNX8isuMSqSRyXWCt7gp4C+fz5QDPqdmIiW655lE72tKfoxNXvsIetmXcN6SOXpvDxLthfW1E46QTk8H5UIq+w5UvH9MhUHCfxcKQk0IIGf3VE044PfRn6TMdlbLgt4GK/l2xCE5s+1vA51HhTVjKbhlAjYCC5wh5Mi0MUPtni4FBlNhbp4k2luLSv+siUpPxz/6K1zGxzXjKYlObEwp+sC1hHxPQt8RArWiDInaS+fbRc3a9bxUVYSeISOTzYBB6wDvNid/Bc3MK5Yvd/yiSzAu2UHXrUqw1VWP8Hku9qXJvDj+GQ3ZgrzWyJhy5Nn8NbKdYCWZ7iGmnDSMYgpArbI1gZ7k9/sXxpgdFfS6GUtJrVxr0NZP2Mcip+AYQ2rihZ5dvkGdeatWpG4I6xwk455bFdvZp0oiCgQaNa11DMQb/xBUu0AeXX259ewrqE78/fVxhg5nmK2H3g5rxI7naKwmFNU6bhEPV3P8FzxuVhoNI3AirQxSTqmUPk11rWJcUscpEH/ztoc0Sg/KtTG4EJP0D0R+OI1ObFaSY0SBxuaKORNiXMKQOtVvXmZYcEZ+gG9JT68S9TyIHRhTVTuwolJAFBWoxR/cwbLEQloRV9eM5fcbiQFOiXndTfIiZNcRQ6gJlwABBDzbiIfB7zQ6nMqkRQVPLMFHQjllVxEqoS1bmxpGra6WnWJtUiUtJb3sGFZ5zU1AZtGLoyMvztgupzYwwA/lIXFHLHTDTEGpS4liea4GLv1D5cQI6qvKNtq1TLMGHkkeNyvOSQ5/J5IXGjGTJPYiaXHFSm1kjydOLaETKYE6IdaDBzi1XFSCG7LH8NJ81IdGsR+KtQcc7+KgG4qxoccchrOHkP/w+AcUbvl7qhvkXpn71WShfvO1jD7Jg2DPgeGdGIfcFIGojcfCAqhsop0K0dvTgpioeRkaffT/F0jiuzY9AscRtYuLVs8VaWEEXkj8RWAUHteHW3GJu1YAkOgcfaYrUjtEEeTUEf9GpVTuuRHQqhC68B0l5ooqok9K/ez8eXKXEEQfGG/IVWFF4fEPTvCtzKliDmDwZOiUGtSRosZRlveDD/Xl6uCQIaVGtfRtdxjxcl5yr5lQSV38oWnDWNec/skJCAfEDW9a9+4UVhmj9T3N1buSZ92aU+886rRpXg7FS+tCeFX8oWnzwqu2VjbK5bdgbP7ERoL1KGKzTzRKGpMLyqecZ4oMU2IRWGcGOIv2IFoi+5j6N15gPCRAY2HRH+Jn3Scur+m4lw3Vsc6bIZwX8EFNW74FnCHQmJV1sZ1n2B57e4JtNGHUNOHcppal5W18hSajFdXij6mPX46Jq4Vs1wV6WmBJgwu2Gut8bxc8PKCr1TBd1FXBX7yBYFjg3DWFoH4YU0pE730zMHfZZMwwlmSAWkLRFKGUVisIiRiZekB3K3+SNpCQXnOMQSu8m3vbWnRkjoZyZeIOmVFW5CbcVc6qn56O0lHex1LDjNG+KUxYa8Q86SHABiO9931euvc0Viej6VP0jSHlc+gtSIvYnCZWSJRFoQ4JWE9ORT8Y7t3tvUDf0XaORJcSx5R+4F3w/UO0y+OEXsJq6Ml+ZZdyqqPJaFOvDuJDDLnVdt84iBMSb2YdDwYgpw1SugVqrjPWtWs4uoFN7ieWDNWwM5rkxMeCbWPz/e+m0ZROs7VVFk+lLIy10W6OxpLgFOqhMTnFpni8s3an1W5LR9Vi/K4sRmikeacmPYV09EdOy7qajLPO86Qx5IhROTtYEjd7IM/CwVRmZ5jIIUSoIAIyWb/c0AZ5F26bH9sos7Tjup+cRFSr27eTmYNePtmwYxxLvuqXuaq6sTH4a06kc4IQRZXHu8hi/Wwkzsxpi0d05xTNSldV51P6uW4Lx9kHdKh/Pya94HPTGZCWPZCHd8o427h5BDGUh8lHdzCsZp4E3gpXRzXBIeT2kx++O1m6fx9KTnIZYkiprjJLT0o5cMbB/CrnKTvWdU6iDmSzsW5+smvTFu4aR+Sq4gTZr1ZTJp/mxXg5VndgX4Al28vqmttKEQ8J8HUlTeT9hVVo/Asep6DBdL6+Ig1VuN2kednGQWbKbR27HQFRk3yeY9j4Fgi0ngdSMfceoQpCHgc4DZFjmjd6gMlR9S5UtrjAYFvAoKSpFiuarbfvPedB5Gp1zismIA2wiIH+pEAqwsMtk7C432Bo24G6NqhwiJ1DsGzAbn8BKYt75Ffn3nMpvOg7EO8+C3txJ7rsrBzr+pl+XOKYL9at9/1tWNXRUqJVNchWvebJNoKlrJhDC/1w19EJ11g64XQ02xivOGRQfjWWF8hQ72HfulIJcV99GLsKa3wMXazRHXUV0caxQU1mSSHduY/eSomJh9xGabynjcV1l80YPicg+cSq9oQ4XuvwkFxgWJ+SnpaaOkPZzDuoqvDLf2WU28BhYnMexBmMeza/X/jgsLmMgN/XVA+54ryk2uGd7B9Lgar6Ti0PPzsTqOgrA4FaBOlhW7x06P4NUkd553KXygpKLfGRnql0CspxIMyaistfRwDRD0SQYEBXBH/sXRdZs3AZZVLjid5VBYh0fMHmlbetDOjiVHenuTiOC/vMpRjzeIOHZDb4mIVuBfa36haHVZv3XthBWSvdFwjbKe/zRmoclT29eYEurYRWTsrSpWEq2InqBHSX4MibZDvBNF70KoWV4YLmXSOiCMSVRt4dEw37uF3k8x4siZ90yuVQo/1ybBvSip7VBUoLL9r1XurookNZJLyuPlPugROAAR/B8pI+j0z9WHDonXxiMZsjVWWV0PnksoNyvg1utDn3u8k2SUOlnV3Z/L3TcGiW2nP7l7EUj6XS9hegr4BW/j7qHsiL5ZxSK0c7sBwiUha+FVeagMFoN1HOU2jZ1i+NxtWJnKS0S4JWsHXx2TAiA9oAaFGDq0dhpRRuv0lCkOwFa3o2xMTwb6MXy3CB0UBa+UVuI+qxsQdlo6JFr+eoXlvddqM6zzaOIsrpoVCR/6PPGrIqe7znOTEo9fRiRTtUW0Cue9JZinrXeffRzi6o7LhWMJAmpSwO1uk2KW2RE085Iez+TtSk5boBE53pOH1VVHsW3o7GBtm0fQvzazsMHi6x2XEFuXjseNzCCTfmuji0jjWCw2Fj5j/4/+e6LCuZf1gvqRU2ltXkvkvAl1Pybe30DB77UbGxZZLrTEfWvb/w9UcX3iYZE1rfliQDSRRQIogF2graCPw5hCiO3v07m04scMi1v0PHUXm3iistudpgbBYNvDlrO2g9aJwfQq5fn5AvdEx9DyPXFRYBfsfbDlEkzDHWNF1FIC5dF7+zK5/MwIah/f6+CBjS/6lvImI5mZ8qKDfGVGqt9tlnXkJ8VIW/ryC97vyX1OlNW68u9G4oaoOfNO0QqflfGJibe+tyyw8tWmHoO9mTrHGqBF0u+v5EYH1XEE7+FnBc+DSHp5QMXTnxZvXCQ6uPDkZwbxHH96z9oFqQ2qBFoN94mKK/MNNraDME6C1mP8mJQugL7BeGW5qVg/r4atdhNIn5EunNUHujJMlJtPFtnRuAF6nRfx28MdOUfPaIBY3RzxxjDBCZCJQgfV2mthAQlL8dXUf+iR15NHgF9z7S+OG/N6+b5u8b9/q961eijurIVNMrRCW5O/c9G545mlfmpK5H2dvRIdJU1WaagsRB1btLs9j2GoA8iJbxLCK08Z0sGLFCiRN2j5Wj0ccqYW6pzVO+93EEzsufB29E6p51VnZULXHnuRuZalx71wPbAtV/vrgX78y854YmEt1SnAbVeL/7vaY1oMLKZBNbtXcMMs07Lz0uPs7R4AnGyL4hx6g5xYn0SuNsq9gAKshCM5ZMFZ0SrbAFB0CusCHf8s7ovSS6pSgNZvH+8/uXQ5VgY5vc76bXTW+hMrka0UHBPuY4HttyylygK2SqjVdtqJEXzLPt+CEbLHMPe4Y9RZVjapvvj1cftOL/IsgkOoWZB4MTwf6U+l+oBS8rnxsxMg8QQtve0Fhpof1LRlw7ucfI7jpXOwHZ8eSvV5HDSEyDs6ODp7avdTTv8z5H9xIOoB6G2gwCD7XO+gLrgH/Ok1fCFBhRbvNWzPkKawFL9Zqd63tU6HtMA4LJ/BNEf8RO7EDqrv5zLOVNfBszs930xiviPiDvDf/tO/+UqkOQ/3FE8H9n4GgtN6qTth6y7WTu585zNPQ+XEeP6YBJHaiDU/52hOpFxyKSN0wFm87Z0zjTgt3crdRuVJkUNGkt+Mlbd9b/8s4fcV0ED4YcWZbBi7sQ+97mieij5xyA/6rQupFlAPKN1N/Cxmi3dVVABTEOWBj+sOYx4ij7lPCQ+CRvV1X3q+bSLYd//3Cqrz9hrfe0WCgmvJGhxeOpw1Rsl0wjtMH9b6/EZmhbWSOsIZoEVz/xTfMecfuSv836Iy4B1C9cP/YtZ+0NDOQ97mIjufCD5x3HOsjdwF2gq3DYHuMtBDGQRpAL7EssoTgc/8zGp4ev4a2HztMI9/G3V/Wjyk9cj3f/yCkYpcIRVMROSW2+lXtgeFt9diLqIQe7b/Jwr//3/XByC1HU2tabn1eAHvB5BE44X9jGeR24MZZwF2g36fKI9SDrIH8rbwtjoLJJav4w5yBDhYB8yzXQ/S08Z+0PiOSjd+nrWMOsafowgQNHEUvCn5d4KIKyyJyy+eBv6KrP8rN2s07aWpN1ekKruhSoB43+txTiSbN0fgE7xiESsYhkiWO8z4zI4PeSFkjz2F5Yo8z9YfW+WP1fsZRzIQQsLHVjNLl/yRiLnqsUVEow8mLzLNGubeI/If3V135bPgRZBZchVMjRIs+dkjWE2DROdeZZK8g/DixeNgNH9T86xmGXVra99PevND/b1IVAUPLt7XVOZdniDKQfOg6fR/BQQuC74ad+fBbDjnuetj+oHZLQi7qgHgIA5kVFVc7WmiN/oO9vbC/XcFvMhgGvxJ0B4oDUNrcpPDMPYZUMjm3XWltUm1QStULTpxujgO9a5GYo/7FszTU28rG8wOcH0wy9qi6Xa0yElbC95KMk40NM/P1lKSDqxFIfcK530zP2y83307edX/f1JblgL3gf6Fb84nMWRvTTZOWBv9/IrSoLrlpRg76t8+HXrK1YLPqyLhnnt2nebBUHZ1vu06dIfNwpI1Cr9QJozyY4ZuzsJezdOkL76spEomD6mtdM7FzZEDgKw8KHKxeNEVzJq9AYFjxAXmCOseYYaiJp7sTCIm8py2VM/sexXvg21oLWcsNUN76FQuNOCXbwtlT1omv4lps5BwNwBOU2lzV1RDu70vsysDTVfIoS84DffD7noqopU+sozCtqgL77LP6xN2JbcpsDFZZcQrHqfutkxBWIyVdMAs6zGrhk7I4/Gjesa5715RwqTZeUUcddNZK6NBiL76Pv4mraw26xrYFV2fmLQgdRkBd4y52yC2uuJuX6Rssexj7eJt5mhqqySX8655UCy+TN/+6460lwpud1ggRNufaoW+Xj4BHQAOMORGaI+zfV/BbUaMy761b1X199/X78+4v88FyS1HwbWNyVkyFYWD+V616nR2AYXXxmlPwMFfJAK2QOX7g2lMNRYzubSlKCG+eS+wOU18s2lUxseRk5ev3kg119x7JbslLcHdYaswrjRPlR3lCjSmxjc619henehdGUdc2SfZ5DhaHCmlXH72wCIKt3JPaglBQ2tQFFw3zTQkRXTthcDlVjAMgD4ZY2kn2346c4ExwR3ksoz6eOjuOKljXoXZEkCAUCAzuWQdO3Lp2QPu1znHCQMOFsIRb3x+GyZx6NPrZmizbLT1efEm6kMjYMpO+vYvA1ksPi/ZxJAhaII7150MqkFdqr92m2FuAeZHdWibDk9lKnhL67MrGP7n363CXN0qm9p7bEjwHfLtBLYVIPT799WWxifTs3f/lyN0K1vTb/U5XNq2X0ypvYWuTqMiAaamuMHVgAFq4IbOj4BaYSB9l9d5EYZTR28UwPPmaWPgk1br/slcuy3UChx7NTETDQOjARLMvambURPJy3yCzVwhhA47toGKKAQHruwbXPvwdMOCANloCXwQ8B9UfwxbbzURcdNPgRef4jwCpJB2auP2JSLxtAn7fU/uHx4Y3daG+0oiwfUL8dSKe9SMt0y8J6iZnN17y/ziIc5tbp9S+3MLWg5Cwx+AT4AlDw2cFya7uD9LdjhgvDCccEn9TFKaP56jccjdaVasb2s9bY3//IOphnL8wq+2j2cs7l3DN5OzyBS3QhEwWh5Tl+TBskm9FuYN9YctfCcrL7s8/mns07UIfJN386j2EFcGo8UQy0vpPoyg+Tq8Hp9f48JJKIprUyGwm4O2k37+tTuqsG02cYlbK1yl6NWtklpfM27orfuehu/R7DjwfHok788NoQrNtRFZcuqgd1Y+peGZGOjm3+6YmZNZylY7vx2DztvLXL6A/jnsnPpNHN7iaqyGJt1vi7en3ZGzS6g1qsRjEAXIAFrRaVR4eSAqWnuUXfMNCXJr7hZ+mM3x9ZHpC/ivt88n2k+JqlLo3OgnMhePG6G7twG+XXt2AtcXLRhjJy+bpyUilS033tVuwBJORvR5ksmTaVD8MPouYQg5BOP/CgJ+Yj8W2g/ZG2sd3rNOJN7Jk2WXNdyndr+PxKxFoBtOI/9Z9dWZrbNe9oONvg9JMUYJAkxpGTnqbEwoqeycFJ1QpZgrBxYGszh0Gc1E8e2GbhUGaftZN+1IJJKgyMaV0poIkmKwxvw1auK269eeu0g58XeKyvLugIONHSxI4WcxcqMLXuTHLphqUFw4WiVscj8+M7yG/NWzZvd8hV+3ST+5fGMctSXkSZP1CbVz3M2VbSWJIGN5Io+lpVp2SGwgPefTndX6zNcp3dMrw5BbWwNC4SlP5cfqLlN8OrjtFWTZvkO/o/24hEOSVC6H/lhXvGL75hkV9/7GdOzB7t9da1m3ytjSY27S7xyuehelWfeJEgB+mylzCJeo2mT7KR0GtxwjwJVPxOheq3w1auLWm5efO0g/9ud2ibGNymmGAK9q/RZlm3xdaPF65jxoemrdqFVlVezbQ9oADMdqVe3j8KDJ2cqNZKZ0vaEEc9ygDkZNecufd/f30SqMbbO+ueY9e/82Ye/6Skr+Op5VNPlm6YGGhMms02Z6NXJdLsDm3W0k35wAeAZuCbQij5AtPNrTNmpIt4qTqil4D65p3T+fjnj7tt+fT2KSIubfWGEh7+Wz8LdLIBh/+RlUD2FtRUqMPNEMPXQcv7Ph1YLUokvssj50YVJfW/xyavPTCVWDSwKRh4tpxUPj784fV7fyJ74rS6iA4gU99TkpNzDpFryOqZnN5xhrr721bh1T+1R0Zi8LtNR4s1mwc8dBwwVHRVjhOH8fsmtpf2AjGS20TzOk4TcTQvtVgYliX8vCSbImf64swB7nN47rodzzfcd/JkrPvJovmi0eSrD1x8unJdL9+UOF6YLvu9OcKDoNOOf7fRptkTbB45Gw4Al58ev/tdQLqfYfOsiyC1riAihT7cIu/mVwn4yUP4nJZ40i1o5JoUai4Bfbs5xm1RxxnJN54M/ae1nPbdrSO+Q4Gr8vKEfB2V8sx5Svy9q9y/geVneLtTlz/SZ9948YFWEx9ub1S2Wd0xm5WBmSRq351ROGvjRQnPOkL2lwx95zecaXvEsvaOrrv+n1IafH3Tcxjn/GCENgonBLL5rakda59L5Yf8NOatm38shhcZvIWMiSJIkfz1kdxow0XtzN541kh/8e/iT6DYjeGybzfVBTp77bEbo8+8fpB88Xvn8acfmWQAzepa077TWbHUBAnxHiYF0AsfKGWuV0xsA1+kw4fnrp/GvHnzDyVgkcF2aGzpZW/KE4Gg4/MBXpZE6J7J0U5+6OkHtrYD5QDzicg0C6X7KlN+kvKCTw+sCqBtxVJKVWS5uylqqjUlV2vQmY4Og8acmFcA03OfKSKnX3/3sAETdVlbIsZqt9AoYmDy4ueQ8Wwrww3x/a8zCTVsy79Xcau4cJVr8uFVnD/KcP0RRJQ8w1ZhwD9++Lgnc5Jbqak6bqhTPg11V+igVsWw0e1ixYVw6twMsuCh2vXlOknl5Pb0w3tXd5ZhZkcZbRN8Zgi+CAVNL0pfwtGRWKtvm6ZisCx5AGTw9F+lD8oqsDdfP8YEbnsL7f1yadM1k0rXQxshJpi1ZtjkduIB2XXoQz639iPEmIchujwsS4BPe/FrunwjHP76cGFnxmn3htzCXxgkCvJnbYgvtTdRvHk1UHXSC9Mfi+aX+N3e0JIY3hGwZfMqkWWbhUGX37kNHF7qWfMZTusvfQ7BHizyLT1GZeDqAlI/SjcjtPnRDIq91piuNBEwtvcQtgmq/nRDf4/XArt9VZup7ncBJJ/qvJRZaCrUqGhkP7etKrIfbrj62MW6r4VisVmY5Oe0UX8M7pZw1+xUNnbz46KRpvz1pKIoAqnN0S+Z99/2m98fdEhxQ89lFtpR9lw+AR6FozVFMD0+dJYY5SCA2MJ08AtCL4qvJOoUdW+l/VnQ9mzwYsbMTfv6DHbOCmB5Xjk3VhS/iVPBm9OXj5Iuaabs3WK3sP2fCLCiMXfzlKON1gex4IbLj6LB6pvb3lD5MQwIuFOuQ2N3Pkl0svl+R5ftPk9eRtyONf/r/wPHmfmwofsecY95Wk82lZPc9HbSwSsKnd+MdfW6ukdDL6Wcg7ezOr6BT0Pkm671/HHj1jn5qtLULVWcc/s2m3VHYcyyTth6TaI4nvdvITBwIX0k+Mp+ZtWarMPvp4fhdQoo6W4JZHlKGItbLinYv2vQK3hSIMgPu9sX2i4usFs1XOmntRF+mGTUDYndK+pHuNJYajyrDFxonu7Tqs2v0CxhGJihHPmfV4aaRBkhPhrtZ8kFplt9lEJyW1WgNJzD3f8Ofy3O+oFmedbma6V4mckGfkwdHN19a8PyqunInF4zkKRwSIUmJc1NVjvVYtqJKrNLjggLIyJOttBbVa0rN3+9dN/O7bHZQyZQtMIuUTqsZAtVbxEDF3+XsthuTOrgsZhaSsWePVwdHBWKq9hwcr5Dz7DMtwx9JtlfbrChpszRPRualVfGks6SESq5AQHVrHHr+By87RkgtMs1QNrWymxfJV63NvXura1Nrw8dhHJ4RMQdUZrCKB9tex++uNez10TbP/znJND4xtf/dny9+dOvl5TOLXPrK0rczsy4Z42x1fhdNbiG3MBtp7o/u4/i4o/VgQhSW1t4Jqc/uyS452BBlTKMsqHIzL8OEK3yHPioQdoMjYEiyZXbCJY6SV2A3qugouy9/fsL893DrfL61s5B4Mp6MOhyNA6/H370iPTMqk/yuvKqQslQeCiRk1n/+DW+cwgd7ad5WcblCv1qLBIPXpSFym7k5SSrE/7UVQ9hPSRn7WWq/hXeEHYFbhAOyYoBI8GFQDaQ9eZL54GgAxSuYNfJFZ8/MM44urWnosTd2L+yadHYbrrxokMPLTST/V/jMvKtGENiOqVJHBNnKGvc8Sdrgyfkc5OMVwOUnHnkAzhJSKS8K0mgta31rYh/WP+WlJarKwtGa9RDkWtIdelE5+0DlccTMqN7WxOXQV9ZsIW7L+4A1k7hQVGgbDCYVUyGfVVUyDjMuwKlXubcW9g72LRZkOFXJ3KaeNlJWShQOj6XVQ8tzT5EjUW0yPLdrz10/y0ryuIaEZjaHCFQKaDlAiOyq/JaXVVaRGlgityAjplr2LtfpicMFyb0x1siweESQWGq5c3FDwuKIys6Ai5dSYprc2DxEDOna3TSsUBNbPMMAbfe/CohK036QLh9RpHRHh8F0EBnZqcn2ubWox+F60uKyX/ZTLcE4TE51UQnPv7JRYohZotrRWxq8RiyvHXCqFmfn8A0Sn9nImPh65t0Td8aezRFPN3U1JDUVg8VtVowwGjdU8nFtUkpsfZ54DsAYWjOHWbW5APvIPQYEDSf3YwdBb4/x1OvV6OTfXFPR/+agMcqrbuPZYOa3qk/cGV4+Kcbdw+wMGlt/bZqtYzhJjW8U6X3g/pBtmt+RvkiTInsQYmvV42Vr0jM2rP7Uv9XHoJEx9Pb6gs86a6iOk+RsPBw/onsvWXZgMjCeSFcr+XkDtTWUlG0t8OvUtl1MpOM76K6ZUhUrq1b7xqWRYaXexHLwXxvQMdx0JA931+zXkXajrVfgV/NwOHpax/m5IeuOdL8z1b5UTMy5eSH+HX6+ppqW7WkoarRhIQ/SMiSNYaqbZ0PRVsfXuVaAq3Yxol0U6zsvvL28krg//C5N6H7WEiQL9FI0OSt3tbWBOSCijuAPJ121SZha7Z6Hqxm610oe5WAYqBoucUxfguQAdS0A6jQ1s/9H1wxC4eqcWixKyxW+wdi4PIsMHLqIuN/90+/pvV2r7U+h6Rvut56Ade0c/KYpW88J4Hfm5OSs9NL8u9GdOTC8xpYrVx+yGd/BN6FmuW/mB5qpevKtbeBmh3kYFIvIobJ+Hd9dOm54Sv/3IxhWmW7Y88j+ZzLK9P3XbCpQToh68xl4zutcKr+m+tzVDw/xp/m6Bfzrb5jt5s3N8Zwc3hyZwEGavpL2mwQwk/CYo/m5yScOKFXVNGqOHikiJ/aLptIpzs8yoUBH61Xv0hq/0mKVqp/ff+cYWlLKKzV/Y56Aq1y3ju/QzS8/lXkd4D5beC5HWgdVMZhXQhBHv5t5/gZ2odXVT24Ntelz7Y/cmpV5wNHTODosHPUl9yQselHhkpjlRLqTFYHzEGcCi847NU4Ha7GZP442RuxqKxd6zUlqVi7vc6cWKMCGH8o/iCSggWcpGCQ62n2UCm/odDVsNyoLkzXrgHdXPzXp/o1/HmdB1t1YbRLKdd3jetd/W9/pWmdSH746H2CjxblKJh6ZBl4W9VkWOFBw44YgNL8Af3LAc2lHkaz5rfqG58kPn5Bl9UYTQ5rjHmFzKhoidj8yUiy0DwBO9ZUMTrdaP4uDhzIsI/uNjrysfdikkv0JsIaUby5+fSP++ku+xmqUiznB35B0fZzqyOkFubaA2l3QQiATyuHv6049cX9zW6IZgLKOi098OWeYxWLjktnWVsmDNXOAaEIuDmb4GgL0Wm2HVsiimwRdeTTO9D1+/muzIub8frM3vWnMyIW0SCyMTgbrbY2JxqNRArlK7xX5KX750UJ8Np5qo12y7JNLqcdOgl3I7wzc+eiF3pdLy9KPzBZprZGqP16WRAbKkW+Bs/cEcDA24BCP00dP9dzuPuptjOq9zbyzKHl2nsP254Y3ztxoOcBGqxKG72UOt75dGAZ/c5OOXxoifYnZcXy4L7h/alZQHlZMsTIGfylE/8BFQZhD/6SwAFKygs/HuNQo1441WvJpa577BVvAb4bkgt0+O9clAOyC09gjM8jTSfkjZJB1pbSxr3IGALhG0WJcJw8N8RvQjVZiPlhpXF9JSnCaGZ6U13x+Jrj60YKBro+eui5VurI0ja7rDqDILJxQzYUFa5oqKY2Mhs8+kl4g/ytLjHixIsPPKrA+x9ayjyoepPqYD73+X/+L7uTlPFQLBW0rD8bGhw5ZIv1kefnkq//LPTUvMXVfOIU8eXkzCuvGbVXbrg6i64z+l8e38UC/v3LT0/pW+AZZrQy9CY0ftgaDXqsEOObzlAk6snsthsNN8VbI46IGd6gy4bn5JqGzYhIB6yLMlGcgtgW+zZXPEXph336XE9G5hd5J0zPfvreNF6rqWlq9elQPGUFM7U80L6y73jeirHlXvepqpVKr/fRcESiqpnD3KNtDVf7JCuB3lNrYnEr8vBA+I4lyendmSchK22P8LYsr/30lc4/v/fq7oGnykpsT1Tf/q3sO3fulvs96lKHQaNiaHX6L/siezP7M+z7VP6SzFQmD4C3b9JCJL8Yfnjx1uyhcPmdcCxBxN7EDKIheoZdZdf2XNMrDz5Y5Qw98z1/mU0a4mgTT27ddgrIchbFbZcT2E8s7b/GE+FbCwV3qfQ19MQ3SVQUemMfKuzswcQq209dNsE8dak2QfUclQ1L79l8kfFj5LC0iUYY/2T7w2QBnIZrg4tlzZIqbfG1YKFaUn1y45kH68sCA2L5dFZD9l6kQRpsG2/MxHkqm6YbYH/z+KoXXsL6rKsR2AUyljbz5AdGzYVTx1faNkHyoeHNg/kxywDKi/bdOxEVbKdCP45uY+xVsZ0wMvHYWD0cNo2f/ovNLGWr/6NQBYh8fmJ5Ml9C4ASPjA83AuTmib/61IBTLwSB2Xh1u/CvaelRCW5Q75Hm/HZt/DIyB7oavNkXoOE5GnZtrnufbViuLFkeZyXLWmG+CXl0ZDhhPwfpyaE6Nh+FuDFY3x1ZjnkZyIeXBNkiSamizdKPbkH7/s8xKpg2qW4SmxZesA+FrP6np0z2X0RbAtvfPfjBUK1AvuvNjBDGoYq+XbTF87rzri39zfFKpeaNoq9qE+gbZ5X6/nbZvFpYCe58Otb0dBWLznvh6+Hq80cOrrBsBPSGvdt25KWtK0+FtW1II1POJCYA0f5TJ5WNTs/ion/m30+5WzwFchC4NbrV6PLK7hxudbSAqEF856h6Oh3pXG1XswtWnuwNeJ2loFIf221Wfv6pPqV7bv0n6s+z61pPAR+h4tdVut9XKvCW+AoYD93ZvbRMK+KJal9/72d8zfcoN7+mPSh0fX5TFIB681B/Y8IXNjFYjUIaowIaXLUo3NJdmwOcIWx/JUZ5HFuBdO+efm1ZWvytcPNjd5DunJbTsoS2OMIG1UC7Qt4gaVGlXu02iW+GOYaWHsX+Nu47eH6b4yqNCDMkh3f79opqsmzV0p7DmFzOJl5fa4CXr/TcQTaRZoeqotyHfcIXbETYmmv3u5YCCwflD+elLJTZYW3r06ikM4EOQrT/1klqRqemceqflLeQP+Z2ivgNWt0aTGVlT75ADmOzfAy7df6ZuEjnKu9c99P3dYc8T2NVcV/8dQiz/ES/3CNfe6v+PrgmdBy4PV5srWThTxaunZO2dXB3qGivPNhwEvgjdNppvCSmFHeCSc0d46dYGW7N5KkTuVYo/Isn7kCdSHctTcDk65/U6TmFQB0UwjYwPqxPP7WRP882+mE55xmgPmvx201Jrmab9Mpj8iAnYOj0IXnmE171s7dPQOzYPX1h8B9OmmSaWa/VTf1HdmE7gzCg7awxMFE3rByrG5J0SpkGdRkUQjeI5VHdgGnEMFSb9PkkKfmIYqJ6WBAnMwyack0FwyitjqsHtSPqIXnHx8dPYLSIWQRwA+DkBunpYVoXyDGZ3ZmPz2vK2cBuqtTMweXWZEGd5VqEzqm7zurIxmbXgzteNkoTdcOqsVoVPLbhHkSUtvqD1IzWjFcP1WMa1eXaCpZJImtXD+hGz8OqO/orWf1gInvqrAdJJ0TH9sZXfLY7awkxpxO5Dg3XusGZSfCvzADjyh5Eh4O1gIIjm4fnDyeBa+em7GiInMF1RzKCxy0DnVAr1KGJGvUr2iA2mKu+HYBdWnz6xEQ3CkzeofVt35uk3FOJznqdXYtQRjYa9HQ8X2pgvhocmFwq25qfjL1w5sa7mB0LMzYpMg2nzr/YGL95i5FxtcTKTzLmi21LYUuq2VU/w1UC/31ln0DrXDr2cQQdTj93HJnenbUu64FU9DUEBTG1+yXtM+gftgb56jZhOaimHPKJ859MBt1OdCc8DcL9CkQdO86OnHDSUFh7t53bOPDk/l+u+wgdS+euxLRt4M4VrmV5uRYYSv624gWeiVA+CxyO55/wS/1HGOzVhpzd7j5re60D8ljA9PTiEtdjkFhDIBCPxSNeF+nMC4m1RcvSy7tw9DT0Wztq7ZAHQiZ7xyqhOGMgiGLXjRtYfaUmxDsVsRXG5rm1r9gQzfbSXupc9/rljwafAe0ZkqeuypNrTvgxusQIQZipG9bLC7w+IG0L0k/uQVY13DSTDQrg1stI0NUKb0B4ZiNgwBnJa+DumQjh5f6Ns21g6HoA1tIK/M2TDm3JbfOK7Y/VJnowz+s6n55aKQYDRGq+ow6fKjWXVznm6YEwI2lmDTtPUHJvBXVGs2vZwK3iu2ucQbgb3jATKvTbQ5IPd06HV7S46BDumXBh0LEgVoYB61/pIyh1FMXuLFF0pAdWvDbrg5jOcbvys/VUdhnDizOlOVR/Di+W3jH/RAY/5JUW/jip6rALo5GuDHi+3iH45BNeBOt/PPuziduEzjQiWn8JeVG5V9h4IZwjG6NroLV3G5AaaR73Zn6usAxo638x+zTbr6MPUYeErv6uoiMc7b7KbBE+6JZyb7e97quJTX3szyK1FflsLAiv2d5tkn6Gg9sld/dUUt/2pKtvSCOEyvqp/wTngFvuhQSYtzdgF/d+xBCafu6ZbKJCKIN9tgnoAAr4X3ofRgBjccDNZT8ALHt727vp7cDyw7q9eSBwN6Io1PR9r8Ry0dsQ0FDY3cHEODX90JlYZ/pnsO5tOf7H7lrNH+F59o3ATS+D1E/TqN7ut/k/zv7mvT/27bx3FdcD8MZhM/clVMse96PcIvQN+Ga9tz7BXyn8Bx6ojLyvbGvSpu8XSNi2l/o/nnOafd6jn7xOgK90R8FfAp8AQgVHfjP3bQA/naHeh74Cx3yojAUXgD/7ncK38PXCywmAROb9HbhOf7aUGT4EANSqrnufmNcvp3kCK/1xoaf4/0BsuFm4DyqyvbgPfe2qd61i3LnwyznN2KPiXtf8nrv2UBXgkP5sAYpOgd0M5mdGHh0u5AnMu5jSCv4McAfN30QPHF2AxprfB64CgBGUekG7kSpg6x+kANCQtQIbUUl8TfHhsndp3sEGrkYy0QLsZvz/3Y00/6oTzBX2Vp5fMC1GSSXV52r3qF5qGLoFw6Rpn+WlrdvpdP/ngXhdvqD/2RAr/Hvk49gjHbSERXJDt2Hv+r43A/Qh+YrgKHOcMLmwcg0NyzzANRMQGbGjfGT5tRVv7n578zsl5U+Wf3HdR/hJ81OX375hgq4zD18+aXv4+r3X371ddqv1DpP8+juJyCfu+s+99eDQ1HiO8+hqfrhMq+x8Tvd2vDFQqtuHfvS5V+979ZjGq93yU/ZnTx05e+R/i37+/k8++NuHP/z4de8T9gp6BBtdI1t7a22YHGh+4NMffOnKy/IBxwc+//XXofV6R8P53Bdf/QbcMLfB7+ptf+DXP67RZGwdU2t6dHI7wQbEZG8N1HMAAgAQULKpQK9IgBp4fcfjITibugG4QecqnDDt3oyuw7SJW8nueiDmWoAlhdOrJVfAuZm8jvy2lHV2YZyLOai1yLc3eku+nBnlobwOu81qMZvmrSz0uebRJEYMVo0QXTqddoWFx4EChr2MB7IjSFaMxOJzVNM6lk8Q1pfMOkBjJCoDVhDCc/UTINRnmBc9aQw9vcd3ZDDdPf0oNVAZEuBCSyoK5jX5BY4mn4ymglGy2VonQKjbMCM5aunDRsScccpYX4SWFtr91ZTw/PyNiPtmfosMU0veV5o0hp4+GD1TFDRBzWwzrb1TDcTwUSx6niI4kwUTxVD6KISOBkRJgXcrZxGTRHv7jEt2g4WIOYuvNvMxjHa72+vtuRQGsufuHhoIYmsYr9liMwqp1ogBqSOUblQwb+CYvm6O5v9i9vcCuV6hh4FTGF+KjC82G83RXHrMyqbNjmgQ6UdWzDDpm1dGv2S7UvbCs89SgKyr4kJIOVvF+SNsQT8yD9NlLPCaPUSB1xSc42y5B3+g5BeDq2PKhvVEx3FdL8EPXMvwiR88ozGkR7yiZalisiwIHFcGHGgomsiAOwjbbIfGvLFD1WpCiy8PndOmEb7/s1iukl7SsPl8erBv9pyG8vb1J4NOvYwKm0frE/lai8nRMTLR36LAFUBYzcwTy4ZCLP6LX18UtJDvwjpWhhvOCQicgPKvXgksFi6XQ84QUolEdIlugnE5XZD8ywc0xL/3aT6Hw200g+GEd8uLOwLUCOox1Jsbvnk3fwl4YRZt0bUE/U5lNX4eYsyq8aWikVadEGKGP7fDa/91w/5b0jp54KUZu2taC3Tzs1eZNrMEP5+L4+lCqWT/C6HNQZem+jv9Zj6uFEvGEt6hObwzHwzQIavVEmG9NaLm5gaVElvSgwEH3Rt/WHtg5hEiBIV2XCYMy/GipGiaLmG9Nrr3yj/NeBpefWQ42Vq6xFMEfsNL3qW3hcUBWBB+l1XtD9sah2zzIWay20bAPC3oZL/xXltBT1fHfKYFhqIEhh6lU+yPAVJSlhRkKmkhvwUDmycGW1OLBCNZ0hnIqjXebuNJpxzNKvBbtGV66nfFz4FQh7JeFvloZP7opFxo+JP8lg/L+RyZnmU7nOuHcRJHeTXv0CU7HVcrvC3GeYa3b6ZZnCSUaHv+0jzPgSREq8IQJG/YZaSW1RYFYiiEqCM/Xxo1JTsaXylGL8XO7Pw8nC33MMktIrlkp6Ag2N4Lau1ODyLNfJyglfbKLfSQgf2T8a3Ety3ryjxcXiNIsolX078dFSMP7hYzorpRwjVQ0bKua24+HI9Ht2v348VyGTAcKUsyh+E9U2j3fy4IfsnaAFIcCDp7xh7EqUh9QIOVQ6jqssTnQ99rst/xXxrNjesjDHAFoWqXGLRfYKsKk3UqmCjNQiAyiG+6cMw1T0dIai2NSrl5sgDw8M+O/LVgvwwCihWvsAZGkCCAw5/fLaWTboE2hlUtwUeUatsgS98qcZSZbE6G8Vfa/6NVtRiO+ueNqOqGN8+E0vn9/PMLV1NaJgfKnCLZXE/yqYQdZXtPaj0kD4HJmKsgsMwrXLmYd26yK5MHsmuXdiWMExRmzZs07iIETLffpBaui94rpSVzswKBYV5mMS2Y6KsQ9WKxLFYPOdtgk+x13oghkgd72j0ApR5W7DTW9fblwNJhHHu2BKff/SF9ElpYpYptj9df+NFTCrKa/3/IFJKRikLcPskvbI2zI3rv/1L3/ySQO0qZAse95inOmyNr2B82aNnhW6DhB4IykmGV4ykLSnfHWQby+ruTBHu3InneOEcuwjM092AsPsKYKTUn/1+g63qtiqh40LZhJfxer23l1NyQACMIpwhtUtvVDOFk/UZVYUZVVK5pYm+NJlY37mWbIAHPLnB6yGySppqvduaVkrzKL2VALWwC63x0MKPdvcc5dV3Pe9I1cKmalorU7sVG+kqYRnxsD14tjTuEAslZm9kfugmqBgxCooCUo6iZoscbFBOOiUX+6PG73xrzioVao4eL0TdAnMysTd8RGCckoKem4tLx5NElWtdqtPqJUeAapJGa8d45+XDr2a2jX23qpDYb7ns1S0fTBYnceGdYhUqYSSpDUBnX7R2tXhM9RQDc3FVIJdj4g5cs43PkSu27OwxlvsmUcC0M6yuuZdOokZHtKpVmuzFqO97/zf28EB7TRsW7JCZby/Y3oJ52RiTgBV5yAqNrkgP6biUZLHcaqxoC9cXPHScqnM9/U8qP3cO9wP8Xn0VtI3QQxNkok5qn3I3/J4m4cDHWKKwBQmjWpe8oPuEwMxoPOyabePujHeOXKW7e35lKbzXfBM9GNsZCcKFxxOGMrpsDa7HA6YIIkIU1dzq/OyygkBulsm31GzoUO1aFfNHOc6JkihrjTnIlyHWK3tsQgBfD20w6O+lgyn9X2ZQk58Iak7hNMwxNJbW2BakAgrppCcX3z58dpKYYzbLFUjnGlOJsFnjY8Z0GGa3icWyMVsQw40k2MgJ2O2ATTD7dGyMAjXLlcGBcxJaE3gGehR+vWc50BFwVBmXpPm+wU/pC0nIcwZBffR3DW0VLn9yK5ggB2+Y/u+HJGIW7CEsdJ6dFGICusYLW79pxnMCATF9BwBz+99/tU1M++bZpTmbXLn7Sb/wDgc7q8Glm+JGGIUcyiplwfIzaGWeQOnDQmMc5b2GP2Hx1aO4JBhjaLVLqTV3mgsY3YRoycAkZyMY+ZKCU97rfP7jT2i8N6ezqplyMVkCHD8w69nN2JxC0k9if3ijhh21T8tYxVMXNZv38pYND8I/j/0D5hV/gGjAiTvb5JHdWrxGWkkzprv//ZVv2K9BnlkTBTRy+3PUVu/5Pe1U6w64cBYz3PzitdJH0S1mHb5dFCwKKzhLOtXZ7rQZdIrklTKXlVk8J+N/VqjZJw9/1pxJKuRCKOljyu7L2GSAQr9svzp5KNbnE2LE82mE6VuSPszC4FnXP1QS3iIqyem2SnHV2e3oGXmky85WSKLCvbLL7URP4viLcXS3zpspMwCVnDyiy9QnyWYXB1rat8N7uSQG4UMbHxL2G2z4vC/Zkl7GXf8OnwxvyYJUUWWYoLRMDXXdvotV+s/lbiCGR1CesExbFcsGTKYl2vL+gdbhoiptEr6Nacms8BXUkVxbMH19xBvJcerhC5HeGqGmYGtNPd80/7jNmJldE98SkWWSczU6mmBjLA4GA1nJSyLSfKibUz0pzo76h9YVlYmstvsJX9mZ3dvi+mtY6fukJ4S4o24igh+eCHVyymBYoIalFfVAws2aLRtXXdaz91NUWtnAtx7OFtdaWW+iGS9h0RCM5h3WXg2mkcN/awRfu3qsYxfBSxeYma9RxW7i8S+uKu5F9+1tT58ZYi0HWtdCkqXu2Kk68TFsv3hlsdlvIrFiM1ZkzWtvQeOetkspHCxchVR6etrZ7I5hGwZkA3bbL1WDAanLqm9mTxivEUi8uJNJSxlsGBWe6v60ygOfj7Zw4ljGv7bxY7NZuyo/qyzn+WCJSfzmu36SL8U6ICccL9bqSTObVLHflgupjje4cBYRpdeW1T5N1c8GM2KZSMIdpJ4AoZU5Udhbh+yXcN7+OQgyyd92xIavObbeSNQ7XCRwrcCA+2ChaiDUxoE1Ro+yfFC+tnR+YiS/ccA1TEAKHCRI4lZ//PLLk6KsVI1EpXt/O8AiOpfhxWVTBH6ye27LE7kf9cj7udxVWXpEhVKrSWmMS0XgqlslGndBaSIlde1uP6Sxxbc1tqcV0xEJX3BmrtBfi5OAGDjCInbEuGDElcp+PYENYtv0WD5YKnuQhyYt74zOdMZCjYGKsNlWJbg0ArGQX/EgdfLVBb92+gzj8LoKkMu1MtWXoGQrjuntOyJ1NC+cIgZbXEBPm4ugR1d4vvvdB9/QjoaDYYybPGeWXuilTu0yo2FlAaYY1hNyQ7jfFTZIC+JH9V3XV4Pc65g0VcUTNhckx4/gv6rVKOc/6uQwCWVvhoFUJlgjf0nfbdwSp4rRBRQwCVtwuKayBUbaGgIgDKPAfKpgASz9gbWJnRMivkEdCdryb+erg5A82eVloloqayseqtNwZkbXRSkupQ26bVno91WEGAFFaz9EEJCFetVbdyLMJ41ysUL6aXSQliKgr3DBuZvdSakTQSVVgytVygSmVlpIDc5oRAv9WfQ1Ms48i/R6SKlHXxg+YHcWSy/NG3xuMxPw9XywSZAJ2o6f9xeeZ9+JbSASCEJKJhzLd+nZ3dfByImgQ7PYEgepA5hTn9VqrT4CD7LS46zn0XSdq2shWguSVyiAAIii3azJAwqiMMZstiFeGLWK+HfWEcGHzq9g/+joKeVLZHX2OWYOlqxI+tKP8P8/boarQVVbS6XC1stsDNN/y27FU+RTXolCIUkt+q0CjmLVjQ+vB8tBixex2b4ZVz2PBBDu9FACVlniq+/B02q21o+/Uv6R/e8uWVsX21qRzNZDy+mCHUMDZ03Iyn8LZqBCg+EfyAInXVgmbpsgF3Z7k6T1D/Xmr9iP1NaC35j0veqN4hvWijC1rvNUmdfd70+1g5RQhaTWMZY0wESYAQCJrkJyVE2RcXxuT3GvhHsVhxaBeu3XgNQEmC+7+J+uh8+FkPEw9jajZatol2bCYKSRPSIwwRqCZNwQXF9fDuy/uzAoj5NsfU2owGrKspuqOR5HBrXTbb6qiSGh+4A8Wv5tJs1sXRzvckPyve+HNh180JOBwR5T0rxeOO5karSNWrkgy54HahKi36+sESQQCfHxO3zj07qtAyA51lzvcrZclymPOQBJsXB9gHsR1IKXvum9B1VN8Hk/XD9wzChRyKLhBOeJrByYmn0jyx+eUjtG0CCrMYgMOYHZhn8bFb+y4N+yUNQNrNycrp9pbqQixudzyATK2OUprnolBv5kaeYrijtWg0yjSlT45PVH8dgx9LPbfdLbdzVNExqO+6zqYy4Yow9qwlk9xKMJuHR6zIyBItT5W1qpdYCNe1skWe3nNXGLge+7X63LVIgpW/YgpY0gl82Z6inLJtuzgo5dBiUbglla1TrYG/y7Nct9/JMRD2yvo1vGKqLFBvDa7yEdhPwm78eKoEvo2tgFf7XEHNUhTeGrwbumhk4Q44dFCUkzu7DOwcp9+caO7PZgSOLvHk0vn6ny20pnMx/1eQii5LfjOU8VRLbJDhBpcSqOY3fl0YRb7lFuphoqXAw5jh7CyZb81/+1YM0/f+s64J6yIxHiVZE1DCZhOaJRWrJ2tZyJcYyMhNLfbNNJB7mDD+iFU6QgFAx4bP47z2YXVaaVRKeejXi4DQe2FJiAkTT0mMjDzemJR1LnEtmpUlTBSCMMXT4oGFcFTEuW6tR5AWj+Dx0+dfyHqdNYkId0RYsS2+od3d1VAqc9JCEkQXGgrlIVFsMTtSdLXjgK8ye4KjtP2g59ja4vqPVC+1dqkVT+p8LMRqsY+KSm1ZEzvpbBvFtxyi9HHiYfY2tsL2++aG31akUjLiGyefHq39faSnOu8bVQMa53QcA8/ozl3erD18ElX1ElNuhgkd4IbgRls5+TVlJ4Gl7XRetz9kN397mp1xocA723O13c84czm9B++H33EULLT2EAblsucLSnKcrzRY4ORd2F9ySand/aT8fP5DQyYuLkX6JqXVgXDAW6pAuQObiAAF/jqvd+i6XOrd5dVFFHxwgq8K17GYh+9UG2OODqwrMALtn3xoVR3CVqyepNWqbdGKLCwvPwzl5ZDJXoTsONBIaqN9FqnNu7Tz2tOBA5ffvUkKgqCajcsXo64GB+BfX30zpT+57MA/2/Kx/i1z/59bbMw66yWRE83Nbvx/uw3GOv6t51a/NnX/sONltJsf8cNozIRAOFliCIJZnwkKcRVt9HmTERfs4jhUx6yu2jQoRgdfe/qBO1BQji3mgQp5rv75Dt+tU9ctw9eQjndzUYrAj6ElMl+9R1a5bpPuwhLykr36QMZmW/gjJQbMgfWco6BhYgom8o/DgJ6javf5kZZte0Hy+C4jz1Girn1jvyNMYWnACxPDw4/ctfS+IMTWYt2mDifk71G926OSqH1GKgvXDZ1CAPKPs3zC6x9Eq3hZ26Ifk7Jt/0gTcKorAaOq6VmXLpywvF3UzJ5prdeNjJxj0JITn2CagHDIA4dtm35swbJ9WKGYDnvshSoTaQSdt4isI7ovtO96+E6BvakeadZutUwqA/2mu/7V9Ymr0+5iul4mPsqVXfCcBt3J4RJNDvcD0XtkAenTw5Kx3mOh22v6m3aRyuf5nBv9ogrmZaJoaTPriAR6BRlQ7g7k7Tx+0H7yflRtaQLUVIdB4XMdX8j6MepoYSZYlAnPwXPgAPN8LUx4o4Urz81QsC+VDQyy8e7SfIInEazbPchTUtvMaZfjILAPNnhmXqyYuh0C8xBOsDeii2FKw5+KQI4UqgHNRl9hBASx9ag34N65oQQEfp4JwoJbLdWN+rlFOlWakqO+5q3tEkJplM3rxXtBwPVnqZzxG9+k9Y7+ulFkoOtPeUvpy9986E9On/HEYafkOEVqiHAKwiqgapA/z+nRC8fVE+DY2s1Xl+E1NEiKqcWfuQX5UQqdD/ZmyfylyYTvtc6SzdW/CszjadgM/jUzuHWLz/+jI062qGPVxvl/Qv3SuaAn3lXD3yIq8IPaqncj/je7XEBjkaYl8f01V32g4f/YsBkNMXkjIpNAsHxxglQjWABXW+IGsPnO69LqIyNMO9uGNIfr31gwD+X7Za+/VapRK7rSqfaQmvW2hCx/2VCWz7SNq+EKZJWY9Tka6W2jcl9IXoWhxUPNxcSwgDmKCq4dWl0f1UiOOeJzoDry3YYvalEJZ7OFTTT6mqamJKQTSfWotS9phriaHZWFnERAzS9GuS7mPra0wAgN2L+Tqm/z89pQUjaiAVK55YC71p84A4lrkYncpPrp7ibdnXCgGWDmHbCFsIRqHQBkFB8swjY92Y0K2qW/dq1I5mIwJZIaVI4VwNfFni8rx4B1uv/c1+wL2GThVG81nQvn2FT+FT5rMizrNoUdi8soaroOh6Ja8ydJM3KZvBgm9Sf4p9F+cyYFosTrQxVjj+QvQ8CQrD2qNaO8eEvY20MCJncfTjRQfnkRn67nIuQKIbYHLreTNGn0bFxWU9ft199aJEzpXH5hbXvsprDctD3YaAQIdc942VZY3SJ+fXNDSN7/m3HN6RRVrGdj5xCZqSXNe2nvOs4ioC2E4s1xw6IWJxlKBG9oZOMIiJlo2l+NMYHmtZe+Yffk9yMjAhrkr4QmvetPtRLDwf/C/Fx1TelZray7/+QuQPLLFRe4tTNofJB0I5oqQacgl1xVy4tiaidwdAZgex0Qa/VewjYS6ZyeuZ9U+3LB1SBoBivvoV9j2rxMvDKmxueOQTiIfP9apdBSHFn+w5Mykh2aAaW26ZFSymMsJLJszOhgXIaT/JMrSbUTl1pcHrhA4UqcPiosFe/E6o0MdtM4y0XL6TeNzHqTMZo2+ODkVmN2aBJ087oosZTSTKu+uT7f6Wew23uEysYQb27VYd4Qj6vMWCUjMPPtXwANjxfmz9gtKrxoIWFzlzOwlYka46++1wt9buXDw/Ydffytcd++VKwxHJQSTrIM8bXg/9/NyMrE/gSLz96NmuweIcU0LuisgxLoqAKyDDlknDBUeuuRZlPp4S0UOo6DGNi0Sj3QJP+641+KkPMBCuV+j4vCgPfvQmKCdwxm3aM/eQP1kfBRnIQsr1QhhtB++zZXrgxxkma1p0q2jy1M0gMAvudw5pxLb8SQ7yzcZE4L7A3aYJkJee/RNt2DC9bp7zaNcMhQeKfunUTmAL/T7hJqVyn24ka6YXLxcXMeCHn8kYxvH98IcRpZHi6pqoT6/89SLOcJwjOtqCOuialdcln4fQYTU5q+adkBBzT7O5UyG3hyMQHy52Fy0luq/Nb7MnwtYb52b5UCXLiw37zESqVr1yvse8YVeWLwUyTLLn8J0tQwms1amAFpTJhQPoAsmrCULfXZnCF9EJ45p/vw5LlfZubZqOcZj7O/poO4mEHSz97kQPBdYUxPbh122M+DTxFD57iKb7jKT5kHegT2AEq8nI7EM5ekN9eqm8VXULH7s8NLy9HJrmz6IYotXopNEzcyKPe9z76s5vVholSBHMve/Aye1Q8/XAunK4NOTfIZtT2YQJuhF7r98QJa2YP+Tfzf31vmvsdrd+6pBHTQf7inT8fifbKlY9u4pmUGdV8fAqVg4kXmiy2aP67ntkkO0wobbOUZJrC53miU824FkI/3en0odW8aEhBorSvGbb2xdya5OjE0epdBu7nreVfq5+sH6l/u1p5dhn/0NK/2vXE1fpOg4e9b96wjtzBTZhDeig1ydtddb/MYo8KmqubH70whqLFnC9nTdLzPccCgpw0Hgip7a/VLanincAegFgVNU1ZwZuLVjOLGHn/5eLwgSnaH1MPgjjybLz50ZNg5eKSHaVVnv+PR0s2QG5mYVjnJVpXUAsYAQQ0xoa8ZkhmAen5EtlNKDOl7ViCKydU/TT1NLmvHTtEBOo47aaaFYk0KYo0ZCRolnnDDB1d4glICQK0xk3QawEQWn2HJaOMn19/Sd/ByO6Rj1/2iJg6gBvz3WjE7v1/wTBsd2zSopAQ7WRjaLJAf0VzenfPM62Ge1CMJFi4JAIVgNIjZUZOBuxLlORetu6dndC2VRocW8mKlCSpRa6VK31CR6asKGP/3fCisH1GiL49nUov/7LOA6eaq0wGYzRod6cqLedADIBhYQcsiBr+CfrzbsSSoeeffXxAjIfLx68f1KLNavyPVFULkqXa2YbKAds8d3mKhn7B2mq0iG9NdllXdLMoJ+e4DMY6UR6f8spmNZiYWgV3r4Euq1lbvclTQe2sdl5HTcvyi9sz1k2PWN7j8pwm+AakexPngtNFG+pFngkNMrphLWTzuTPUoh5ip7U+mOab3d7WbqFXbg1FdcsxV926dSXP8usF/KGycUlcrxjQjnvrY7AWg7Io8enPD58qup5A/2+6MTBhye6eLFizMItCOsW4OlfXHbOV4NTSIa//7YvFRj4T4T5aztb2qW4LyahNuFoMNAtgdmWhfCbtkCdM3iAXlskB8ZprX4aVHVQpROQKuLiYfMO6YG4g5iQvS1DNXTs0GqwnawPrulOVT+UvRKON2BN/Y5Z4cLqbg7tF/7NzcT+QKjZFt3Oo8MKNwia15c/15u59sIoTltThQTpZnJ7P5cMMnpogqAGorDPCSFfXivGBVl19EYrBVgXb08nqIhLTE9UjP7v29Xein843m2tkbKXVYhWgtHQ4DEYiSUUsVgGZpTHx4qnpv7NHSiVV+M2TZ19t18s43IkCThZXMEutCL8z/5trUZzZRPaJSgSPg0lbQaEFq7/7LdFSbef162Fo8mAyPwd7Il0V9KTKq3+Jb7DhfM4+vTEaog92Au+4ID2evFp4aprnF81zxoRprEWzY0wsmnbA/1g4pa63d7u0v6r3GnvBTqd5XF4PgO0Xm0Cs89Whx6ed0LHeOvmqFCqB6xVqmWuh6cSi7HkLX2G6BknczpHZkipVkFPVDhjfKdcRfjcSrm5EUtEw7Vcs9SGZ7Jk1S6beDmtMJgjDjUtWF2A5ICzmGGbFxIX88frxGfKzZySVyR1vmhGTwGdq+8i24IrJLxri/++CzTOjg/mKACsXTJpScoT9F1Bmqqf+Y86f33H4clqQgz+mE3RASDPKeAcnWwOOXTTukIVSMJQT8nqz1a4XSCqyw27L/sYQ4wUz7GIcMxKSEgPTCCTUGO54ITbWvdIWAS+fXAh/qAQ0o1Z4cJFnjMB8To9q0BSXyOpGf2B1K+Fo6gyjp0s3QyIM1BI+LsQlgpKaihQvzYDDXjBFXTX6QwdG0JLW8YL1A7Z1W9CPsGy0uZXpsW7n9HqlnOWCPGYeJ968/NlebdQ6WeS0dmL4Zu+ffz5b/In3kAoOdG1rkyD0+4R7mZ2X409My3UVvdDG5iobTvxvm+l6DVfGaM7N1J6LH0j+hvl8VnZbSzb4wVgoTZdN13ZDX6qAl0RISDGgYfL/YTcV5j764Ej7vhoXoIUI1fIQTeL+3KVruw42nzIiFBO2iw8eOrP5kvc7VFOJdfI8V7YD/lEebjz4QurWgftR90+8h1RwDURUr95AxNXpnP/NY5blonDkIdZOILVHsl6MKznrA3ShXrobqUsqKOXF25w1tjck4b+eYm3Cz31ysq5adLAdnnRumMNlQC/ZaKBVuHyRVMpadX0tkUVd/El7/r9jD0uoWKpE2FhzJxIGrsSNW+MVLS/SPi5DZ4caRb1pFgooEIQcV6pihsZNkiCCQrzS84H0fkRup/0ojs1RJJN1433PIAACmYYRf5v+wWCvZ/AC/zjzeuJlxCDgvTgZRuzpEuvjFMk9swo1rsyuT20v8I1as3V2Who6O1Z7+cK4NfgcSJ8OYXRw+vUlCaVoSguKZivdMXOea7eanUBGUBGg/tuBXuK0ub0xrGVLyzFg2ybQHUvLM7A0eYOmHgvyGISTGDIG1hIHMzeBJy8Bsnc0vERdtSx2N34QRPrhRY3baX7CnQZ+9AexVLbDvvE/pWTxzf5Ec2J/XzPdGRO2CYbqOX9B7Xq3OaYWspc9k4dosgWQ0+Tj/eAAwjkjpbG4kIaYMtgtYYoShEx/mmtJBlGuFMGqTa1T7JqCpiLuoDLjkrxRjBOJCe0ybz0JwlmPQBBGiXpWa550ZbTfbRPEA1dvcmOIO7Y1Wamj/zWBiiQ6xWixnExfpxDvfug0c0y89ifeQ0oK6sfTwUoaRmmx9U9mOdyNRouuSyHGVf+0JPBCMYjyYkif/n4gTns+XS+rYgs97p8y4nQjSr2U/txdrqzgvNz+y7u+LY5lJO87nAnM8/66WehHUhBf+BK//z2LJI4W8/VqlImd1I1CukPcfsIqGfTT4WRziQbpA+i6ncK8TnAOi4iWw1/cAFixLj/TbpZEys1m6HS6ktc7o9EMhQQ+LfnUYMih2Ieg+8KlzWrHV1FiojENsJwxj6rWCNLvcZjnMPAIHvrCBsCIbuR1zIaSot0sjjOmvXQpp7WHwykKcVxa/InBgF3B22GcWAT0+BWDkOFX8AJPv9IjxSby0NJ286k5U6UZa1ueruZzK5TG+li6ShB0WED01tO22cv/p5uJoyRJx0kjth67dPGYCJu25SdS62AZX8FKQPPKM3uDtw05ZytysDGeThc7EUmpVBtaJrBB77BdvbmpYjjAJDWYHUhiRQbUNtDQOqu+K698nbY1UVmNreTzfaBuAj00gecgn10Cs69BBkotCfUxgiYhnFNEGRdpJVAZPn9B/vyRUVDHrHUo7aYA4CGUfqCHIXKNfd0pPf7oN52maU3GWw6Bi0Ye/niXLPK4ZU3uDTv/5c/6M3Ef88HCvLTzNcH3AJjkNsQT996bk2D/QTrLc4eJE51D/96l3mC6t+2GUR4wJ8q2MTmTo6v+qtyGfz+4CjXb5+B/qG0TkEjMYP/BYT/Kw8AZyi/uepnEtR0vSz0vnUCpqPO1cjrJXTFeFPhD5gK5z89Uyiy83jizPijO1nGiN9j5J6vai3Odlsegj4mrL8v5QzLb/C5fGIazyWJYZhvIUU98r29/j14xjDdn5juFZ8QN+7kLGqfwDHwcxgmU4LA00GPLYi+guKgp5kBurBMqCttxQ7BSYTtNVK18qUOBxSFKnwwIur+7QXWjM9enWZWD/xHztaOknBo9sOHxffnA5I/YPFisLQE8TpmLJdXKUPAmF2cocEprKZPcb+fO8UcOSq4SbY9Uf48PGdeo2od2eXf5keW76p+Wn7yqJv/ZSxtbJ+Hu/dS9oUV5UbwyVDr5rnNrlsyK4YZYM+uKwO76SU3q7BcX2zYmQZ8SgdMQGPzHtDdu91dMHrM34eylQ4t48HOPjX188uRPrFiPn3p6y9V5fDBkoKAlk/v+Dz2NQoC7zTKqZZnxW/h0yn2tUa21EYB6vQwRGZWSFBNU0iZnlTKCUT9MVSwgfgRVivRpmpdrnpQc5Y3nZlg9JTFbBSTIsWPx5Fvdy6VgC7yz2GWZeRarua9GnKeRo9IIOUWfWrGglC0qgFNEjjkO1E+GXphPIaOVU3vfdtykOtFUhddkXQ/KhLdR4NiOn4/zvEEglLGt4XsmIp2E3HiDBJzjPdhUYSG1q+cWlSW0jLewMzVWafWozG9mXYz4rKW0dtVmm9dX1zRvPOpASIhXB36JoEhhPp8J1L8eKo09uVabIj+o8+ucuVZuh4eyuWiVVENocbgM1kFqrcmC49VEC+oe/vvJncZGZOuVohooxodcSHEHrz7YK4EfBj327GSD17IcsbJGWEpGqBsrVOiY5JiRhQgqZsX63iAf8V4E52oKhcocwU6CkayRpQJs04/NfVKLho30SgJpH1slBQsaqqtRYfdwVSTvnTHslkwn25YX1aTf6GU6hpANMZhbZGc8qBLBmfmqGBWrA17gKd9sPh4mrkbWBFFyyvF8Md1ag89q4lDnhPgkJb5sUmQPIG1iINItDmtnhLtR106KNAgNFWnqutGe/gu373vzVZAkBYCnvwrGmjuUuvuB8zs3KHfM5tvZ0lIZ7BbuL/HRpFrt6p/sLzEghfm6/F67rmUZj15z6MlmTm9bcwQQR6YxZpqdRaAGLejH9wVBf6hxUvMsFL30xT/ObIzSrmfc7TaPy6v+0tPjOAGdzRR6eLKX2ZjX9vBYZtzDOqs51nxhyxBafeFyPniz/Ww5LsbU7BDm924u1lySzx+mO7LoebCQtZfbBWTItCxTC9IPorLIY82T04FQK8YutX8ItnD+LcamaPxgEHKEnRxpWd0+DiCvmPDFkojGuXE4PIZuTP0eWhV/OEjzg0S6NnKdtFr+fQigILU+awGPfi6hWpU11eX0Ye9xMRG1qKXBF9Rx6cGJZr9t5fXbRKGE4JyQLdcbRuvf1IjQGXbyVjY9BYzQz5DdzB66UAh2VUXSzV4GFL+bqP3CgtwoFhozPHACal6X42oK5Sts15aOdaT668bYgI+EhtF6Tfmm3vKgA9DUZPTXdg+K8/mefxpiUBH1dRrvryjrt3IVDQgchl0dFKt6pdIUfZGCpE//ITiGhQe0jMiF7+hqQdtcUFvfefDcOuLV1z7FLyka/JFXGRgYAJzwZzlUEeAdDwGwwKjsP6cBbx5wA207PiqBHKZ5nhXmcuN90SjP3pxmjHw5z0GeSmc6S6wF2749m1uhxPIsSUGaBmBijLbDFo4QAmT1uJig10EsDIcYMpjblL6DFNyZwuXa67vBcrkCgmubMOn2abW+HxYEH7hZXv0z8p/x2Kj4y9lkZMCaDCUoWn0/C2rHnsP7caPJVbq1HpV367ULIX18+bdOOI6Po7ELW9uB3B5r1mCSXb8XvNZb6H9XXOs/kc6KreOWifUIZ8bZv/HPqVre/i67wFDJTHWlhYJNaCcbfTf2ZbzfRmKg2mgGt7dcnyBAAGKNZjTKMuPRZlBZhxcS3/3LQVslTpJCvNJXa8QgeeYXhDAbmqNLF+vtHzw8+a6puapBjqyPSdIkQ9kwlBmO7mLnP3v7GqCxnz2dCxhJTomBektd0wBCHHr47D+69f78YNcP57TGyTsGcZJix6eNS7Kr3aGdwC4F91uwMW95438BIRLlv/Ax3FGzRUPk4aQAufQa9fupSq3NB2lxNHsAPrzMmXHVhi/UoJjV3ypH0b1VLXPQMFer0pSM3HnR3YfV7rRrw7RYeSIjmJeUbrf1reZ6smZ5LCtTU9d1tExHi2rLFGOymLAZ9gvIYfP6+5eB7r/sZfllnhHiEAYsCBYYS8p61OV/ZsXNd5gIYxjTi9x7bZw0SBtfYuI6Q87tq5k3LZEzgU/5HXfyM08RW1hfwIIRY7Nn1V2lFRc3F4nM/cQKruU9dxw1wd0eQohmDgmdM52d4aUmth2PYXN6Im/Fw2FRjl8r+N7HmmedQf9mbW0YWtZk2ZukIeGYbwGv7zakdieYT4yQyZMaBrx0OE6unmTe+qlWpHSlsXLg4LC7He8gR2EgK16BqJM/gtrszWAVznuHuRw8gbGfiF5xeLRJ8zKs4Wg8SnPvIh5+OPrFWDVJmQHDfvPC3K7MeWzswESghrVVx8rp1jTwLhPXCQqDvSYfgQtM3Qs3wy3GrnCy0yhLrIfN0Bmhaqli9LsWBj02Iwk2xJyju+29+WOj20ePSqberDU2iyU9vV3kDl1kIJhkb0VXFkbxcrOsZeI+ZiCFA14oFsjn/zJ2gdfpleNte6TVF2q1sFq9b+jJ5l1g7HXHI90uMV1qc6VqLZBIEg5COXHHRvyQcptqgHs+pputngEHlsIcpqA61VeSZKb42edfwsDHwtIUP0S3JeKAD3Mzo/35irzdnw2mruOVHPItjWkb7PaZHBWea3wAFK60n+i6Yz16Z/61XcAAWSfjd9xljImnc4rWaLdbDQwPGb6gTGyaOB54Zg3rOZgIcpcfxbZFMlD1/IZQTEWP2f5RGvs5Zgb4tZScrHKEhPpmLhjlEHda/yuFqHrUhPsotnW+29v2DTYqelkrmJX7ZIZrxWqloWpqCnmuhPqgOgVxx+Gwd5ElKQi9B2p7AupLq2AvIXeMr7dqmo7XlTDF8vocMNKlyVBzsXDHhoym8Syj2irfforxfn7JuHZzrr9EACwRZ2wso8QvO/eP1zStotrVPvclH9ep83y5qCUDWOb4zcnNGOGJMWHzbn6XGOHzFS1Jzz/WD/21fY4iFT23BrorY+e1bheTbLnCTbQu/72ezNlSKbtansNsel21RWH6mX+bExN+FlMyXobI1gbqCYbi+dzZClgN8430YHGuXGsVCggYS47mEw9W7T/evJHtFMUr+BqHKT0shgq8QSbdNSo2bkhGwLWRVAw7CsCVe2vCs8X7elDFx/jHr47YApesfNTKLlMO2c/ppkuH/i7zulQMbdqN+o3UUqgzZLfZ4y0n98a7GEltCdvbTme42Ij8DuVAJkK+zi/iARLgvPi/ig+1Fc0s5aRFZztBWh+8oHU7QfOVG4hijWJ3aMEOB/N60TiS9GJpW7X9ZP4OD7fXPq7muriRVUod58oRaHkYxER80OQi4tfXQ3nXuugtqtASceuZEMm5seHh7mglLl4PL5RgShgYJ59snm/DqmJQr0dQpxV1u7zOXhTjapg5OllriLyRlYtlXry5I+2/VH92ChNA6mJf0xF6PlLaTIR39JiX7iVKAkPLgU9A1oa/mlmOKyhuhqjHf+Cy51Qul3kQ7AnEXvPISGPyCTl7+F0okKDF+AJ+FSOZH1BaOXCZoRsHCYdrlSAxjx8NwSI8InDOETZlux3pTqssMm4OQ2dGmsVad2gMMFhSpsubfgig5sd3LBgp8XjrY3jhYoo7fbL/Er/jbcJjuGJsXwSuwMV22Ez1Sxv63fPBy4bppAPiVjSr5mOE8V4Not+2wmKivj9SJyNvMHvusye3BlYf2z4LYU6VOGfZy1ZdtDFRNGY0ROJmjdtEoqDmsul4hDEQUWoBkRi0xGAIjAPSyYhvKfFIatIMLtyeUe1U9VmjZm+v/aHiJgW8Ml3OpxRBB9BHRmTXc2MGZjrBxsBIEluO/LviI81F0MfUrLJlze4zzEpLSyJcS8IidbvvfQy7BKyzTM6kt3bKeZ6wXDkyjQFvFd6KVvhmJ107BlIFhlsSS6jKDZYRVlsNFeY21283sceneTxezuZKJXFN2x/TPuq4T/8SEYtFQyJSpi0JIThY6KgpyEmJCAjzTo2EILL1UFhlbHn3z6MDA7QeXiWSkUimJW6ZjcQ/jhxwmMMZHnPN8Tkd0f8NSMKOTiXPZ1wVAZd585Hdqmz87d+eiXCCePsLNfT2Js4WluXBRSElHZx9iOZRptJyPhyO4vj1ZuFSQa82zA73QJ1oNU5JEIqhpVLPA9JGMPWoMRRwAebJOn7tch2wtvilO4e+sbNGX/vvlylQHZeR5OEdXik2k8ilh36QJiK103aecs9JezTxu82aopGrWzAws3MyucqfU7DqVTWIL3K8hDnTaQkQtxRNkaziZuP5HDtr6ShyuCveLJP5pmM0mVaRrTCo4u9KEdchQ5AUldM0y0mTZa6bKVKxsSNLvKSIhC6Q+Mpi7BV269L0+27UJKltVoDLGG/+p8pZNk1OHFVtVG5dmB7beh3O93REmy12xWW6LpErsXtiVgp4oPrqIXG4I7qRHL0MlyuunzzMX8PUm3TVK2Mg+iSe1mi1qJWGE1mNlmbkPwYmNU5fs48iEETU0O1tm8nLD9ijcn0ZwEwPnZQIZjodvDbixDZFZKDaXoDGv7dwHbNcbvjdJLJ5GP6Pi+egB0AXn8N7iX7LKeZ7yWLwpoBfaHFeadCPc57J6IAkrjFA/a+KCQheiZUfvtIczoehbcislQDIUiCxQwv/rM2uHsW004QfxjHANEGzO9fmw6zA3Ga2FfIi6bG4OEyowpym102/ucq1vj58gtHBGzKff6rGYWfUMuinmAo1AlNXrl8bGklnYzfmTCXVV5jM5eVobvn/wjSrwav7QVrP6mLMcNvGgtfR/ymSX3FITZ9cSqREeyulcqnYJbMCusdNOh3bPB/dsPxuW8d0g1mXb6YYNkuroTKV83z1zbBNdlreNuh3/d0wcskyQKg2yxap5yB3gyBQpfmrg8wh3rk7h9yx+hlstRUjDaVv7/v/zW0RU46vx4GZyHumvj8LIkJ4wfJRuvCrZnLIzlijLtUBfAxLvE3ekKnzNtVlVnKoVUG9X6py5RB6OZDCG1Ttf6K/2Bn1x0U35fIiiwnhm7Ct0rU6BXSPzzBP9ozhfNZQW+hG0/nnJE4BKJnpaDVO7Z/bIyJFhkG98JV9D9PLWeW5SV7NmjiNXZXBEBTFKZpEEFiwTws2thAQ/l6unGLH5ar/KNaasX4ceO6PXXAtwyVxVjclQbAyVDYtWxJ5JR7Nh5xAgPBKVeKjEjWnEj3MD3DDcHn6pWuiZsOumgwXq+n0ANm6//5HvnoXxTBK0rOadqY2UAjq906K27PdRknDfs30e3jEjlSWWSO/nvhogqdx3sproum9RRI4KeKHXdbVcJjYOl5zSBZHK+FoWu9s/f+OMje/SgmHQtkKh/mWl8lLdPYS4WU1nMYwTTe0H4tOIOQk0T493+6wVRBYXzaD57Wq77/VXr6YF5PINS0br5moTDObSozM32SGHFp3rRKXkhPKdKfD4TQ6Q+EwynXOdBXSHUrGAoC4FPj8+sAknIjoRoFGodLsdKcoqAo57t6/3Aji2gqr+I2sUhn6QERk23BSfshgPlcoRPzkyx+CbGSBvXm8GC+4ogZMo2/jgyX5rMGg7ZsgGaCSPQ1FtK4QQS/sTTMjzwp8TXZ/NR/xcxnQfe2teo2nxNYyfNo/urELFhAIwgzPeAyHr3dMMr8UlpHPWyL1jBvrAoyC3KISaFOSUr+t+Z1hXhnpaoZWYha50A8SiDTD7QGDGK7+475f5oagCn9caH9WNIIpGyVx97Dco+jfmyDByZosYw3YQHuvIc/pJHF45bxXD1qOfGofnP/OsKu6JPj4Zowgl0Nu0705xNdN/a66JJKr9dzoXfBhu5XxU8d1BGzprpBFoJUsJqV/W/t0CzqPw+gBr30B7mwz4wCJG0LoratrCIMGHx+vmI64pFg+RuGGhT6DyUWQyNTiWD5X+QllNbyDNMMLenZ0INrV++dmoxIC5u2M3uQDc0zBaR8SxBuRkvwojw5ZBewBCJcPpYo+7pd9UJNkTa4lQPD7fKu2MsZ59zHQneBxcACcg7QFrrc71ENRh1vYJ2oqM4fuMAGzRSxG9TOPaRPd+MxlSEWpG2EQGbRuBsKcG6Bcnw/14YocLBmJRqNIjFGX6oQap8mq1xura+TV8lqtVidkYQvh6A+1RWwqHo2u+Hew7z9xfmdVlomErEVsTBkNQ5PgmdVlxmex+GogYbaY8+9s5TEN0Z5gdRVsHueoQFJqdG++50StkIMu8Tx4I/Xb3XHlhQiNCI+A+Ns/5ZNDxiUXmNVuUJCg83kQMqdOrTNr5uuhTbdAZSi1vLJ4DJpVjxJo5QoOgy0SkkswVA5PkDU7mmQ2mIZ4kd4iQ+U3XyP81OhIelJhdzL53kI1q8yOpYmC9ZgeBDwu21QLmMzmqsrQU0CW1ABC9tKtqKqYL622Q7g2/xcfaG/dGdp1YnjE4N/BYVgd4ta1m1OHO0D8py/uPGhdvZKG6EjHXNzK+bxKocrtC0W982pAcQMlXw9HImLR7Do5hcelLSOdmWRnt1ankoik9WoNCXnnr9b9MbNSQELAULkNV4w+/iXT7lyC3m2dUAO8aqyRo0cNiDt1y2gnEQoPlaFqDnx+Nlf3zy/lpnlYC4wowXNAQ5rHQWMkaUv6qRchxauZvWfHuM247R4dxoSUYLXtSw18/Pt3TjxtHS1Lb5hYORSREefzsHJLvDuzIjVffznhmbVjJFdrhpiM7HJQvdtBUZihRVW750jCCsvM+xeClJ4WVenx/tEgxHsW5brQ15TsPf8xTyMii/cLNc3wLQIw0igYp0N03HuWHdvZLOIPCNNTnrqBa2k5clR42KBXU0UbBvSy0qiaT/Zykneqt5FQD2WDQcSRbnSWIjC6tvVy8I3wSZF6veJo+sQ5+GiGT5XL2oVopBudNcV38GC4Kv9LMkSKDbeYqwgY9xuXT5AXEyvMju1ntmhBcg2xynTnKJVKDVs2Y6RuN+BrJy8cZ8oPTWE8DsXM/wxI/X4zyZkBvWZBTSRzKuekvllE+IovU95x854xyW/FlFpONbYc161//RQCB1MrQZA2ZFffIhm/SyFiA/7E23gbX+FtfP2zs3s+ftPo9yOYXFnG3JFsHeBO+zYvxFIprW0mScrhdAUz2SCuX0kUCjpnvFvTKUSVvthjSUbKmh/DvGb+2lAyvsN3e2wyszpmoxx7JtP2Ezhx8GUIRmZ2W81epWcrH0p3RaWlXn8RRwEOV5IdeA94HNwP7gV3A7/zkqLpx3BTnylBE2YZqGN0QN2Yo6lReDBcajufUN9oNVswJWB9vroRco5jDOVWqVtXUHxGkmMbKKSUU+B/DLzXzObxev1eB67TKMUMGTa3mmaL1WrCEA00wP9tqDnTPmY24UaAHndBnKqVWqRoWhcyCnNWMIY/N50Oo/upeqtepdLoTATVZlvmNkd7602zcdyJIovi+qAe8hL3RWIcWRL1g3hW1cZ2+VQPF1bP9RMIvAjjuxDC6gUaNcCmwBsOEsJh+atCXrQ1Dhtn+aKaTgpiJ3g+K3eY9aZWrnV8qWjVQvvH5YYGNJ6cohq3mQrIakH3+n2kdxzLVtbMIRMag1YYKvslszgUPKSILteRr1xPnrw3AJva8TMvtePZL5gD/fyV/2MCTBbGI37U6w6Oxi88vZy11ptmYJxkcVIsKcZURWC4lk2SV4l1UVJsCkDcJW/coJiDKcZ3aY2CXjxIXEJkIFsi1iNvsBjhXUUBLZpBlIxGLv5SY/ekUtsEeWEhHD7bzT+4/XjpbKWXROTBY9wOiSdamiwKQrRchFwnpqgEbBhIOUd85UNpb3N6MndrRVgQUIGYF4DqURYHumKP1B8+NIyBHcI8jQ9nM9nEkdY80kCQb3U8xxLgwBEFjkBWWAQOnOUV4rR04cYHPRMjRL9KjWA+EzxdwXu+SLKQz10U0WjU+8uKIDkOrcBwv9kmvbnb5RABL4Avfa41fdJ5ltDx8TLnInFUpOO/GqoLS5ML5Yr1Nw4DF5FQCJ9a1fAkWxwpZ1ysAsgbbxwH4W79SlJMV1Y1hXbd/ZgFtGI5mMWTpkQ2KDD7vdvGYnaEuCrTUltJTVyxEdKPPtKPRd658Ao7koGFmY7g2daam2PYyyMizYtgR95cKAdnhMarJOnx3CWKYqOpQq07HHYbobiE83FrX9YGF3iAcSkKsg1oGxkMRSXizw5QgWRygpC+kuOoyBRiMb1Of2SMimUCBMVpAxqs70Pk9pAP9nEErW61TwzkclW9LLO+As0NnhIxW7cNcylL8TzWtpWUQHAhq7cusX3R9U1V1jh0kXP+uoyq3TVSK22tCNjEOGfyCIo0crCFdluWwKM9yrDQsJtbifDpAj57rNOokG0cnzg4ticulgo59Hqt+t0nD095JQ2tPgXk5tO3X2/32qjnUFynYQ1GHboHidfPXiajj0uGxiI98Bl56PluWJal5VgSwxKYpcfdv/YMUxOFROtxToCKtoHnJSN76uqkl60vRDcvwSfQokwVJVoU3xJlBfIMyj94q8Ak5o1sba9/mmWWSsV8hnLJdTM738ppzY6WLwn2/sGRg+NDlJCoDY0aju/zNYxegELn/EkrdOIl4/PnR9EO2m2flWbWvEG4Oi/pH6lKdHbwgxVFtWrrqe74iY3dP203+jCK3XxlzZLOej/I18cSkKUpdO98IyMpcv9bu9BCRkZuV4xprXNajETtvO9FHOI0LLBJ600TAu9cgEt5VRgmcuSInxgOu1ekjcxWVTYJjOO2xgFrSqkkuwrG1HJClPXAVJEvX0kYOZbjBX6WhGiC33DSrmvbTqLQVj4uIpCA4f9MSIt+5YS0EVCcaOU2eIfK8hnHCrw7rB5E7t7ReJbwF+ewNohiCI5LVhE1SyoVgzothCSE4NJzZEUxGQ0TWyNrXN7GNSCd2Vv71qPB8yqZKv3y+JmrEnLopMMqFFqzleHFcXS9A62txT+7o5g3ieVkkZPMG97pJM0DE96Lh6Qc0YGg7QR8DyBG7aXMlT4q8qHfn9IJU2px6cBYYgMFC2fZgq17kkUSyzjwmwU5UZ2EQmWSFARFoD4HoJug5SdejIYJyV3ueLepSlF0Vyki7Rim4SomoIMOJHQgXt3SoSCimvckEozLAvu9liNWRkwasl9+rBeXclq6qNabWiGvUj2ukzlWFHbktdTuIOPz7B/l5c7Vnna/sgdmle8iYcdLgIf+yd/7WUyq9YlsTOaC7kVtkgRWWOryUV1ilkrF6KnBe/TxvjYEXvz470kf7acwwhHMeNYdRIgKBWmuOdllljw7IIJZX2v4u7+z+69jE/QtxSmGpjlxGvlBWlSTajkrHY5NIyGqUVQFLIv7d3uABigTJUVJbaE9nCBpmurAEMWZ0QjONqqbsMai17+rQ6fih9lwWU/cZuNY84MsC4vxuFLiVU8XqQr4T8OR0gGVoW8zDF0RCC67ptpR4jkOgb5QGDjeOegDU5XqJvwtXt9n19KHuQc3nNkwnD2pZV29vAhNgu3Uk229ex4t5p1n59yj4Y75lsZUd06Z8qo5+AdA2j7QRuu/a9Nx2ZkMU5M6PR5npX7+QA5rXZuShsMQerr2aRN08B3P8Dl+slpP773yf0f+KX++tJiDOIZQ4/H19W5F1degNpKhNitONFl3fcvQNV1SFNOPplD7qQ4hkxRTID8BKsMvI8g8VMPI86K/+aN5lCyscLAydx3AzKjagT8ZltalGngnUHwD4yb69ije2HddBRPj8Xnv3jM/OvBHDrAjaNR9XMluPF5Ym8lB1HYu+yCbczfEYJSaE2roddvdmCKmwSatph/rdPvBGAq0qCSrmsajUkTJnL3M7cin3xuAes3seSb3pyt8Mo7BwFBAf8Ibtua/8EXL5z4Wf206LqTFpJx2Ey8+KRjsPQuH4eAhGuiBhAM6ULp9vk06d1YoDknJTfI39NwS5MP+UaHUqDTOsK29Gtw6ng7O4Tud5vlILCxb2Laa9CInakdZ3HZFLaWby1jo8IeLZ8+Ju3ezx0oV2GBZ8Wnp+siKUy7g1bjF9AhkJ2X3ZuYb1dlyY7KnpElHr3BU8IrGJhE670cRx7ziWFs12RfsWCGAVRKHsdQWzFgm7krZ4+T2UW6TilyrM52DojNfmGNIRpolCyO5+oewPRC8IwouxyzcLgnJvvXKz0i7dPRgSvw0Awo7QTSGKHE7lCQBjohJDj6r9StV3VEvXahGJKVqDq1uoRAMjjjwGbm1OUktvGVRwrgDEbEcQUntE0lxX/xOxZRKK7X6UQE2RkK9BMJhzezEngcDpOnMruedCqNHsNusxbPLEw4nqp8JRqCbRs7tw4XikAbLBm0zs+PzM+X9xlZPrYGAtc3q0co5zmv+m3S9egGX2+MmLnxamYeZUVzSUFbkYZcWrV1iRW4fgxhTEDy4CbHpVUzAsuOOFy53nVFCcI6hJwoKwql5fw06XFnLhSw7oVX+/pX+Y5sn3BJ/drNxpZVxD/vUtjBtqhJBLCGwrbbll7VlpOh96pwjbfY4nW2bN0avKcuh8GsjYNAnyDcORRMS8fzBhx8sCWmNiEkqV+xkww8DPyrSXwnT2LCIazybDGVYRhj8pS7ceHdY9QHxz94OQiWJYpm1JlaX6uACD5kdpdf/8JxTCpxVRiAbGvZoTnFetJAx3cl2U/6NDT23tc1szzR79x+af2KJpMtaKp4q1aYMZjIkBMFNQIVE/o3egLAoBqPmI38yY7H3P/UUf1ic1GVWzHo5Q7mU+AZmJ6+1OpUiCvaHbg77qz/01GhnGtsxPynEKiOjRoKrRVpO0iTKF18CMvdqfHatDEMSeoiTF1nIvfUayj8YiZdKTIT22SUJp2lciFY4L4sdVzsuQwV68PQ/3Wi6NjvYdaN0lAoX50iYplF2fCJK4nL73zc8zG/4l2jE0Pdfzz70RSLxKBOS25hq8qZlKixJAhko8emsbLITGuoQX95/qs7lrEh1la+ZIJ20vCLE2IytGOpqUJEuLikMx5yejhGJoXKkZJfGjHmyEaziEUFJ2etoPMyv7W5PIFp4ZbQ3uRF+S2PQ18QYI8hy8LrbwNZNZBpKJx/9grQm59ZxBLixlFPaDy2yP3OntCeYWdzpKgxbQQMCkpeWX96YwBdY6NLn6u5e3PIGuACPrgLHrHdcWZ+w06QlLzhLiNN6GKKtMJfI3yF2Xv1/b3r6cBdESMnKas1TGxmFOq0+sZs+dmP9mVxwOh8PM08jv6kV4TIiiUrCfxgeEAwpqopiJON1YvpiL9Zg10MzMi5ubMpV6UeizPshf77Ecdl0yhUVaYFWpT+/n2W5ZtKCY6CwuTZC08nYdL3etptnBXX8W8Yz6B6c0N5e8I0Pla9o5BJ0KFNMEu40HsqOm4y2Y2ASEuuBLYyUEjihV394dkiKTUeu7sdZSkzJqG3qIKPUlqMgbRBXEBSOIk9UFqFPRPfZd6O0tfFuTdIwVJH2mjPM/g1f6fKQRg1t5Z+7F3BwHnDt06h9+bBWOFbMtKMosHFaKm4iAxlkkEEGRQIgvIOpnnFyqhnkHZA4ncPRTeywfdu9UmdG7HNM47neKuX7QlK+1vO6HLFqcb1IDnsQSunYcWcqE8H0OtVtZ9C5YG7IUDceaNYISGHoih2LIoy0jX25sJK+rPpzJTPLRfPDZBlo/OFkVaO8acLs5DSVlep9I/pd1Lu5HVYI5fZUhVETQQiLl6cxF07/sr++VaOGCo41Y1KDhrD2SsyfnFP1ht7t9drRN45PsKnBNTOLtNbM2SFfMqO5dKtD0jYbo5iqzPbjqACXi0CjMe8YUod7KCQTQo0lpfCfQ0ezBib07L9r7ZmffxLbusHjiXxnWmAOmmtDd4pPEWC3DDwT450IJza7q8enhwuAVfGlDoYLW0bAC+LQ0mQj8A2mK86iGfVV13D4D/u6KlB49HR2QO3Shm5YpsKjUnBTJ8K2naag2EHceiYLAS6gcby2x/LTkvLe25J1msiveifsuIg0iBuiBCWo4ph1FJf3oG6xCc2ZYBlIqtBstMsZeL1xNNKzvKRqgs8y/j+drrHFbvANMp+UQl6DtENHZlsTP38pUZaTNJUQRVZc527TyYeBGU1bX8X5AXdAZXqdZslOQhvGH18r6fRM67DPSmXZT3ZxhUkYoGIjCiR1iNNIsdilUuH8EjfSncjt/0LyGVCNOPM1Ib2SjZx3vBcH7pW9nE7i19PFIrWwTrugweKmc3rSAgS2JGUlCyQFkt4UOFkM7FnD1pdHXQAZgJO4ElhGUNBJ7P/42zR/9x8lFVbVq9H3UHzEi9EUQVO2VDLUvcVAkZiEunchw/J68vb801YE7QQEU5zIEZRgpektlOTQkTWGpAiSEc0ojAdrGXJixpoqy7oZ5tUqMlNIjqvCmkCv/y+MBui71ZANbiwKURtV//1GtjrWC2tUulgX1mVl3dIMU73cbbHyrpiyG7qFDhIUwngrUKsfnpEIhplWCxMMtrWT3xxPX1aVW7JxdButQ6eJPj/JL5rxujC9Esa3m5URNtyxuuPRcpaq+PFHXFFtifU/ja8DafZp3NHukOWwfZq/+Ap8nwbPfXM4z/Jut/oUytuIC2cgspsU2iNJmr42f1Mll3IgaFz/I9o8snfn+qbxblED+A8v8Ar/4VVs4I0ePWhYEUsgkA3TeOI01huGSdPI4tpHaZmCNmi3YUIfrSptva3Ec0uP0In5n15b1n/KNzsnty+lMvVVK69GuCiTzScSq4PiDqPIq1IqTRQ0fE2xzvoi+S4GIOytF427rRzDUQndJqqxvopb1gRd71OPsnHAJbROg9R++LbpHZzTxfkN3MV2vR6f5pV9DXm/+7KZOR/5wBeZ55wiR8Sqja7RqHulmewi1SCDjpQpajY5Giu2V5t0tBmGVlyJE9bazqHRVMqF+Pj/7wsaMy0fFnHaB6hGxczfWptIpoM+VjsPjBrNVoc7lGx+WbDkx5npKGJYQimQXCXtiVihmNZXV5R4AW+8+Z2Bg4+N4RCAPWeXU81W9ILZHdNg4VX1KJiDBXi3XhzH7z/+M+MBgs4OrRpnhGm8s4TjRkB3ZVlOlEbGpvXpod32OX0wB+o1Sd6ogqrplh2ns/VumCnF9mE6yFOuXQ6JMYEmww6qvsJmqLRGCLqpU1qyI3ASoWiKQEJC6OC8S6ayZwA0uhEWiEg5Pldt3maQxp5daXTajrPSVE4mCa0q7t8pvyPK0pjTImoRWY1XuywnqqbOPj+ZC07wrT4pn2WKvOUxvwalrzrvLSmJXFHrgzhIYQgMtVtgHxEnXnrbW9iSJExOg3zcZDprtOY1O8ro+hdla0YCQF/2L95KpDkXENIo76GMM8EY1NFFwgfMZERfZFdw68Cu5hjYJsR0qeC5Yn2jxJQQdmE10vANsDRpupYPuaSaYxKsv6Fcqy1wcKlrAsf2/+fPLaviW1O9lw6joEj1+pmyvK7vngH7OGlatjZdE0rRwnTiEdYbIQUeFKKN4CVjlNxVcT5aQ/fPvrIkqnVpROsyYXgG9niBgxjBWBWwo1iAQ5fGondi6ZB77cOEnY8EHLYTcrkdFjDUODU491Ino8y7Hwe4yZsPDNmv1CzG8HJjMInuqvh88Uri41z3o/dPrsnRi8XPxABCo3ujXleGqqHIAstgCBJtSCplNUgMFiZpwzit1oJLGUoE9OahbXqeoevJ8NOyN/qmojuW+cJR0YjHpSHtBsd25tcS4KNbLlTIKJEY3JA5z3aD0cqeFYHtCyyDA0tG6x8DNpwSj/93rQ9hvFVGItleJxAQPE0RmHb5M8W5yHwFCjWJsuNO0wbqjQZNf7l5EQeOz9GU0NQBhpEEJhgmeT5XnXQKDJiZcX+AoA25hygh5aWNn4vXWmzd+9Ey2G2CWSOwgdi9NJKggjLgPc8dgPzViDVN96sN1qZi5bbd0IuyJCfxTgrAhDjWGSakHSNVx7IEFCG5NIuCyDC+6Qx5LQuWLBTMvN04s5I7Zgfx86OsZNALScWJ6xgHDzJowYVcWvMPQeszZXwzFo2qL21cw0+oueu0PccyS4qax/2j6e1ILpfNRAP+g3pV32GZC8Huzwx9QpAZTjMTz67H1XyhUhxmAClixEdOzs/mR1mYSorHz2MgTmrSwixj51ncLpTWE3ayAwXU36n98XM1tdAUj4y0sMucobp1hqsFBlZhuW7cuRwJ0xSGYOWbWrS4uz8QaDQ7wblGqzon8aalA00xA1LMtM2vbd7dZmiSZCzPox1MbY5HlDPpMMFvFJdpKSL90MhpyMCxwVghbKHVTcaEzhu6zC11maxJ66zniCsWg9BC7bJRHaPQ8nj+X9taI4USd7XFHiqfS6KQZkerwgedTAzsWFhvlhsowDKVJFtnnmSZj1RmMlPVX69i/SYadm/vAd2NTiCfaLzD5H6QZyYGwgoMwK5RVi6yQpClenId5LUYYFPd0VH0SRKuwS24hmfwk2SpS2pxrXXCxM9ShezYudY2Je3Iylzbzl9YLjeaY85Ma4IB/ixb1ST6kGkQlxMKeg3XvOwxV0cgGDaG//+67YcV2DqrAqIgfo61mzAryqUVvlW2x6e2ZTtZ9ZnLwlDa57Pl16EdXMNg7T/eQufhGrz6bJaiYq01u9Ygoo8cQQJVRrclaMhWt5Lz/OIqulH0C2WTtAHj1lgtnTeXCB/3mbdZ2LH89RspHNbwesk+tlK60Wzaa79z3nUvdR9H6lcbV+PAzqm2VNpnmP+iZG37qMvy68pP3mTo9oP7JNTbQHwMJQTn7wJ3gzM/9pA2y5YnifxIr7H6kUdmi8m2txV99JKccCqlkCep6uYGlymOY6hYnpk1Vu3hvBMyXaUDueY12U1J0VJA1mDgNs61ShmjOVx5jEgMwNaJIyv+1EhGMbUUtyFbUGWLp9DNrE0IAA06mxEXAOEsG4IuuOo3qelonBo8XpP4jjOcTBa5cWhnFNztko8viH8VcZWZp3JoJDBVy9Fkfin6K2meGlwKcQ2Cte61yyWT8Vjrf4NTU7RycZ17B3yT04S2M0kF31DoV51Sz24JPN9Of/vID9J5Hjj+O+0oTk1j7eg7gWa4499H73rzriGTdiZTwwx1SuZokXeKyg3Bv2ty2OellrXzev4mKaklkHM6A88pZRudMQoguDtCYk4i3Pkl4w3V2Ag9fPDBiEQA/j9JWSq44WUJjUl2Iha5x1yG4oWsLG0FIQkEtfIfuYrZolqu1lp9GHX6/EwoDJGxpTX8QcuMZ+CSJSulH+pHOcxlGxbrl7NxvKQDvNfAICqfYpGbxcHIxXvu5y6xQf7lk+EwzoBF7boAft1Al89uLddxsLJzMtZ5k0MRPeTDzPTkZLUgwSSgJALjbIv7EzdGVa6Fgo05FcTWjEch1v1pkgBilEtADiWkrGgy8Qlx8YjJkbL33BSyMA2Mm8xWu4MgSYKwmnc74xl+DH3BS8mHV2Alqhz+06MpE0vjxlYfp0kFdwINraQmoyEdkF8Z6GllYE6yb4xnjyLztAsJR//tcGNg8YOQQPWm2kBT1VjaYw/ublSNZkOrlbgbLkMzC3X05odZTFAIczYRwODljurF83XaOrTkpCoMDr/eRCYUl1Dj5WyR44Nx9ToxlXqpmWC3BZIhKYLAUVsLTglBUPNhC0VpqHYEs5Akik9zkmY7cKmLlqwRQFTDupIaJdaQw1gm06WwTyIYxhO11MQghWw28fDDi/ZeIl+uV1urclSTSebESaZaToXEpFrqUMbwHtfeTVcnNcqt3Ix9fovHBArC3M97fZgGjA9LpEDl0FUBiRs4lqHrpu36QZTE1bhIzGgvt1tdfUj86Xi22ggsl+sbKPbgbrbpFKsSWNqw31aN6kOezHus1nA5+phEJgOmlrIzw94JcadA/Z7DJr8XIehwZarV2KP0oY0k/AsWikQFVo9Hato+jDxZoFmVwrZ35dKfbumNaKdYfm0vRENDSXGv2ZZSnnDVRs636V6MqzILLYXBMdhtRDoU3bj+d9eC+WKnX25QNN1Nx1sh/t1/Ob27JegtkNKw70aN6u3vLflhT6K7p2WxbCDVPN5EdJ4oyMjDu63vmEzqXtlxBCYKY6PGESKPZtxu0DynY7Vwfa2EpYYx1H7/GIIKoF4uOn+5rkexSKyqZO1RJJvJqfnKKS8J4zjBp1lezgmljBFuUW2MxvalqOBbfAAC7+ZHLVUptYXWqBuDD4ExsZoiSuF4fZuwu9m7NEOtVjPppJfEmiiGa7PRTg8oz2I5HRWuQtQyqGMPx5PZQaaUZe0aq/QGoj+qSq+mfPl2QoAu4+pGkj6PZ8MiHYXB+RX2ylklkVe/XTgdHx3+7a+R0fGZ5dBWKpVJquGXUewvvPFLyvnoQmhlcWlm+PuPP/pwE6R/Av6+iLlueWcqzMXMlNH8uemiXhPZ1F+cT2bCKZA6YIeXpJeeiFmMHXukBkaJdLwQc5OYrKusk8MgJoGmUjMsAhxETV0Tk1y3L3wnlJZURYmvsyzwVfyCcWURpOjjCgbRQPauLDRKXIIaaeaTk5q3XFqHSawPozjNy4Zly3KLDZaaf3V1x7HCdtBudtrtVvOsqiYPOP9J3lf1jl1+QwgqM3zYGNYTeGqRx04nYF+UsankvtvQM2SlHyTW5VIZnSg3u6vh6pBamhX0J/oi2ALPk0ECNs8351sh4SMU7py31NIONgDIzCR55Q7Y60bE5XOnQeYIkQsT8ti49f5HMLAzgpqisWknGfAvZ6d7/cWCBDOHv5ad9yQ06Q3bcO0HF+VDFtkDcyU6laXbqb15u9jPkDGQ0YXYUdRmjB9dJSBATLIIMNbFw4ZA3oapzGy/vyLBGBJSDQdwT9jG654ieP/u/pUImHPegLpGjrs589lqQGyc/BpxH/XccW9ShrEfJXHk2dZPPQIiOGB6h0fwLzxJO6zB7pxy+BTM8J23NrHAtoOYyGenDEedpxPmYGE/Dj5R7ahhyIctMs8CHGKhFIdieH3UG4nGhbAsiyxFMgwMftFd7s7Bu80JZpbe7899EO5966xeywmbbLPDdltU5ZzjppFW/9m9mPlApyjjaKTjvMUBkQSrx7ExO2o1UbOeoLNLdA90dbQHTRL8fB5WoAknOtLjav25Jf3xzJqVufYSe2eo7XwOQdLS0TeqBUbtALdzVi/N7D8nBI3uvqD8VFk5uf0JM7Mr1p5oj/qNdYT5XLRYF0kn+1/bkJ+rNBcfPlz9S/efQrOHwLUyFg27lnQNeLyB+BeLaWYadN+OCN16HE0KHhdj0YeRVB8LLfQgl6jH4wTF8u3L3mTvaLJtX5crP1rdTBSz2byqpnnsJknTwMeBrQoUgVMchXWjzEX7/huCyiiKqhuWn5azpcNhYZF7ANDEkf0nXqIpBopguNP3BCdS1x5+2dkpq5V6rUOqSe32nEHXj6rFQrWQLbSpdLH7w7h2y4TeO9aKI9n8yjBJcMhMMiSJKIAGt70HsloqV5pdUoxrL8/p5HmlrMVkKduXi3r7bE7s19pgDW4QPxfn43ECvZGtQSzW67osKS+dCC1WkW/RhvKis66Wh0E+HOaBykAM/+77WbvqS+ZIJv0valuXn2Pl03qzN9STPl/gRE6SZN1Ny8l4ciV7ZEloevtit/TwxtzzHZoifEPfciJAcvq+zA0AQMPxPb80LTKqH0lxluC0aMSY3GdvYJp6DS1Fg3yssRoCK4WoasoSwtyix043zjRbP1V0GiztRWb0XiRzMv9YwkVYtEw11UJ73STBIyZ5VjKIoOF4YxgMnCfVhBFHc1mZmc/t5sJ6pv2t4z+GkdECqJ+897XV2Br3VSJxRbNiRofNYjLotao+3UCCZnmbN3o/8VChR5UCrLYsx4MNNud2y3555TeeHap3nd8V3f3GpSLRtCFeFJr9ysxqzOOfTmdSScoGCxtlbMuysB4S2b6bEM986i2UrQ+DwEYXavfr1y6WQy3giw2d2zHPh8OkldAyTBOvYqcz37yCmd99DOWvuqUqdokrkBsGQMaAWaZxuewmd/pq9se+vmfFFdwdv/hjpcbv6X9vArTJU+aXaFn0uJrLTcIwiEvqvW/266ma17ZRp4/Mt7UaW9jfmXU6zHyeihWTPljYHya/9Lt7I55AGNSPwCi0DpRgTT0arQxiUlwnlEi+tjJRpwP53a58MOuyNEnfmDi6eEuEzx8SvTIRfuWkDO7GVS2XSSbz1QHKcQzPsrwgqbrtuLoYRCVaC46MC5yuKpI4D56hMER3EpJiRABog9MyHBm2M85nEpXkpIvs6aAsxZ2rxbRMTQGNRITUxh/DJvNVvtp0aDCA3f6MpuYT+uFkuQzx1gMrjotkJpHiTRRl+YpQbKKOyfqiSCwVq5sIfSsfzxa7NI3ehNIAvbypVHni1UD7j7fmEJTh0qPDG0GUZrbreXGx1i5Q0Y0hhE86P6Y+1qq0gYozjjtXl/jJodm7xxJxLL0Omuyzty0BzDoB6cxYr759MV5fxhACxTDRTi+osmE+sNtDJzefk83nVLZBCmtDGpPvN7JV+q2iYwJSrRH9cH2Q66YmSqaTiCtv8shk4eIWc/MqDgmxCSW5ye5rlphrDoNQQ9VivdWlU7L+UO7ZtZnOXYzwpcfZTCk73G+0zfi57XdTy0gwAzJEIczh8QYkoVMYyIv5TlvQ03p5CwgPk0HMIrWS0ejg4BYmQic5fpeJcPKO+d1KLsbzCQCbF5bEOmATliA/AhT8r90ul5Rp5cFlUWDgX5ve3MjtuFkdzPeied2a1ZDot961WlUxpTKvVjtBMMBRQLYy4avoAPSvXCdIMsRGCgNXvpOZ8yf46I2lagkqzwh6SY3U9KiHdsLyOOs1j/TYpDUsWP1uHeCmMWuHvzbigtz+ZPM4SO3VzUjNgNUC9o3QXxwZ3ZvWjZZjdo9bwiqZzW0PCPcYF1VWxzi7eeu3jpt3TQ8njQ4Cpio3HfebM1Rmcri3QsHIsp73Xh1Hv2cm8UFweNpv12ulfJJaY3Yfx0HEGZpaARwwmH7uWYTCw1B79rmrijUFATHy5Ro6EIxfTJbNpFjYLgYersBxVKJiHl89nc7E8Jxo9EwtHSFRggtHYtlKpcqeL/qythBUxcqmR7IYbQeFz5+KMyyDnbsgrlNI8VqjJeJUvDaAAanXG6j7EN+XbFZ8Fj5SX2JAeMi6avjDeMCqMamVv58r7wxM3v80DaNiFHmxxDQI0voscjseZB7IoGu8YFaKAw8uJ9agJlPXLKaCStdUw+xZMPskFYrvqCMjLBAeUVbRVs3SvJxS/+7yti5fDRGu4Wg9inRfRNWsZoqIWQNTjKQ5YZpmgV4ggx65MtmxJCl7yDyFsDsVpxd5lnrcvNzWSe44Dtj2GkaxoCRDnYE4nwsr6RaQCZJ19wxrE8f8qU3VckKPN2kWudSEf9LT8VZfbfi2GYZ2W3QtI7VouUswnH+srWXjGDsr9BsHhR6tpjXlpEnVDzPF2r+YHIhwB5tX9HGl0e5CCCHUTh6EtGuAAa40PaYHRBCjTaOvJnZauSgUmq3Q1+L/GT7tWa1zBtu7e3tSrU3pftRpUsVMEolYaVGZ7c4mn2flWbeDIgfy+BOOi/2je6IQRRjWcvSZb6gwZ3wWBgHbo5otD6JpSEcGvzF1n1GULOnSa7lYXiKR9p50Sy2q4OMjRzsbJoWrqS3VlXCLsfNIC6E22JnoH/QbMT//vn1v45EX5wY1+84JQfqLt9QT5f3dmtU1jAownlbUsnG6T71p94mmYIEB/RYqG0JkHuke1gJ05JkhtT0u0ahpfa1m8l2ZRggEQxIMR6UQSuVM9E/nj3QclVonCUnE4vAELLIMUspXbntawqDu6jtTt/u/dBizLeWG3bTjoDKt7ucqHRGTXwbbMqB2tlB0y2RO9/Z0ulTUebSV3JkeHu1yS9gHD+68byBrScQzY6MrwnXkeaSV1Jwc7B/sibcIs5sfn5Gpe9kS1ZbjfaDJ0xsrZ3lcpvib6N+l72snnqjJtx/LhPqXLQPqBvVFYrfS7jTOK3NpTLJYSgNDNpNLMDehJdJItxXTQ+v182WuQ0mUWJxjKIqkeD1J+IM6I/jiOWAo7a6fc4lPEwbxwbRa9LGlkfp5OU5sWWABDWT74PEzLRjGomw15FMbsd/pUvYYbGdqVHu95hkMBPus0y8qZVOVSvTBVpOQh9ZWlPuKOykTQ0IjpWHHzMejSfTwxh2YaozTdhbjUWCK5ABHGP1/vb7pVuA05oUAq/NvNArFlXBZe6iRXLQwFhcM156palYyOdCNqf1eOctyX65mdRqYqupWsieLTRkQxP2zv2OXDV0PK4EEXx7vOLkOG3u+pymzzqhHR2rwEcjGNTtzL8VyfLQy8oMNQ9ZVIuBnU+W8fh55SblhXQwz/gCZXw6CxUN2pYemCDrW+Nd9qyg4+LsCf76lJtFLOjPXzJ+f1bWq9IX22JFa6xMzkeyKUmcwUMOWetxGDkoY4IQKRhZ4fAcssyLVbyuIrbzazSnT/3faAE344omltQg63n5mzrLa1SmNWr7VHU1lcoUiNyEhT4t8CfdkzzJ2K3gwigbcuM2v2Xtwi5mgWfyXxAe0dAJHQz+4Gs0tRhMnxciF8Ex9H6T2Gi4Ommza8TNG84BPu57c7Q0b9N74jYx1zmgnQi41neLPhLWbuvkECGjmTZ/HuDRoEEaRGV0Qbxc233iBKCTxExUWUYwyYDogEM3C0y4IaDt76YHgcEJTO722nokSgYC8SSpxbGtm/yI9QmLSskpBhxD5pORDuv0uvZ6v5vl9fZ1epAB3LgEgEdwD7gZ3K7wpPurfuzCCUWp9BmwYss8Y/QirnPdvxuq75e10I5qpqKxG2dAtFe4Cz1YpsMbua3UI3R8OQSU5Z+S2yra6HMcOAuZQO/1qpH/TPuK4fosCfe29M1qS36UrGu+Lp4WLHDOpAA3V3BcGFX5OtGRBjBIV7gtGVH1rmCZxX+Iq5mOb7jGhkHDvpabrscfn9WeZcr3RIaSoRsh3ujOyd5Ogxs6YDIXrUy7Pv3FOlsJMKlLZcww7z66BXJqVo94R9Qum7gb6NDlQa758phdm5Yr/FLL3DLwgljcjoOSEYJLP+wSIgrmAt5vhp2BPsSN/ubmdjD2I4R/M6moxhfuUWs7Ib1ZqzWL+XVrRqJMlfLSWlGUpXhtbNUIbjA1loHk1wu5EUdM2tDj/sTB5LNqWDPEL+lP2ZSZReDzw0PPIv3XJajtbuh2cFzBTUgiOuii8fjHVuxP/yezOG6ntx+naPQEOEW/8HXOISjzh6o/TXbTf+q/RZ2c/Ae5wsai+WQ4HtZrNGj3dJc0RcHezxxub5MHD/2MGNHytJ2FvMD8waoSY6aDpS5mr1BoYcRoaSqUtObLEElEwKiFqTpl5uRq1yZ+Zc1ZSKLVQITIsAVRal5CY9Xn/lJBBFNUZKcH/qU4674wAVm+cgZv2EKiY3bMBoF8yWyyYN5CTeD+R10NGnQ2tVCl1o9Bod/voSDjgtGh+g6bpRMB/SNse+OFGYGZjYZwV6PGEoLdil5YEj+82b+UZuiviIbiX+ijLhcikXusP8UDfgMAwarBYrWZBtxv8tvRev8vtctpwwQ6tBmDGvBfVVBXLmc6iFVmgr53p7+TCLHMxRgmp1jgKNgzaZ4yED7Gc9jhl02E+Lz8syNlsErVTGTqEKCoK82qjsx/vsR0KEHBAAYcXCO3IpsRUTdXSD6uqGLWwqzaGNfKSyRdQlR4c3y60trliw6Q+Yqu3aA892pjYy/1SzZBGY2UyA07iwo2n08PqXlEQvi5xmefnqKV2ErSTQ+jXAUrj0FX/4wtyCKiU2cnDHYOuFV/M4Z4ohn1W5KLqMWRHCj/LpeenMMDkeavo/NWxiO7mbr+R1GZJ566KHRRNFqROcZ/iSoc7XWvwdU8MjQggFTVFh64mdwbZqKSb4867bUyd3JRkru17mwnRFarOzBiPQo2PIEYv+sQya2Xm33huvc69V0dCkIOMY1QUtIJGtCI0onMO91/11rWgLh5/HJw13Gx2i8s7vmo0OBTs8SMhpkFTV2XDoosD7VVHCHC4zaNy4PEqZNdtIiFxCF00IvDBgeXaEg/bQ2sESR3A3YBHf9MLXJ1HGYSEHw+6HrlbETgeDbHblBT14zMuj9W2pKHuR4HOU5CF58t4Cp2eoHS3dVUTBQYwZOh1ttM3NloKd048WssahCvINMyG7v57B0QiitolV/j95ezuvB/bCZFf9qzG+Qre1ePtjHx+j96pwGvVAKNYLNYeNUCdtXZ19QyPDsYbHV//2RxpVzGRxUZZFJ7NFe6I/FIuFAryJqmpqf5UyKZSCf8VOzSyHwNlNY3G5bP51VyxCAToZ+e0NM2uZZ6DHaSkGhXErKGWleE+QH+fbPJs1Wu/ii3CQYWxusUS6P/axT2fUYJsTb7mZpdu1Z/j/axym1/ko0sokrzA69WArFin2h9Mqw3NKJ16cpZYmCr9/ztRkzExNlsBvO+HIW+txeLYePFq+d04MnXHUNIY72g21GBgdz5uHzvZ2dBCsTSGQCapEQEAa3ZOqz6oA7plqPgtohNL1LtovffbuIPb14xkMgj+S7bBhyN8nN5fWecz5md/+5nL7HDRVToRvfnFgf3SM6gQhBupIcaj6iK1RllHNSw38F9WnEl2VQ4ktWkGY8e0tk9gHqD3307lfuxQbT8epUDrw6x3HOPa+1RdtSwHiDP0um5y159tjGk1mqiWE9dbFxyVtfopcUkhzNpxG8G+4ETmC4GlaYpD6WYv7baBLb/hhBvp3uV03M3XqqTDCFief5slv2RVMfmJJ//2R76ZXpj1jvgUtU2KRKX6uTWomKEsnU8oCARhSmOniBYoJbBd073YPr/ThVsQvRGwR/9V3+YajWjSRHqBK+ULy3sp38pwH4z3m8h5x857FU2LLsa7i1bGCODVLmTraF/u095kdyYoFrvMp+1G98VEPDZ5+il+rBod7mEGg1BDBD74240GOvPuHVZ0GaG7LnfqJEnlD96vkNYv5u1bnZB9rqz166f3zqAJ9soWwm6cM8wxNS7sk6BcKl9o1Ir5KBMU89VVg3Y1HE/qAOKIoDtaIu7D2Vg8lqud7YjVcDNPjdmojF+lYGXEp7OJjgGCGTzffyE7rP3DSYLI5jYFdoFaxIHKOGTg43kpSq2EHIcYDwudVTHTqEh45rhiWZPi8aG076Fhcfrxe+0m0me+ttYhM/X//nFPWCujHN6jlwlUYtL/FvGsPVao9+3/sZwlzZCiGcvayGgeQdpVJMko0HtXYGdwRr25GM2f+uKG0E44ENsInXhfmxvtGiFTsX4+LZIuZb5tzKAgcsm54tAjCNgZ93b9VcqR1HitBljHDniW7glCldWij+5pqWKo4+pRMJlbgF2wZHsbEP/37n4nKiEmhD3qm7QtYsbhXgQ+T4QPE2G8ZVVFMoJwVlOQRMU8wSIlOlsihSjBkHirwWeFOz2HxMSiThq8qUzntwM1kCDmMIxFW3YC5eLh6wZcThhE6nJPPFdr646v9DhcmJr3u8BU+B+GfLw94mk9j7Mrb3N6Cb+lG4Eu577MNkbNZcUYfcKeCBFHm87yRioMr4+85H60DBzHdL2D6SRB8xu0dbI6VyLT4nLi2aOPTq923tdYvzOFANbrMY4PVxVnxpXu9bD1dSeSXAQax5VKB1scgbp1F19P0sEjVaTAcymNhD1e5i4u8LTtD+ph0AAoNm3t9DAZ3xZD0ztnMoi4bfcC30+em2P2m5BDhUhTHp/VH9rsgMrGv1QYUVfZ++88n+zwrXMvFjNSTsoTT83HZa0QHXM0yWcO5ayPkueJtmuLgrVRWQ/G6RWAbiGyISwTyyMHEKMV7XwvWwGQwLFcR8xptA2DXZAe13GkcXURaUYzWBNf3UvPzHzKmES5fV39hexxYmlvchfWZZW5h5/cM+ml9ejphDUgzeeX0Wj9X6+rcpFV0wtOz5djSfdzQPz3yfu+E3cwSTXDD4uKX2RxUaoEgjcXtelWAPkEHk/ZMHyne145uzPLU1xaKfBpMvdsu7VK/Pz1y4xdABlrI1ls8saXAx8Qu9FtQh192lWZOke1INzCRxTjHI6Cj32xqJD//Iwn7Fm9BhM0Xe2wVYeLZxz3fmLzgVoHWtdmjy6LvFg86jceqV/+2Qok+eU6kf/On8wW1FRMU/NqJhGd6HRWZwqgiluXbJUpBFzJVrpKeOX4+un63PkfaOX6n0moDK6eYcFIBW8dwwpwwqqhKHb0SSTBF1k9wLDbh5DymBe9wL0jEmpSiuzko+mlIE55y77SKK73jT9VkZtAhr2KU/2R6E4No9Sh09arMlu6/f8D9bTHffAWh2jX3OIoTHUWx9n9HW1iws+AII4GOO/AmN/T3l2gU6cTSsaV7QrF+jPnhsL5ntc3g2Lwcseh36VAdsKU0APIwT/d3BHzF/+5lHBS97dHi1LQkcpe/lI9vzbIy32Xa2OodtQqY3KSHO3Mtuzamg/LZjhG6ighsHZN6WI9PaFcEAJNHQ9B52fM/9tt+sVUgoAfr44gL1HtAOL2b5xL3WGrknLDqpk2c/qsW9QHTUa0HC3+6IZRTNusid4IxkJTM3SvtxPQ1qz3bMnp60CdzfDbp5eRyD4LbV5sZbZ2ZhCdRvMgc8IMiiSCeNtkDl2kkO4gNHAzAIPrn5RDHoAJr3zjqcyxseRLU2ougkJ+6eDNo51ngNi1zOvBziSZx+IB88VxPVmG/vFiT/eD//+HfQXGZJE5z9eozzfeK4huOWNNwRlqntJmwfHS1yDH3C2l328qXHz2hzdf+63rKR84wtF0qdFtroPKaYiaxTMc0a04VkX2ANWBPe4WDAkUTMNRIXx9nAvAnPvh5bgDv9MqQh8PsyCUYChRyfX9T7fSPVmq1NMX8TMfB+rR2cc9rYS+lTxRQirKVZud+tnxjF0rVdDL48WBjEmSj8EnFINRkhWPPeCcCSSfAJB75s1v/gv6qalOwFo4gq9kDStufXwhNtMGURWs8sM95lgwtTBoUSvrMsYPx0yqjeizrr551dw22wDQJQY25vvatdfn7vFmDx8MH+TCXdGtGeGMJCN/rlDMxQKR7Nl4U8hjZkMkm6+6BCHGVsBwzE3+vNQAlrDGd0lUqHBkSLiLdSn+W+f1HHgd2dfospqlLNMQ4yk5cgz3XvArKZ0S8Zy5fgY3sAhCaKCFAPLp5m7DOK7d8h4VEq2kFidwMRZOjuedmJJE7VMgt4WmnxV/qPLoTciF8+5Iev7CydjJMHnFzIUVmaejcsQPvbodIawDTmjcXyFesMieykoUlUxsRy+azTKnT7T+iy0/gL80My5TLl4M1U+JG88+xZY8xHpu1oXcjEQLamM0bxYOGt56lY9HPNXofFxzT5HXleCgzlEWLvJgQsZYmvyTnwg9xDcvYfYZtFsT1vtpB1zkvo7VBvKD/pPGBMlAkP3WXhkdONypMUuTn/iizO1WvVF3+cd/VSobvf1+n35p7jq8eDqtn+dWeUwJsmqR1zlF1T4mmCr1tUTlXbjkFEUiYgHGhksKs2sLmg7sZqsOa7VkGwDBjf2SiR8NCkAOiKBhZzdmZL9j8TVFKcGwI4Dnq6dsWsQ49JoZ3oEItpy8/EnC4sYfu2V9iCXPZNX5ab+0jyodsTpTBRzkObhPLw6MV7dWOKFGUe5T58nW8eRJsLT9NVAYd0dfMg/a8dN8asj7FT4Ra62H7mRlmVeBlfjw2ePOw4m981MQPfBkccXRh/5jev/cD760xX/HmK+xd2ugRN7P//sD3Y112NkFbtZFaSS/qh7t2vKP/Wo8/06GFL08L5fTYwRGT9KdBvuLX4Ms0+4l1EGPSMykHQiqydEsDpasizIcO/zjM95UUxtw/TR19jNGaIgiO5ZPdlw21oaeIFi5nIx9gget0v/2ZvueMnlT8skL2B0wppvK7hqapVoy15uEV+pv2vWaiLPkigGdMT6Y5RCcv2b7rDmq1FhaY/y6vyi9d5XIvEJHPLtQX19UJbomdrNyQ/bMQuyLRTl9QpdJmUf5C+MpOhm5raIlg7lUeeMwMGeoteDXYx970DjRbE8jLvavjh84z7+1HnWiqcwDkmBEqvsdlcr9TbrRuLPfTK5GmZflC5HDsu+XcSiohYO9HOzCz5MnO0neO95i4raHRE23BXzSR/Nv+hhDppftBvV27Qk/kjYx5x+Nfm4HMRM5buPLO2/+02FWL+WwFUexCbHYgU2Iz9H5uafQBCgM6P5yZ6dxjD2rPDjO5vr2JZVs/tFHHpEJBobWDGD3kmAIXIrD4aQvVE9Ph/dv5ehZGL4y5BQQRZAVrySG7GH2JcP3AZ8WbyaL3TX26ZuHPMiz5SeXLy+Pl6b2zAXH4F2KgtzU0dGaTS29lgrv/0Bm0039n28foHpkm51cmJ9tuft3tDjI6AEgdfc202N09m/NCwHqFXpbUj/9rfXWW07p2LY3NNEjtM7IDdH3J59JfhYGYXh7muykP+KcUb25kEIJbYKpBM/AaDRLC1hZRzZ9Vqy2edS8JuJ8pVupBJ0z84H/Dy6D5q6GJHpOhDxtrYkHL8FM+ymFyouTFHsUEDzBxE7txjenJDcYv/qey+ZUCUjOaJPr3nA1kYqE1bHmdA8LXSFQaUZUDqVAwIfGE8m0LhOHpxSJ9A2fw8qU3t8cruudP0eia+UIX/m1jeyKFHFnb+dGwUQXPFbAF/3FGKuyF/Bj+1w3qDeh3EApXtEGrM2k4U4D23SQBH4+fgPdU9OJJnYIYC991ecwWXc+RwlenF9eR9BX/7J8ejyU4vdzE2eMLE+gv7oTuAejsJAPPAwm9wUpoZJm2j+MYyMUrVyVLKeI/No1kdcw/CAqwRv+mZjrO6vdabhaowXKQIrmMVzs1BONJ3nglbTrivLryhbL/nCc+YJarZwKuUNy+Ke0wJgs6HCpWy3Qy2VyLuo/RYehUPBJpKoqPFKmdDV4W+okqQDvLDgcntAAvYInszrnYC1a9P+11a7RJMXkJCxItRvIBUSElblZ9/r1zVEzkRbzfnZwwRFEFtMIYpJHvT/rt3MYbDGbdJrGb8SiHEUzjQK0aEXFwE4t2OS/2TNZ23FFdeCbJoRMhMtbRCskeRVT/9BYy02mv24lZFRdRW64GqiUikqmEh/vjKHKfrdVN6tuKHIAyArOIUMUM8q9mv7gPf0EHVj18YzAKenPrst6WUVOgUWH385IiqGlvGpcm84GjmlI+ulK4PlnjgMIItTSUzGvBOkNAK2zW1g4Rad4ItOdVeoAg2rkL9Vh62S3ZqQ7iQny6EST/ISr9PU9xM2YNrTVdaADPd/FZ+MtSZNHWODJlw2FuDWm6wy04/58pmAMVkSQLMImnKx2Vo4vju7BR7ntW8Qkc+rKXVmaJO185yhGlxlor7WiDS7UjpdT6C3baA5orvpQMJQ93CwhqfL/zP8MVBICXgVHmJ+T33TObVZjYBR3f3ICv3MvT0D/OTu2CHNcGeHeXQxWXx4MIP9SprxrPR6t9pDjebXY8ns3cPNKIMaVtdrzArWzhk4h0byuU+iHrsj6vlXOKDCRZGCdsUjaaFFRXacjvfv/gTyLApBbEQ7aNLcyz0i6KcBEUtNHekQ22dSCvGSHqav+7/xuh9Zzx6qgHS6TVPtCttr/3OVlmiTmzkOL6DE0JOBtdPGkZZX1lCTc3LrR+iW9lq6B28/mJpiQr2IwnsaDseen1WORlo1QMt9rylfZLBTJi0gFk8lF5otoDKOtYDgOmTVr26IubUejbUfnsYefXs1vGBrKb94Owzq0UQNNJzDjyXOPIWA/sJ0hkqxUf/MlzyYabxots8UmcYEOmEifXN+A6HpG24WyU8NsJX0x2IyeoiHbkUY2C1654b7sWRQquGbbcedI3vxTkz7ix+r7pyn/gtt4nAErhucOa5OxAlk0P1xpPPwSDDuuC2cL2b7ZD1ByzkmmPfclHu9Po4AeHWWjaSYTNI7ynNX+SA1ml2Ef6uyo10nkB9V27Fq+2uM1G0MLJrPDKd6HvzdggjrLYhqZtt1mYS7tR9A1+JovpTbNmQxUjAjF034cpkOGiTr+XBQkbSvDzqak5BVBWWNC79Fjk74F6CSlVVwon8OEMwaj18TLNpuYXpjGDULLCKNoiJwmjQFjPxNS+YNYeqBTNciBrtcEuSShZUgESpdbWfJG5woDxJD4pKGXyJ5eHgYHCiszjae/X+hOBwRw/qxusctl67WSFMJRe+NDNLv7uTWKN/0LPCSUTYktOi7zKTmydzS6NaD0GlENPf8R9YyHvoIAOeYHPa5TgMdBe1SIk0WlPRCPOzh0iQ6EKK/heDqZOduOLLXGw3FscZpM++WjIjdPRm1wtZ/ZW64CJhfnp4Bh+opiWy6oEHOcDU7nZjKeoYORMqC8elDC3gn1ularUlKZoYByVln+w5Z3sKjj/NwoGW8jG4n0IB0rjuSpK+ejMHZWPj4PcMqYtouG5jfZ6fI3P6fRQICLcGIEUbiQOAqAuLO6Ko2qrBWMsk9Z0cnCWGlFRqooDbcO2hVqcaJ4sbPGmv9kTP36Oa2JUUxmhzMv+oMFDhtqt0LGPS7VSkjiBXELpShk0RDvWjw0QgUozQUprQMkRjxucWjeQvbC3M/laXCdpe8bs6d9qaYP6xk/YsfOy5Zd9FJz62SQF/dVOB2DpF1m13tz8DjA2kRJH5hll0q1kOAuOFS2GksRLv3/xzJ+Nj4Py4F0xysN+O5Wm7w4VL4yuzv+83gTFHtg4eYYcq/oQZcRWoMDhmopcRubsTbuHaXjc3CyVIHLXR43RnsNt+tnsC4Loqp4wy1C7bgWOMyWO9L26C7uuJL0Punb8YWdO6jngkMMv1tD38e0GEWjUjobZpRZaFl0ZWX/M8H003nWPtCPzxgD6QpgvYA8/bF4t0tY+SSmCPqOrrvxUV69vbK4Hlks0avjWLuBpNVDQA+atYFtI6ctYc346TMwCcTi8rueH3vCiO51cr75J7Th7e+YSYiD9BPp9emlbwMnE/U5YFoRqcEjDO2RZHd2rrk+sCMo0ItFIqueG+ZlyMEeJNbQtQraHu0E//441kGtERLzD2TN7DBgyL+pPhN9QvLnYU1mL2Lpw6PcFHuMHkBQ8uvTVkr0/XfMK/DzqbxrfGXWgcjrE9E3xsHzzYfVwm8axqO9IdbwpyZ9+21gWmDpiWxFJkn95AbcbhKioUmI89HXUGlWOpc0egmp19eyO/vAioBDtHkZV9zQ5nR2CvARtP7EzmfiM8ur5hT+RtX7ivfMQaGmnbXjT6mU16LAtZ52OuqZxFWkawJkkwiTzmvg+/+D8tQvcIsm8NO556osqavuF4FCq1nZbJ/qd+iJ18+vG33nvxD++SgLVKTaBrd4uldlz/l7b02GQqPAsrgpmrsS+4ibAlzQDzbYPDG/sOCmCZ7YHTee2kp5+gdxYWe9x/l8iH60Actxq1n26Ovg8yjQbAfyK0csJhkUvSOKdFAp/2G3yU1y3ukWk7A9pGqKWb8uXAjnP3t1Ni8OYD+O1Jkfuwzo0ASnvL71flLOWt9QWKGYCeuX9Xvkol7Qs5AX0d5cXVkH+MgitG42klWCftjvbueQa8UVKaEhy/MIXKrZLh0qLor2OHDGshXBa6/jV7xssLH1rn+Lj++m4UmI5oHqdziJ2dgQii5VzKhDj5dqRkPPp+ELI/4tMjOgm6I9k0atPgdNkaDvvhtGSDxEaV6YjgqZn5kslXAuphz1RlrbxrsqHleCD73TTWcDkxLiAQysHV2KEOu65pBGZdbyvA7wckOkxWyrVDIQMHW7EGN817Mt0X3EqDqCy4h84eqpjIwF8Mb5itAdcbqqx6XKJMbd3G7LNeL5yoiryPLzxlSJAbYswdWGm6ppg1cAwfe78sfZKBu5zA3jLBc1IOgXW/D/LoLgDPwQrC5D5J763tLAKH0iWSkg9x1MgRRCtuGbsOmR7uEQyrPkwecjsxkgPOXkwIKZKxcPynro+q5rLRMvGSHclELMbNJpYuxycX6YzkhSOJXTlvTAEE7nfQYjVd173+kpT13Jn8PFx7sVkBB10+KadZwRWVqUlN5Out7pwSgKbIbemOZ4srGo1fNwXFmhspWW5YjFs5sxF+L4/GYyJhabgceB+f2TMJhsPY1FjmxcJNcYoiSAOqAyirS+K9KdThvCCN7Ipip72rpnZZrnhyDwXNqPoEfYOVrxNCdShJaOkmUa2fzITce6Sr56F9hOh0kMiaPuXa5zEKQJGBKKX/4BJen4eu5J0ZOT1zbvKHUtIwWj2r1aWGoFA4NCjr2kD8YoOZmEyQQURXaZLT7EqlDxRfvMPVWSPVgiVnCq5O2BRtlKTnG3KsSijTPW2vE3rQyJtNAvUrUCjijexQ8PTrZXGhE6w/kmEqvBraxPSDucqzYhhUwoqRwxt+4NPVFB9RHqgHfy9gouq8VlLoQ5h7HN9hfZyfBSNnlNQ/zWvVGHVXegM3+YuVa55Q4MgVc105lsBUpfprySIa4LKqJM4HcSjmj5gLvY4VPDtFAwsy5l0LsohZrb2dzZzq09sDxyHzG5mA0yeF6dumFuBRgRzXWTyRiD+LwTCYVxqhJ/wgMCf4HwVHbmpELUePWpOzIZKFY/SVy80EJ3At0K2b9cN1v5LJFcQesTAd/bBmIuuORF9NznVycebItOVDmc2Uupka6dyiUa7Rg4OFU+XAuNeLdtxTK0mCvW4HAvAoQqfOuCjNioNFUCzZXyB4lNB7ACi9ZhyW+Wuh3mgzmN1UeykeP8ZYTEu6j6L/oEQPxCF8p+eptDpDTEv95c7XcfgUOsd8zEI7siSfUXCPJ6J8ZbsMiljY8e1fg25b843NUhK91qnnrHexAAkO3U8PG47bCtZtLw+uJ2u3hK4KoCrmzog1uAST+R4DsAphhN3ajaLnRvV0nwCFcBDQ46hzndi56ZGMWXhh+qKygac3x+PRJrt3Gq+emruf3mECuxebDEh8NbYUKqGxiKwjotJOHctl2mr1NQKwcEQCCYt7MRcCDu/3ATJyos4asyV+G3rJ96+21zv91rpcqNDCQTyvrwY8VCPpukHFrBCI1q/8KKuZkyeFuj5OEajsRHN7i12kEzWe3ZMlzDABZUjhUOh82CEI9cOgVtkEA8G/BnRtIHpixGuUA9dAQzlg3gA4F60L9q4zyLOjKuGNh5LkFk4hzUIl8c0E0K7mUCtE901PNkunkMhMpAGReykw1dph2m+9U6X0vXN0mfMggZ1Djsra/P1HaTLKb09rRR0XC6IQ6D8xyozSNXyGczjpxP/bD64+8HzRavxNGs1z361uZqRqMFPthoSFJVGX6MDQPPdtYlxtJYW5mS/XyRixiwHdEkw3F5il5K7mwkPq2SaqeVFS14SfY6voE9kX0KLEOLGzHNrUD3sBeW3y6qJskcu6ETtoHdW+IKTxnHAKjM7Y1EihVpE0Kog0rqQ0EpYQa4ArpVtR0Yjfu9To4z3uy5kErt5BfWZ1eU2S6125ZaxGbgzqLW6GDtt7MwbEG9kTL75oThWC/LadYLwWesuNB0EZL2Hd0rF+3ekAUqY8vUFDLNoqoWyzsiXdnd2rV9JV5jalklTVMbzd7hcJDOR4CqACpdLRIsTnFw4KWvneU8jc0S/XQ7NanXBqYM+Mkg6VSCwAWQt1LOSnpzaUVaZzULJtVMCxEtnT9RyLhYdmUdNxCs2gpy4J4SgItBFui/xUh7YTb3c/GWOSeBetzgorHel3X/38N87dw/gzLVWiCOof9TaKif7RUjXFotVBtV6AXjdg+fEV57Uzvda7kpheM9gPkD3R4BR/n2BTYz3o7AqU/44VtmN/i2koU0I2CaMTPuypw50qNXOSyIZ2RAjW3tvVXkyZR1kzF3OOy2OQj9prJTbupz09BLf4184MQiF8VDPGWskQ/v9ZlUHPPZ/HP7NFnmhVoPaUASPRv6t02KzhKEnrB4rIoVe/xDGwGlj/DS5gLNt9gclaj1738t1Hfp16P6dy4U2KvqiEv0sfPnIGBsV6f/V8snOnivBhiY4+1m34DWdsBrLAW5ML1jdzAepC4EJ9FGn4tKidyHYe0iMxBjk9NtXOYJJQAgsQ9dmCS7Dim3euW+g6KYx82VTF/IG/E3vzo5HBwT7Z9OlNB8PvL+hmWTQhuTt35FN23Hwh62w9cmydPTm3QHCVZgmoh8Gzk2FRLsXDvsQkPSo+pMpEgvXuMMEQDK4z2/QGPKvuPfKFiZRMQhNmcvPyEYd6Sf9QUqcYivScw50z4Ii0A5VuLjYSIfcUOP4Xf5pc296Ro6vE/NTOI7Mp5fi9DexPFMRX802GX7W7LI0nRrgY5vldBjQ4GPkq9hyQzJqpbcHr1XCtMZdToA8A/8eu7cXTV3Kz3N6lYLDtWwPg6Hi3qbt7GAh9z0ydm5wxP5+p20tt76a750qoqGlYOpUtOLxhBYwQpsY/58oCuZUsRkJoyDY5YJVbR54X6WCQbrCNoCWvWW0QDMTvYp7mov1tYeBlqrs64DReugvAqbM9J5C5bDQcqEss5C6Q/OSDpRpGhnshGNk09fHZj05srR2+/T7BZi38oyQiTdEXT1E8j7y8bDpRRW6VEHufdO8MFXLEYyXX7CoHnfkShhGDjgmckYWgHgDR7B7lJx2RMDhjlNSyFOEgOmVy7ZhnMdlycqNclDl3C666/FEqVXnoLGE4Vo83yf08qTGfrCVDngfxSggg16aECkKH93jmRCfpfPY0JtK7YoalUW7OTKflWylgohXgR52aGzK+4nb+ww9qFQUYJ7XKZNvc2C3d3b0eRmjfZso93x9eoa5kuaFcYAj6wmvTsQTsj4vr0wK2F45l8ckiNpdP7dOvLOO+dt5Evw+HVzBvbeKlKRPhZ1U2GNq6KecWNzkLUiDEifMee85DjGlPEWKRQnIMttNi90O6er2U7uEc929cZb4pMQmj91J8YtoWJnb6G1KiHtYhBRI2dEDm2PmZ4S4eX80BnjtqV3o4qTRMTt3P3VK7FE/L189bpU3QN/vNktcELbVRIOg3N8qEYYnE/KclOCFx9tPpq7MrgTvDrFv0eJLEWQRXGCQFOmXJ37i6rO2pKCPgWjVeyWHb2MgrDHg3c8nSaaVf8UfiNbQTZmLR5aSqrfMlNtNrua6Z4wDuUES824VRWTR853aSSUC96ZGJqoEhtB91KndcE4glSKjI9UY+2eT2gmE8g+DEGUYFmuk4djQyd+f3MhPwnea9hBgDF+PNs9efpcQyzjfldSzIT1YfeFAoN+Y8j7CiSomfriae84gQeOfdftrPaGbANPSQK5qYY8NoubY8TCYGEqmE0yHovRCNsJxD7uSccZj3p/NArDuBOjmCwrWXyAZEs9N3agwY2KKVhS72JgnIMB3o7DOHo1rBHyS7swSZXxD+muIBeVap9Qa/zkNC5w6Bcfa/78eEJYN88HNJRQ7+RKfC06YrpU/ePv3X083zsuXyFffqACXyYJYlZ5qpyv7OBEIIVjzhy2nswkmluBcIRZTTVzDKNt+rvylc1GrRATGLq8SzqLah0dWlBuHYha2MdYRuTodGBDFDnzkcUgeaz9UBR9s1zDe24uFWOoykL8SPv+84mRCqPMpGu/WotvoJCluyEzi6aauyzy6FYze3CHY+RXVxIp5LQGEoahHt61WCppn61hgFpwDIMqNXEWBZz4gwOcs0pPrgSCXetUedbv8elw/EU33fvbBl5ZDhcdwNBg2ueBKsmED8T4rkDbuQpHt49DLmTtzm0EHgpHZdv9H4InyVI6cXF8Vs+YE9THpWZYz8DAiSoTIxBkt0ObgR0S3wsClYxsCbqxSWDBjEd4QO6iV+H4Ddid58hDCw66DYYhqZNrksvdAR9sHxW4rrafX2EIrtoDwzS8fNdrVHTTTOyXjeGQUOJP3o9VOgez4XsqlXf645tt3cH0H3l9M10GJYyNbFap2X21mXPmDq7E7eubRYg+d5cjROHTbLTYV2zGo0WDcRrluICzuKbnMvCazVyXbIlydKI7u56FJokRPpKVT37PxNRaRuhVWBgdno/v7pM0zqzFIqOfegbnLKCq3bXaHnLmZdRhdzgU2h8ZYhRqA6TMkbr61a5P2xsRscR2GaWYGBEAw2/FK3QMpz5jMtBon210ZR7gvBcMCBpL6tHzZ+BgQ0BZS2Gv2iPADcNTiNXCUO5s9pNhTdPCs6LwyAD/DDzqHO4m+xND5djdV+hOXnoNMbXRWTRmhpVX3GallBDgE3VEIgRoNTEeGPUQddBQgQk/rlftRPdrahjMojLyNGlduPDV1ebk0lmLn0V4uIAljaoI3mzLvZumt7RhRpck4UQo9jZ2j2Oi11BPL1ighXS65urYhz6Lw9+OxDYxcWq5npK+qUzWVht8f6f4pBBKyZ7PeRsChWKs9mTWI+LPiNy7NMSt11plURl9+KwNI6d9lNJ97EjLVEsniA5EC+YxpOz1MHfgJ3QAdmOKHK/PjqfReMFsBscpQeGE7YfhUkFG8+czQA79Lz9483Bj5cloqHPee8tJoAPfY8Xjf8Q9HYPFfCW3XtMJdeyz8yeglwElNxNHUHuSOfU9JLYX0iW1HE+CNncH7Q0oBZrixxld7lvuarO3V1RT+TUUE10MoUJkJxeTyyuipsvbz1OVFEFklnlgke6/aatZ5PaXiF9nf2iv0YapB151zCuvHrnj06/wsjkLEXmHN87fxEDWFcP3V8j3bZW3bak8Lkwk+X4RWT0GOTBmJk3WcHJ4E6RTV9xqOEM9KaQOmo/PqbG7OpthT+7xh6CbyhKE8Nh1RychSH8lKpd5WKZ6DYWR5S6hzXgnmk9sBvjxOB7AZGH3MnpfKnL7YtxatvnyoZpuHsYv1UP0LyKOIfOF0f84yK/ZYTnmOE0trohMYngQonGXRkJtrv815HWy+Ez+zQtW4FcW4+/wNXJ98yaDX80f8Okz1LvGAkX/hKRn7t4RxsGdSmwSisGdR5TeR6YZndwv1vsHuPXRBdnEvH5+5b8DHzfxM/wZv8Pv8I9Y8dkZLMCq7SeEe47hQfsWhCfC1XWyZ0q2LdffLa2KQSqHHrkvxYu+4ta+rP+Y0j04H/VYnwZygmtnI3Le0VwBcXdPhiNyqnTQEKkjjI3LnLV9GAfba9ECmZ6c+iS0yPzLQ0EI/NVDVoQzns2BH8tvGgYot1LkpxZ2aESnNLe1FBdz+eLdAefrKFhZpjn9IpUo1YezhvR3QbYyG1JwwuSxs2Vmp/ZJDm+aAUoEZN25aHZEm+VC0qacJFGW2jq821s2fH2d+NtmgBDAWmb/UiDTduGIv8gwtD48TPj5ZqFwiYwfDNlb25x//sJ6J1YipYVvTJujumwgsCzSRJrKKN4knl9k+cqOeGYki1TCCRZhOeN571N/Mmigil0NoXgowG8q/+rZ4n9NBbIbdpa5AJC7QtRUGj3TW9qOrUqSno1W2y6214crZT+WWZKzixOZQ7uszFtDWLKvROgBoYEqs4ZnK8D0RBzb6hmqFAuZBHcu0A0EOvzGZnjtZ3y52spUZ+gh7Zh8iQaBQtGTnrmpibN2UtNzXIVHsk1Yrg6vEJB7USQp5iXX8MowNhoP1Wb74qi3qKh+BEkhzAorMzXQBNDwto8Xja1QTCyVu1wrpwJqtfyFyZUlFazbOnn5S7Y7gjFR2QIvr+8L6XLwRDYJRhI9m5iCd8M8RCWa3cQXDInb7XDhSYomKBzRhg4totGOj2BSJ8hJJMDAazg/M7JzWCUZyQ6XQ8GoHPwAgWBQ5Zomwrb+iqHYJsgJAjrXnU5tyXik/8tJcrCUlqCzT818cE8Ls/DzelbonWPdZpuZPs1u9HOVoPs2y3G86nqB76chkCvbdv6fWk35Bs9092Ox6SCe4vLnS6ttDeMke9Wkc6+cbDz5qHVXgOr6sJ2izcGMlykR7fxNLcPYt6i3yEA+ypCN/QGfJ+VDicJx57JsMkYw4yyNAp9vP1FiO7QgELtkso+pFiFqTPcdMrNZKmWxl50xREwHxyGLDzPJ+exjZEZatajSC/O2PX7l80v7VGwit7jmmXlxuKOfd/0jfl4ghWBjqbYt7Nv761PTvCMkDqSQdX1m5cmW92BVQIXATE1WKJyutmcImKqU+EnrJUySbQKxf709in/+5UfqDpmh8t1res9FdPfYqAJ7JnS1VZUtafimoZXiZgMr/6ieNPSZb5W3is7UhWK2LhK/0s/t6UeB3fVQy4XvNxvjeorSJE0BqwGpS+slnKAOZXFCVSvbjY+rRr70RkcqfsTzN9JPtvNkYdZj1HScdHVh9Y9/u4zH3q/f0WqnLB4HRniPJshtQuImNzcNbQHrfSQIqVq/voPzsUi6Nq4/S8tsKqfmayuIguOds9ayyJOKpQtAIl4Bp7DPJ2H2bnmzYfbnf+CjEHYKPfpwGDC8+nNnramDvzR6Pg7s0X6NU09CY/Ittm0K3ua45ipvmtYrGs74tSss7Q/RfeaoGSB0hYW0pnUAdogTKIB8gleJMUO2qbmfszklgYByEQOtdjixhv3Fm9nVXzoWl9pEGmfpBz5rQSHHq5udS8u9hCRxhybRifRCoBslkuoEJyzoUoxhqXSvsvDqzvoYQ13W8LWRXungYUpFRAqutMxO0A3gtz5XTnfoHzLJRHvukkrboknXn+/hnCS0VfrMUJ343F47mwN7rJ+zYlnQygQ9vURLQT5MU06Jau7uKgZ+eEk1QH79aLSpEa/eekV/rc6zvGKFQZA4QD90KQkRT9mjxrGnx92LqRxhFike3Q9+rHYXi09mtf1Zw2Wc8XBx6fLMmMDxW3dvyXCF18PAy6JK6cKtc9s4uwhegAo1tFiC3D/4qY3KQ95ZT1jZXPcEN3QDyc7lg7FJJB8mwpCw7jH6/3nQOS211nTXoFEcagsXGT3EfL5Qlx/CMsehbm9XcZpDfjFX2/IZfKMGYoUHOsByZL4+pW3HdAEpPNzZcWL2HPLic61yr8yDcLKiCd3S74aXuQfdp9qtRHirShBHp9Ejw2yq2LWbk3tqttjfvDVjEKUD5if4h7zpqHChPEHJO17Ml75qePTR7+ynOcoK+Ve/WbQcAyuXTGy9plq9af67r3AngmdV7xhVxoexW2kqXE5ajsfwv/uaNN4VVW0CC+1VYUBBMxR0l2Psla3Bo8ff7NqPckb2PPjW8snybFmva/o7tjTAEOMaXr//ddrt2wdMzLXlxAhVVO0E6fXayBt3duDks8c24zwrY5am+fUfzd0QWS/JQgy5M3n3zVXDgp40QOzU7vZc9y+6A9mP3/yqKc16nFMSg+Ll4hOUVHGn6utBxipM3FEHu7jdFkWs5oU90tcU08WBG/Um8VkPxudzs+6jqIq50KLNHJvsIGz5AasyFzwgeWEuJNAZGJuWofDmME8jEWlA4mdPi90Gi8lWdIAKTVmM5e5TBA2VWoHaAkNAyCYebTUORQgmZZAie6mmcoTvTc7coaZVYQFSsuk4vpcNKxe7P4OJQcYXIDGMFyneLIC0WUhCerbxbIb0W+e9HsJIDPpfdn2qzcOHfIRhIh28g3RaXbBnn9XjzKvGa2pUoUSltdICz7Ush1FuhoDhDjDophVSKsneIz5aVjnJoO+9Uyec+d1FhQv3CHc6H22NUSgxnXO490KQdPv56R7z6rWqxXU91OmaKq62cyLUQZ8JFxs4QcXzmZRUfR0Ua1KSLTAKfOaNZSv1SpdT/e3LEV8///13NXdka3lCOkIGryqquoKsXvZ7Z1XISILQjQIFEdD7rECwq3C8vPoi2e2GTLvVeHyGNARk7T8uwSGN9PKS/cN/ukST9VGbwQIWPcqniyGub625Aaa0df8Ogzy6WUfAtlm06CQD3FvfOmy1kOn9z9bwX+eCbaU5lJMU8kiWBbdZvuI2V5NhYl+VpVSm+qc1UPK+AEEEVHZD3tUERCb55Efx3Wq0QItrcd7GuXjp1Br37loMbBmqrT5PdbqWJRRFbX7yhHoNgKILF65zLn2SV3Q7M3uUABtE/xhc2N4OjPK1lOa0sMNqPGSN9x4+U1RTJUx5qJX7JN0XJnYFkRVQZSlYamOLoRwB+geXViltksLxma0pquuGnptf0UgiY4nPM5Q0e61AXJi2gZPf7iBgnS159fraDmW6MlNGkfuWrPcod1PXd4JD/DQpfNk2hmse1A7GQ1XRIyy6FKUPZvtkcO96Ltnp2s0LIJmIXqVO3Q5F4WaaVWqPf9eJO/pDFlSTcya4yxnv3XPiCuuZ08I9efbZH54vVST0pclO8iWUi9MUwPunLvv8RToSkhprQz98ByHJ7kdzIRLHdDLj7aLZxjNUogrP8J4JLLnvwXJncXgG+bsi3qv3RD8LFV6gEXOtOX/r28uUuGQsFE3fucz6eNHxl6FZZToLiG0zDB32HTROnEV8LpFOVPtq8baA05q5h+wBVOL6U9ELUvlDyZVpVYTOt7//lwNom5XoFP6lYRsS+6PGY+hK16srFVfj337FTY4ejxFO4ENZLTclgp2UoxH0b8W/mKs09pIyjUBDEwaRh+2GUuuyTcTcaVigJiTzVNfHOSAYWWFd4Xxz5rzeJQ5BvKR81SDEHs71mHoYJ5RlrBaS0IkSMpLyOExFlLT+AtxqWGVw2DJFvTybY4Ozks9GAfrtdxvW/hS2Jq0Ad0KQrM6XGNyazdipoAF3CFEFDaNi4aCN3WvjGMiimM02WSIw5sVgtiyar8iX7Xi5eR04ikxibM+Krm/iLd0X3hUfJZFnxksgoNnzOQq2NnQr5GgJHtLV/XgwVXWcVHVawJlhVK+/xvbAWnk1ufuWBKdJdjpcYEO2VWOsLr7WOSzWmj2EDEFve0y6IhdPhCCLBdjK4Lh7XG22z0/sFQSMzF1ptzAO3U9lqrVkvt5BudOYxEZfMc0yaJDR+odNLREJuA2hZr/HYinpqnErn700CovvlInmnr2/zLNn+vjPLKFep9MTI96AaCln94XPNusOnr94+fR5W3PA4x+9PXIlUIulg3g6EU0NOZI66lHd3cl+JsKTgVa1pgpuU/rC8P4HrFpYUpofifHUK6BWG8zFs3x+p/Ekm2YKzVnnsHQBGE/B9Nmt0rR5V/4e8nDhtMEH+JpeauPTVfw3WHNVvuAMreDsYhG7FA4bzXeIVxvxZK5Jmj1ZgOqxUi4ezIeHMJxdh0JkgZmUCsD9gS43uU5tvexnmXL28jCULa1EsQK10dGGoXHSbTVJx9S0bNBmhTq4LK+tjI8k3ZAVHf5i14A+jDoxoG2pM2M6xZnqy0iAOBFaoYIQkwK9WV4ee9b/VviGv6OmRMXQYJBA56i2pimVq8CWdynTxk5UERI3Bhi7a0ezbjy5HMJ3cIFyDCXcePk1wdWKqT2aVKvr5Rb+Lpm9pRiN4p4bSkkm3pfIzf5exKC4eDld6z5hNqHrovV/yFD2WlEBO36LdPk7XvyBCVnJRu6Md5O3UdYeIfNSkl04D//1k4l0POQKYeLa5URKiHVxsKEbODYUIy6pkT1cxtvPIIy9i7qADUjGZmxG0hXw3HzAkqQKxptJGLC4+W26UdL83tJM38F4xsmwlOrYVJO4BwoJ2WpjOxbypAKbAKA3MliWliaCVVQ8FaOUgspjqTwv55mHBZP4+dtlrTpXCmFk6SvrshgQ8RJmrSXdZW4X1zLTlUJnRqq+oyXRx038w5wIK9kQ87wN+SoD8pIl41JTWB2RDR1ohblF+xgIIo24qvlL0qxd9Yz41hEmC98nkROb1UhyzQumHXC2Vn31ffRxkyzNE9pWGu/InbcOv7nA8WyzIaq3ZfztTobqkhB+EuwCPQ5JgqKvyqhPkDikrIDB14rISHA0+CaIF/5YNXHyB1Mt5jWt1Np0fy5nq4qKmLi+/gp9vLU/Zh4KBqpzT64Yt12yWmvuSsfMnn57Wan34M7+AjP1NFHgxtMAsEMMefDhCuSq9R7LtR/r/LzthhZNr7d7+gPJuw8xD8ddT6pQa0x0byycSWD8wattHZ8XMu8fxbc2As/S9DJiWnE/sB3F0msQ47VRsKtEKBGxnDmWYDkZfHNX550hlsXqYJ1uGGUyk3D5W6uFtoZTNql4oB9WhKuTj6bf2Do2zZzn0dhPcyeII99LhgK8zwzfSZ17NorLLDdjzxpw8QkzAjgMvlnNk2Ktw92Snc5Go8X6xETusn2KCqN5yYA4wWDIVLni7vTOVo4WyOE1BRV75x5x9ywEiJhlkfOhhA0lz8tcOTuy20zX4Qm1aROwY/DFzPRazWK9+SqS4KAaaJPMklc/O/3pTUlH63w1WrMrobBYbk8thkwxfPQehi4Hu3AGq7AOa7EG2/6Bs595HMlkKzMZeeoN4XKq0Tu7lWTeVlNKeASrIxMbDemiCbh3EvhfXLVjWfdzri6Cr+ekf5gs8WvrDeuvcweF9QWwUGLaEY6AIAZO4++vdqe1/gwtJBSuCtrO97/dT83v82swpGVG9N3N3/zvrv8MpaJ/3w8H1jprinofmFJ/38RaHmd/mJ3wB/MawYC+W1MO0/lXTTgU6pf6r3Dqwb8G9uquoSUpO/wvF6RKG2zuzIamma/xzEEuW6ytBgaNdc4uIe0uWSRbwIKu4XT/uoYOyA74VwBW63qFwWrTUic1mAo376bRiEIAc32kf3SaGjV1eD8+zdRHi7EN7hCdh9r3Rg/qpk1G6eT7FpB103abN7n/s1g/5i9M7/mXRKprRXaQf0jCfILrxtFLxhKwNm7o0zTa7PPkjAmX8RnAgXr2QHiHL/WHwgbcNs7tDauhpvF9G2immOyLWlfUJ7tjNohm8/WZ227wrtZ1ZGV+/Pyyf6q11kQPbunR9TTxkF8HHGCpDMtjp7QBGhFZasMYDfFx5IgucXW7dbi8J9+iExcPhI0u7x9cwAF9/IrRaWpwUd2GYFGjvOuWt5fJJAv1soThFJtBqabKa1pPoTWNO+bVKWMHnO3DR2HxhYnA5tVh85FVKgy6cGRt0rBEpZ7EvmLOIko0K8UnLyWjPGnqksW4MAcrWloPR3kwbq8AYH8eLRIHK/SgpsLQRQvmQDZK6GSUNqH3/Im7fMLLurYNxWvOcHJEZSS+5P9XeEmQCBNeOl7t29DvzQEYiqCz7cEtfJu6KwteXpsYcv0u2+w9+sjNqmi8aVq7y/dWztZPejQ7cF33/iAO5T8Zc7fjRnDwowX8Dzamq+Mnu4EiFMzulZb4Z6522NxLYdK6kP2kwswrLcqccnifhtGqwoztZ2TiYo6CZLLK4HNLrWDGbmW3sPvZo+yj7GcEmcvewR6chs+wj7DTkaUaFswYVNrMba/zPu+Hr/lDuiyF6ERakiK+lFJbI4A0Z7KrKt4L4q+mQERK/WpBgyA5eoet0a6eHNwv48M33DkLC4BFh1viPf0PUdne76zb01CUEaH//1brt6lt/Ti+Bvdr72VWkv0NWYIUz2GvtXu2Bvf68brj6xsBdlfeb0r9fUpLX/1hgs4/eklwkRjrY0bziWI0y9GYWDdRn9pweDUDuJVjsl6XeoNukx7vURbbkOD3eeu9b6+LORNM5pB4R/T9oWJcPIM4CaHVwsRajZKfvCok5RvBVx8zF/2J45udbNhb7XQZPVDXL796jF8tceByLkTzLqemn0ZiF8zU/EGq2k3F/Gb++cvdU4bI7f9yerC5E/fTg2VbsQN2YeyiRyDLpZMxdbV4SOv+YA+3SFojfpKhlJ44PNVvkgKqR6PNc9KUX4qK+1KmtcZyzb2V5cdbzyL8v1/JlPPpPU6XOIoU/HiUSexs5Twlx4JYAA3l1w1dZBlcrXP2fFDV0aE/9J97Wuw0BKO2Rq1GM1tGYt/8G+Pf47SNm/o2B/Ndp3P9mSOqQ+PZLjpHX7G4Z4kovfFpd0z0/5+ve7iqFGUhZBPPGgrtsP+5kzzs0qQDK0laqNxgbtTBXg3ya8nQtVHbYxkwdNXl1aeY3SBlal/bJVCfDG50zybVUEzZBxl7zEGm1uE9MVlIot24LyW0f5/v4/2m5QSW2HqYrzd2Bvd4IbU5Wuzk6PZserrFsjgsxUyyM0d2AAzB6h/4IESh8S9nankrEbr2qTvU3E/7P27RP7zN0zJDQiuReIerkoJBW9Sz+ZCcdII0Nnh5KPhQIALPf3uq621TZDqc/WW97uLF9BNZPuy0yTsY/HIN0nt6BuWYa8XgGEi1pPBFTgr0VIWyqosqRzbzw6Atz9lqui99wtnRUlo6RaMX8E/AuPcjt0yq2hDlFAOZjQzZeoCddBduIKkSSZN9GnIEad/2njs4n1wChbrmS5SKba6OfWDkUexnI4PGyg849QuRn25qEhHwUX1//ZVjQnyXnKX7fcvktWNdxLsrUOWbzxFxFqOOT9Kc4qbLoUyXqh3TeaATbCySh3oUAE+xrgFJ+TYQup0DXDTsNQxVqDV5Kq08BPBtfy+aK20mnDqvKJHn1/f2/mHYL6NHPAY7n33t/T9hOj8pk7axbK/PQb9n98NtEgm4nb4T4EGi0NV0snvDnPK+iEmdFtleZmEAD3Xbz/RE7M29/3Cic3Zq7yLpr6APPPjvwZWkgMy7QX7xqXIXB9Gzm+E3v3mVyy/dm9AhiVyfTPee/eSjmRJD3NkwfZTYtH2VF1+hIcbbsqgyq3KHdX0r3g+uE4c91xYuViWHGyu8SaHHj63P3hKqcAVGkMCBg6zW4Ds76MsnmzdDnneYOijrUpupPRzdJtdRXZVfS3+5ajr+gZU3z4WzSrVSbnRVSwRG0Fh/1YBUapQjWra8LF4Ee4zVyfm7f3zS+PUJYNcY1iPEkJF6z97/tx6nhIIkLzgJCNQbZBRwTmnLqC3wszLwSQdz8sh0vU2/u26ng7PtYpMiwpPNtw4Agt3xUXKxZMt3nqVdvNfp52wMxPcETwr5UVn1Xp/E2dXrakyl0xHQih/YWFtSMyGVwIaHqBRq1ZdnYTbBUobzOXRdrjEFGCTsp2/7j4i/ml5pJWeT9RoM/qRoPTu+dcu05kfORLVeUA8USxNYVgrzaYm+qFPNx8EUGcAoqb43MKtmcb1z860YAaoWPewC10Ov+56T4KHuOPCPLUciBL/DI7D//2oy2+jiabstXl0OjLGBf8I0/lLlF2+sWrgk1GuA0Wf31BsPVyttWqLxaWlFwzW7GBlu3g2jlQ9feZQSKE7TTkk2D+djj/efQwnHwBvMTx941/skmUsugb9O0UWp+xzdPv5q8ctXJfnZZH0AynXZXW5tjtlt+jm6NKYh+7K0c8iKk23JtQGQnBMR1o1bPkhcTJQgSa8mWfjRfDCNWMnNUNc90HsmfgYOpMmRXH/9A6RdmApnp3Dxz22ZecZsKB4T9ZsK250tgzxx7NwNBn++2dT9ATcO85lWw+urmaTPMlhuxidk4/9/gNrLQ51UiqqF06ibru+ZyHS1u9nyJJEpqyLz2capZFgGQ+WgM56oGF97CODrT1JlVN2NMG3zzoF/l4SQf6nw3i88e59gyDTfj/ybowZJNzKQ6+5HlZVxPhVP39D/uIBU3MnxqSvqW6uVLXdER8DRlLTwVpZeDfKMrlAmJOJrvIhP8R5exLub4Hu1wbIwlXVaZohEqJUOe2O3XbMRKm6kW7VN0ZS7nPbdDX9duzJaG1ahOG2UNmCJ7ZFkAHfuHL9pqjffx94yP/HbR/Bk+hbQ50A3AV1ZaED+dJE+DXoOz8pozLy9rn43VbdykmkzEtrRqVWLJV6RkFPFSBktumFHWRLCb31+60+iBy5TC59ak/Z/qDcHBfN/WG+lsTUNbu62aVi6zYtfd88rIPJdW2l3sekdLWejSjk/3Q+xQRp8R5hX7AZ877R3ciFbOxVwumFkaJbnKDAhgrWu5WVX2YIAHo1ORx9gYG0TAWdbK7rAtybTyXyTvTr6FOwehXhG6K5ltbTrUixXMmdv2KcvOb8A8FM6OZ+bMzdeObx71bK4vCfGgsq5Bp9BolSrc296OZ7HSL6WnAdo9gvMJz68GU+V8OfqJfWmqzcmxpO4LhxMXoDfdeurt64GB9030v4g7byK3yjcYmxUG6g6nbgO1RV2XsMM34vX1MmWLyTbQDYxvgxhbZWZQbZNile06JfFn9TdD/7OAMIDARsVtkhtfLkGVifVAm/rop+OtF+pZDz1xt3c/jV+VkiXPc3S0HXDbIyVtgJeFoi1kQOUJhqIrHfFfbUkJhv2FZlsm/si1jpIVSpXPu8JppcyJSX2zodqWkOf5/vVy2fB2lCd0oDBB0CTtfz5cl05asqJSfT6VLAEFk1wUbzaK23Hc8j7i1sEC50bgTdCm/2rdRAxg7hQb2tJbPe9xca70jKfSZM2XiABKbSwQA5LG5i+O2/67pIySxae/JjutbMCKZL12IVBjmb78vVc6wDyzo1gv8Sxc0/Tgi6MHTHR0DVQk6dG7+wKR3ExmldV3aTxGqREuuBEdABjpMu3ulcEo36yupoaJGp1d9zrrwhMcyZmj/mFzzdrLdRy7w2WCLvFpg3BCIKjstdkgCe6iFyxCaLIxVI6OdltxUL4cf0VNpVa2v7M1qPly8v/mYKv631Xjnd/fPXsRd2dWw36c8qBwaeSmQ/mYJyktrZDPLLvHv+TbzL50i3fs3z/8r3L/5VzvndVmxUGRpqrmkbt2k3UP/zgvudBQJryBJb/43lJiWdn+rSN0vTRmni0gMK+wBfWAB+29yevazixy8OHiKgQ/QY66cE97jY/zD5wEH53dMu77PGfGY7sGmR39JwoGoZpEuCm2DXDpq9xJHFiaaUqTpGPwcgTJZmlAP82kdUhtZrdAmwl8Ry3LjgbgpnymJr76MAuJBacBR79rB6GPS/Y40ORKPvbiuEEcVxXE3Q3WUMdRQmkIswm9sAvKp3SBudr2bADs6b4Mkq/VA22HcdtPLn5+FyBs9t7VODP2SPzHFP93jdW2EQ4iCTLq02leiAwDEVFQLcCzc8jUKEr6DRcXGa3DsE/DgB77hTry1kl9JcvOUEYsM74miCQ9r++FRfnrjn9SUKJF9vhHGGMIMn2WR4H7qL6anp9temWgcajrqvvhds1Re3PJp4MnW/KmYyd+lQy2zccxYM72CdbFx+5vovVNL/7D9YXoInNWMskAwO3e30pWsHoe+8KP0Bolg6fYDvOsHTmBeAXtMfTvlAzWq2aGHTaBOi3lz1I1wazcedbrrieTIzk9Y119WcnbVj08mYzIYTs0sH+2jr2Td9Tkixn2w3iM68RUytmiTNbr8eWel+eeFEYjgoms4qZruMqs7fshuK4GtuhcsuwsY4roBIYIYhhlvlIqnxecq6sL3LFFCBwfT7AYBjJm0ZxW68L7Nron5/qwuzPRDxNoNXDoLnFzNtFXI11mnOmQmRz0ru6qmrJQoWopp1aEfobXLvO9A+yld3iPyU7FfnoNMNj5M3e1ddjYBFgPRFydny0F4xDAjwUL/WtzWOBz7aikufxuOGJhLV8Q55yHzHwFY2uf3zJ380HGV7M9cVpFusTub0fYIO0ondQtaB0azcgcCC216kkH4KlL+0mcv/b5zge2LmsqHRPS24nalEq/qJULZAIPj/BH9xBEr3gQoqBBXndfUtmJvpanL28EYki72JT6t2ycsPLFEVC6TNPt/gE8en+mk+gZicndGiAQP3KaGxK1fzcjjjS06IblbHeI2VibSQlQEJ0bFtWWsx36Dtebk8I4DTOyW4JQYs3Is1nHjRCW1DdXesPWtN0ezRNq3g/jp8ZMWNStnJAUb8UFZM/0VrUbkKxJl2r/rRvklSNmGrDnbi7bLfUqTwBPypP4qVIAfaGFStX54kJy7wL1VmAhNaDTO3nGHlcZk9pU9+VqehYYYSnu13v902qa1oE9kCFMFqWGgrM2WPnzpilGQ/HvHIXevim6SPgKSkOi4IcfXGlbwjvPQzxUKcVdU1nKjqgq5QboIogSrnkqJIcCcCDrahtmsp4eCt7UyBhA0NN+ckDmeCoCHyiVhB2/E0MpxDnZZTlx6P0RkKrOUchXO6U19A0xScIw2tDoEPcgA7Jjxky3jz5XM+TXQiCd/FxO4N5d7fPgxckSR+m45wsJHFSHbZEHgBOx0egyXUwdvrwukENGJk0WZP1R0u/Pb2mxKnriGlTjFr2/A3/33JLbDwhplPexsvn9kyal16pr0H2pbTQkMJWKt16a77feShyJNT+4WDgaFGK0NXPn5IZ5E954tiFAqynGyx5uqQ7mpXNoAKAAOmw6I1qYhuLpBxPMyOXneMQajCY+UDL6R1DjyIHqBOS0Wa6PZsjAK7lV99Zf5pYrSW3XoR/NzWt7S4jULwZS4lOCSpvlA75pAB0RQG56iexBWVUWjNl6thyVXaF84ZSMeBTUSmK4PsQAPrbV2covlOn4bnhpQNN7Qp74Ef/+fQMKemWUUUK+c7GMRSmjS4qr8hSCnC0Is9EOr3q1cCKeH4+UJypq0zoI28+SJx/xWEHw8UHDTe+TD267/1nVMsAfHhN4bX5PXOZ70TOX8Xpu6uC7xMAYAEnUrPDyMYvYFDVXmAcc9ItrAfpBGTHxAAn3g3dPqWlRK21vbkxltTO4yjiRMI/nvnqiBRfON45tvGkMZpaWIHTWAMRlJBABFm49qvhGBWIBYn1wOpazWay0chJfNQ3r0GRVr97QB+PjME5lFicJfhwqEKXH9vrUxFZsjTUaoCJhYxw/pO44yjSYDG4/iTM8pr0YDF/ybuimkWursl84ygw2hBBaBMn7LuyePc9K0EtUdcbcqBanzBysXc/8j4tTxmxvwiCAc7GAKKEcQFfOJIztA51oVWtNegYuE3egZ8meQV44KMGC6/1qfji8v59QylmMBw1VOYmTAAg9Vl5oHEo1Ch8OllFogVdm51CT4ZE3s+FYaomXrA2mNSH4cKglYKWCyfyBVXm3CwhcwzHytTZr3N05Db+GWP0QMSI4LIsUoGFUpcyx/mLqpAWK100DO3w8IFqO5Zj8pBGLZJYDcMzIH4bIEyTqqEZbkF4vI7NFMTuzfhJqnJ6iUCh95KoURSnihxvbM/mqRXIjMVDhNAulv/aIOSMtPJhpQa9HKnbuuI4geQVBhqVcSbKfbDgrnnEJsCU6RyCGwKiLzIzc3SgFD6iIFKmfE020gu8qIAgjb/osaeFKaKzRxsIuE8n7kfzUrK9jkgc7xNTVhQFss9ni/uzPVzQeXDeTrTykJ/fnxBRZyj3b8dmUWdkmam46aQORpAlgal+7lHgYYnRdZxViEmgdHsmjWrdel3cTfY6p0U98OxqbZ8H4EBP+LoubJ9iDVw4G/k2EfbJTSTAxKW6eBDRitValT97DfRiz3Kl1gzOCYOrV/9PlM+mtLfyf4QaIS4HzjBg285QD+Pa3nOSwoQV0GjALVww1OlcOgN9z5z7MbyIsUSr8i5lUONTAhTgNLtM3TCnsYXw89tNw6gzW020wu0YizDAUN0QeexwzsiRG4V6MCwJeBu9ZFPldtzYt2qY2H7ls0Y3uo52qPDk+VZOVzpSD0S814gXW17G1JFa9GFVPNFN09Wqf9tZPeEId3asZ2t27YMhsJfdNJycv29OnOBjkazK9earsk6BZRFnxYWM2ErGIzHaw8O7/WdE1ONK1CQO4Uzda6SVauOS3wq7Z2lPNcLP+Bm/4Gf8Mkn500QBnAiEmxuBcKIQXI677ooD7Q8MjXxBpTz4fIcN1UupZCJbrlMLn64tVJuGzQyWZrO2EQj4SIyAFW6XDqCM+hv2xqojlEoWGqzdSVPVc2W4JHRtqsm4eQO/HChdzxpRTwqQILIM1ds5zYRLAAH9Bb2e4AoXRNfK9beeJhFu7YSmSxNpJUIpaN44WsW2j6En9aiUkDToJmciBZkuCtpTdaeHakBvwu+y1STwqgOd2qz6VfxErTG6XOgn3ZbKELR+j8B2BQMK9CZpCgeigVPrMdlv2gWGp/P5JtXB/OboMpGBIBY2ucbrGvj+TkeLZO88QCLJchgP3FtrnGuNCFjOnAtRLdoEAJYqiD4EUK1PzADUnvfi6XaZECiKIKrDNDMK7Xl2sL9zGD8FtDApGmsVP6zvrrWqotWrg9ONvldqJZPoVEEQDjPfS1Ml+KAne230yiwTIW+d8t2h2Vk2KclCKMn7IjxYbPRfVj2gw9VklVNurEEpO++FffqtJ8RfBbbss7xMuRgFYu6gF8XrnitsM4Zu6gM4Om8AFdrtY0AEo0r1g7UL57i3Bs+Hy8NiuBw9ZiLUOnQO0/c9OKb7gXlf2EqaeCqHnhfkyXI6tv9cWXTto/xIXd88GOG/QlhOI+h2Deazev1Efm3IQ8IFKCVLSEBkH6IQsjpFBDBalOBsqmPjDHLlCdU0TbOJtghQJvReAK1wzrgoWA7TrNAuuOzjz7bnKgm3PMdijY3iQCI2SS2nLkyCgeEhNhbtlO8MgrosfU5KG5Bv57S7p8Iaot3Vt3AF0C0VYo5SRwk/fXHk+XT/fvUBrkCmRJBeL1JED6uLc/sNz5kxFa+u/7+cgs3DccIPZNmnAeEDrtpnI6kLFGcxhB8xeEoGaW/+8k7fZuxNI7fvhurzGz1FJyxuGe4dtzMOBxJwHtVXlYbwCYrq9xayvI5qdsl6JvBoNeCRsX4GkDputcl1BbNR7vLqs8VHHQ70+udO1Vd+zu/fWyEkiRyBjeXWihLZaKbRbFaH+X2ZKhXZVw+hYGLqgXJNFwQ04720De595fTAz+vLQx3C/VAiSSL5pUMioSsw07WDgYQUgtZyakv3TNzZBgjINpjsuIQEIydBAgD+jElr2pxPun38oaOz82gY/4RqHxu77/yKmH4xOKKpQBACdYuauX7hjj/+T/2sGclFV+t/MebLG/3+epd4smywF2LmMuv95xe0cEaX9s81gMbBbJSYhEqPwvtMFPrwtEgWM+SKSje1XQ2sFlSwAUI23q9Wjo1G7vn0PNGmYdsSKBRKEIef7H5NrN+/xWTrfr/W8OzcWZp8//L/3N6UtzZJmuX97/N3sKfp54lCc04jtJsmlzWufbeYZtN/Hsqdmd+vGvXWX6LnJrTVg2fH+HRfBU39D7TYwXSOF4yH1zTjVD6ZkzMR0kac+73aX9rCn4nehFHtjHtoLHqNQ8OvQIBrjAZHbxy9uckYPvhxb99IV6U/aVETgx007Hh2XSg19QRuE0Xz72EYtLVVOz72HfSJ1r+6K6++edacGJO8qy//y4rvvm81AtTwozkGJthb3hUV8wlxJuBApeRe3cQ3H8gaQaeu6rcqTZTp8Rx247i0h6WJp633s6VrS4Louo1+QJCUyNIUjaGarOtokB66xYiQ4PyuQnTfBwzZZSqSiMw70Pj0FRviaIv2dPsvF7kdOZeCZZtEukFIHT1hbdotivtsu26woteKxZ/c/CB87+p1CJ4pVIQa53Wt6K2MZsVFKlBtdo7j9a18Oq9t7eeScUJ3T8/oF+NAG/0loyEruXXhBiS3v+YyjN9TalMEsLRnxGAA+TWZ7DMFCQyFEWWlwE8Cn26yq21FUroEqC5ZHMrpeUHPx/K5HfANnjLJgYE7Ger4sCHd4rYUth6GVa77ESt62HxSYk7Ngi6k+n058lYdTVUFPE03+AyzAU0UZSYYlEo91cbYGvVWnLNn2mz9SxPWOTTJZktJhnW9W3rhj0tga5GdKHDhr+1WaCWzkeOWnpF6tn13OQbbdwy6zQ88FTAh2kf/P1OYVeoXBgz6dNij7Ma+9Pb+2l37F/Nk16k7JiPIqYEu6JcJ3iy/O3Z/STYod3oru5XypVj/pvjKx/rFrNPiJyHpr32tEh5nGQ2EhmB2dxXY6Af7MyW/xxrlEd/9VZ6kQShvUuqWmUtmo62xmEpUxTx7J/dRS2/FUm73q4SLu8Viyq8ju2K1+eeP/Yat6LU481UbcYz6nRgQJfJb7wLHCWraaZ8sfh23AwcBJ9wBKDyLouWI1stmyrH73VzgrVPcaa+IZ1QwrQSXDmRNGUt+4KNNBu+WglOcgcIEH6zzxaDmOXp8KqyZTOYqdZmEfEU2Rw6Ih7Dr/OtB7gSbXZgSjarweaRL/UvhpFgdWe8ClSIZMxiC5s9FCzYST83f6UQKq2OdLc30ePXGX5whopWumbfD+COkC+E0jZ1ns8nyns9509oehyTKZs+P1rJxFuXCUe/1b75DV11SNSSs0eeAtdDP9bsjbyzKJs4Xx18lr5v5qPTcjxbfP+2ICVBMOJpbNpaUsFw6P9qilL3G6TpSep0Wp0UbbUTvZa+DpV0vkNE3y0kNL6+HtL95RHayGSKBBvkm6ogFnJPuw3xktks4ktA4miNzNgTo/0OLQBzMX4Aojhl4tk9dNzcYcJ4OJ1b73mpa99iE6TwCmp7dJRFSW77k6jQIhwLqaPO/joPkdLWiJqTVBRmKR9Du61ISG7k6e8K0Hq5pUz7+8179X/1sr0IyfMuOa5C0g3TonYpSxkC+tzdYTWJ4k2tDH+G2E6ocTeADXgw7LI2hMLfS5LYPCS4Y/DfDY+AAIFvK4jDpswgQw+z1Bks347p37S9hIPJId9kv5IqC811fEtgiCdY1dvT7xlN96tU4s3rp4gIHiY23ivp2WJgwC4Yfwbt6B9u6jM+F+ReJlleUHIzGArcFNqC60zlBzJ4/20ZbpzAfvcHJop4sGw5ZkBjqrIt1uAm5q2Fpj65tUSG4FmYrOt+33iF1Af1Xx+X/dKDT3SGz5zj+0xMwcECFLjaG0jHJiaZTseFO/PvOeNLi9pYnuuvLKw5fvIOZ0afeqLOsrpZOeaJiwxcocBU38QBXca8Z7sUUY5kNWRv3a6u/+Phg7NSdLGvJTPs0V0rtVg1I24rzQNLJtTgNsVc+eWC+z1gWuIUWl90mmKyizqidoTHGnKyCR3UMWMGsctoxwR/TqU2gb8tx+f4ql02RhqDpI5M72qZYkroeDj3ZDpA+yC4gk7NMupXeXDvnnavJLNjr8tHImly8hdNmouEWkY0acZqS6m5bseu2RdbrpXS5wPtupW9eVEDGa8cfd3T2KnKF8qvlNl6YMLsm4+EHP95+U5+uFSrp9iR2yrTDJZLWBb9ZJ0rYa61Ul52LVd3RwKoy8bxwwmbyoyTc8kNK53Z2iItrVUcjGIaXVlPAW+eUlG3CMrYZgJ0Ofy4fovGyNocyX6bnxeZu9xS0Juq8MWaBIVcu7LRpZy1oklwrFKuShtpN2xSMXq4t7vBNmw7bBt8Nwdz1GQ3dtK1kxXPPi6Y0wN+VVdML76aMdQlWI10hLo1QVTEoy07zsppVXVcJpUg0pM10HMbF6ux5AIZZQKYW0ylxuAhCaH1nbK+kNpVLZ61ItMW6T82Z8HqaxghRk7pm0yhOEvtt64nshI0HkBzh8x8/OltmITZOA/oP91b55PxRpx5Sf0maFcEIkiRQvdMTvDE5R0EdGK7eVmvWuBpHaDo07pX//23+eXO0fukyYaLsBQtgDgB/uwmZE8rbwE1nYHGFovVHNoaELS6C4ZWIgrQRWyAzrjVHEJNsdycxtgbY3jUtNBeH8gTg/6H7MSJYGemmcGznJoD+O2bQf+pQaonKuTsBv5gt9z94/ELSbHcE45bZtUk2AzUOm11/52JsOS/mGMGsuUYG+9EBUykxrKJBx6fz2UxtSSpBNmEqziEuuQsIlyaN74Xt9r4b9yMU1ztO7kQjcoJ0WpusNqe8iOco542Iz5llNVKBoWfqWo+n9QiYP3n+tYUqPgEUpQhB0eWW+hgKqXhNkUy8MyCyjkBicqNee5lXLIPhbB5DcyC2t1Qe32TNosvhaHi6v/Ov91Iwy1uPaXTQWE4tmMaGyIZOmyQhttmocozuC42LWUaJ3stMzNVogjuwQIVpg9pPtzcJNnhEdvZkb8iI7qaLtKj7ScOZp3/9ES6cGp7vQnegRAaTTH1/EIKAVdvS6lJUoe8dEIPRXRLJmcKQRw0AX1RaAc8xDpjtrgaTnEsBWLPZP5uKWPA5mm4FohSuJTKUSos/0dXT3Rvy+upFPDZissmhQYnpq3robRXohB9v1Jl8cozAUPYxJ3qly5TThBB0IXXY4gq+oBh7cAglON6FjjrchFaD0MgRpniD4tV8Bmz0HFph2fSWPk3F+ZN7brlijtsIWD7k/NJ3LKUqIyW8YTKgs57TR/7CqSQrRxbdPYrudr6pmh6z7zr1i0chX3ybxdsnJ+pHSSXotmypKeGSCTBomOXFa9lQw92YdVAVZLkavzr7vqPit6NyAczBPKIqqfq4lfNor1HbqeTqMe7ldo1yY8a/3VNnvNqj4O0QNLS+lVTaXoxWzcfdMiA3MTzZbuYrf/YKYdRm7ojX5EZV4284Gldx5+bq/MCKWugWsW1qbR2ss5iOxbGSmjzZ9t0nm+SQRBJUMW07nYE53ThRnU99DQ4RbWq+4w1pfc453xTCliRa7+rAR3C9HYuE34kPRiM07rR0uhwV1QxQ2WbIS8UTDyHGJiibe+sznZIi6bzlovHidJ79lOZJl4tF8hh04eukSJSQymcQuu5wRnEkm45GnvbDoXi6n67rOPYEAtEjeSNM7gpS2yePOjjpL9wdQ5XpiwdSLnasdrszurMZDCNFZFFa1BqGOGT9OJXuUGI4PkO7jUYXl+2oAD4tqm2VSO2tF5+6OOePq2Hb0IvF9VJFzZP0UeCZ9m4gbcRROUelU8xhGxV2Z6aKFWaW5yQ1kcd2shXZx7uc01WF9Dqt90cX+BUtZV25+52V6cVwNUwDjWjO1kLnIFg+HlpT7W7k/lrMCQ+HXScD5BPVmsPTEdHGvWhpmnzAUbAtkGzk12tjpYoxqjXhOjuyfbR8/o4Y2zMaR54/sKZPy6rcmHgbzsF6n5TWzgWcn7Vb7cbZeVEUtGo6LwyHcRiXixNPCYJZUQ49FoGF6ycYTJOWS4Tw+50EfIa9POToVaTiYXt1eU/sLHflmUL0UVbF6MP5RpXcwdrhErPqp4kEnp+WBPoelbzn1qL6xnHq2JI4bwTRoeeH8X4DB6tgyho/kUne/xDVRwjWLGFDcSdqFjFocH9uK2jwkgEHuVnuVQaQoPqeXR+xa8l3T5/b4FPmj2xVwoTemQeVitNyCZ3jnypfeK2xeTVOWV5c5nEgPjNXsphcC1e7HOTxZZYEQnzjqVZIjKZFA6Ki7KhtIW4k/BTIWDW/dzt7UhkR6xpZ6qlWxpdMes3qrs5BHJ2VTmB2UxYVx94y7hIzxfeqcSC30rS8OwHGKioaeeDdWmJSoARRYc3utUiwJmD5vLb62tvDFpU5YcDYzFvIIa0WbDBRhdYo3zVO4h6ieZPpfxp8ZZ7T4eIvu/TxRojbSM9isrvkoU1fade8sM6tExw+C5jwUtFxPsdPCuNMPBL22Z/t2Dudo3axvB8s2z4wg8054k1c9n72vey3PQnO+MdzQqw9WWNb4fjUTw4sTvVYojvteHbTjUByK31kOSftNo79bUlr/up3lFGeEydNJszsP7HWWY5OLI6aL5C9n30fex9793iU5y2zX1Y1SqhZuJCiGki4B0Fc8hYee5zdzx5YC/3UCUsC18FA658b7kOPzeKMXwsd6duNlYM7ghN0ZS0FgnWUlG6TVnCa206nv5RfsOHvcKqkQPACL9diPVJ4Tcy1N241wzH+lGF03xFDpiC3LgR7CygyVXpx16jJJ+85NCfALyInzry8zik1ElJ1ekdtUJGEcwik0qIb4PNrk7puMEp4UI85TZfr5tJgKgXT9YKY7UHHxSjike+SvHvH3/Lmalcgn56ez++L5h65XuZVkSiwjKiblibyvOZF043gcpONFarFTCISCuOuxDGtAJjoDnaicHurxQ5dYtEOiMLGzVOoleXS+mziNOq4bFNzQv7ELE1G5sgJ8QF6h7d/9OGLdiUHtL4W3QnREji7EeRwkgtGmHJm/GwvsxbfZanw1irXsx2LvevT1BQQWJfIVInaTqRBOxlKa7HOzpU2La0e2D+N5wdsqJwXtue7uadwcPJiYWvp0avGimvrJ8enI/wkX8kpftPCNj2ySyiaXviusJbLlGbaCpT0fjJXs5voOSPdhCsAjMnUOi36BBvP8dPiSJ41Bt0uTyAoJKKRqNDFkxVzvTdHiDnBFl9a0e0AoZKz3/2fvzTHj116km6prB1ZZkmNzyjnh1/frDrH2rGxQm6R6dY3dV62ZfP13Vnf+/6uo3gyZyc0Qt5cVRUnyef4/Y8JhpeTycgE351gj5jg+mZbIzDjuasSPCcNJuz49532ebL4t929jMVLAmK8z8Y7ISQGGg8lMx3NVV9Xb/usOZirtJqlRFht1tVoRtKV4nqsPXtxUjNrwMIPF5zodjr77oDPGwq1T3KzKA0PaU5+WZu8lRT14cAT5p85rp09Or7FIb76/t4bP1BjZcGccByTx3EETPxlRHFuLoh7bMqSnLXra90IfnEsRzsXNF/iMEg5I1CpWpc5XAs8Ox4DUwsJ0yrR0MxHaVpdnWTi2t4Arm9gybzjGl89pkVBOqUaLzZiiZQ5Eq3jQrNe0QRcyvQYJ7Q4DGdIEJAFW2xBXL3dl9O18xhcmYklB+WaJBOmY+TO0tvbZAavY+ZesrIkEahY7qXziaPGNOW4UNuBjHWpjDXatWCZBsgASwsi8+094oy6w0J5ota1ot5lMYbmQw66e83Pqtk0F6Fnwu5DEGF1hUrmHR1K1UJOx5keeJ4cdVJijvIhDx+tdEbb9r401AAzVUxO3ajnq6LkKMmqwRqf0/jmW59KOz/S2GxI0F13IrIL0abMuga8pampOMhHnQNVK4LJZQAqEtfPMCRODOiwi9gMWYgOlqvVVQdFrrfahpFPJMhT20C0wy6tyGzYVXAZe/u6+WUWgtehW3/38lGO3LG5Afmlf8skTzT+pQvP1BzMAmGr4w/sa8YHmq0MHqcLOy9UJkJ8A/LYfPLyInChe8OHp60BJd4CmTvvr1j20avRs4O7oiF0L9diUc2YEatxwSPJ9M2O9qkYMaL8FJ1JxiPVdXxe5XYa76q5lZ0/JDP8ojIWCjSyiiC3nTnPXNOOsJ10Ay/Svo2gdS+Nlairai7PfoS0wbn5eKj4LAzOFHT08cz8tlidq9t2Kr69B44TLFdvjc5KurqpuxFYht9tQYYpMaG0Y3p0jNBmdD62P+IliXxhrv7MIlEktFGu3dtTAM/2TRs5Zeq3hkkFJ+qCQp4Lk0W4HY1cbJVcoXCsj8EaI8SZG6u1OgrrsXbFGvGyZSrPaz+nJcDLQgdKK2zYk/4qSrlbjNyBW+6FRZBJr1aptWpF3/c9T8KkPv8pkibGAj7s+9j72bPsw+ynHZMPWFJEUExCBeejXImY8Ak39nzz1m9R4L6jYdM3KhYhma3bzHOmFhUeu7QNCEp8xrzv2j3yeARYIYmp+rbOrNrsnVGZ5BivR4kdO0AXBir1p7sm2A5qo9D2Iq6eesrPxCwVjQ4a+ej5DHb6tf3Gs6/V/ub3mZGVERWjZ9cHNwFOSwoN51jbirwxHlG4wnjBhlWjcn+LZJcWFEG2ejV7Mh2N+UgNCI5tOz5JqQLLcQZN9Rk11PVA3cyHU/K1NjCGPTWGeiz15L0JCkU3AhvmyrIko9aVL7I3hTWZs2mbWr7a5WjKpSOE77imKnDsiWa9b2/iQESTdlm+o8D1gwurDMGKHQ3dFli6iQLEK+DHCxTUJmmwkqbJ+DlGuyQeVFOZRjNYgY2a0CLhIQglQ4IsMbzb9FsPFnHI4koqrTVNkQEi5kkNZtDekgmwxcMHqcxahW4/zVbbsBrTjBFfcqclSG4kH37+NKBVZ05WrqVbtY5vKJZrqaLmR8Mr+35xMm+y2oTquSXkzlYWWsLjl82eTqhIt1FvJlE6qAe0AjZtxuetr/fuH4eLqe8ifQjWLzCeyPl8fhI5yK0QYGfFvWTx3YcvuY698lJ1lg4Tikmg2prcai+bCl6O4t55bhssqoJz4lc6mk/0oGKXHEMy3IDFgmEZH0U7LDWmV9SGSEvJyzYQJjtoq3HtFQGSUrtYoMRzela730sosphKOXnzZ7L1Vm8MkxV5LOFooVgfonQinS3EVwqPENmFhQyRDE+PKwmmOCadlBWmWsObbpLEP2o90i7yI8qNZSUf+Bw1MeFjw5K/zr64U/x/w352ny/GR1J0G9YDbf86M8WARc6S3WwdHSbAONlIusdgRTe4EUxyP2XJzlDnk1MUeHntXRgomsex9JOOUVoHHXvIN0r6Z15R7cA3Fi8JFauJ0wbz8DTdH2FgIi+mWRT4ouENcjhLQaJCcIlabcP4mUpGbzWNXNt274sUxaltGpqTpcPKGqW0B/DXNzwgsFxJqdqQgVGisZOs1BtTLZ8mVzQv6058vW8HvHLSAjDbHUIFKQm5I01Zb/RR2lCUPSqcs9vMUpwS0P859XjvL7o6bACQtteJZJO6OWBWdhGPqZHakkW/PCqI1MMmkevHg9QbOmhSg1rdhzrmvOu+ioHfuODkC8rbFPioryp6cBOT8lmAPm/wSLFXcRhqgNYnjzI5nYn59WKujM+hmzNTMb1aVa9SybhsLniuPGwEePJWgBtpHpdRB3Btrb4mjUQkkLmTvR6O1e52NTU7v7+FLF6UTB8C6mZznmivQ0lED3AZOUfp1zJgVUyZ0SUXEKCFWANyM+3mgyfj/mumSdU8GHuy+7vAtsyInaWvYcOhxXawh7By4HqV5YhltRS3IUisW6fi+0VWMoNrRP+LVjyc2DJkQyXcOR3qCuabJdG2xIW7ziFjZBG8ggnMYDNSmLoMRNtN5qfXjnq07WQibjXI3GP40ljMdibrjibybbM/RckD+CITp5kV9XG9xuKuVcICHYKJVw4/MN8cw7OrUI69UDKncoTWCYtMedREVVxUiKrCM5qbeA5k40khLImsDhBoTFUiQRnqxUfwFeK0TZ/Db6h/sLE63z+CsF02Flm4+KA2cyjB4pP4ipDTFWKwjqgryAATMl4bn8JBxgtkI27W2wmR45QjHuJf/VwoQUzs5grBogCpa1ST2y4Ous7/abMQ8jY8ge0m5U0G8mJPkY6XdoSZuNVEkBy8MP1y/mEXkLXjKwtZ25IjkscG5nEKnuqlCt3d7yMcOsRx2pE0F9ziIzSU7bAcCEi/d8QfzlYjGlw3WOcwq+afgw8bA7vDL7PQvuyR4cNmd8o3bBWsfc97e8RA3VEoATyIbZ88cKtbdqoIK+EQUdGiWQtCGNSPef00Apwib2fcyhyM56ZMwmQd/kZxWYA6NQ30+r+KQw1wSInrHywRMObCwgg4UoGSv4YgZQEzmIS+jygRdIZcAEM3bd1XJFO3VF41itEGGUslePxMN6PIVHU7DVWSauZ9qQvFCAJrMh5NFhsky4VYgkCR4EJjOh5+O8oAGpiSbVQtQ7XNBUUcl4fjohSsLqPnT0xuS18Ct+owk9i1f9CK3R0YXq3lZ3lW2t+ziB+FlRV9Ik7bDIVCcUJJDK42V78P5xww17LJSkoDnuHHjzPn8CNSM/uHTstcfU25fPqu2XAbirf6PNlqCtSR3Uo0RRoxD6W9RaE8wIjyUzTNyK5fLdnetWSOIUvotbqcW4D/G/p3Fqkdk9HJmuleoitZf6aSz6w4Xpy3iWsHhfEpRxzPHuDFvj30U4ynhAL1cIB1CBm0JJNbKo/12WPm1CaKYT6I8UlH8+RF1PLnCy5GVyHGeVsJXMY4pppE588phjlYYvK/lbqi1c3fj7R3VlKNIQRTgsAL2dIPVMRzLm5djvBHx4tLpPqrxvlOIgfnyTTqdN0rTdpV9XK8roRK+o3MqLDMFjAdL6H9J+1UxdoPQ7db4aLWWCFg2igqHdpzPT9CmymcnE8KaDw8kjp7V4gT69ZiTJLfvK+y4OaIf3RHqUJHPylesz7aWvtPEuPJLI1TvFg5vVqDeJuTMPcFwSWoLYN5m8B1Q9O/5WHJVmzaHEMTrd2YNlA8R5az0WypRmF1tsRNCUWb99ZmjPbBPgJ3Tov12rXZarVFClGc5oSAmnbbLAXTkcwuFHnR4LgKw6HAHxVXitfD4GrK+iL7qaikeIR1qmPbZ0Ae5ZGtNn+nsNQzARknusE2bT9VSL3TrLn4lf1xlEEnKdmAjxpRaD/t3RU2u5N1zoMbQr0pApabs4rXPsFgNpeJegN2BDHg3KVWypHdiYVMcnHgipBGk+hn4RiNeEMRNLg4XcoUSjnIUswhgQtYrZdp8zn1EvYYWzSKEk16vAFW6AP9SLCTExkY0YzGpsTvQYRlMe3CpBIiHTQPtvPJ0v0jc9UcXtIN8RY7d249K5a1dCYVjbzkisgxFQKxB3KQcEMB7x7QdHAK/z5tUVRi/mvmVGwpIjN4qvy6NL1ix3b3gsnpDjeX9QZdLTuNSpmDMdJPuzGbI10Bto+HtHuJ2htOgRMjqcwGIOVrpRHAlDwpYrtJ0hdOxEsbvnjWVW2/Najb7FYRvVLWWUos7VRCVhDnNnHl6ukneg7v+OEskgEf6p+YbVZYKLvdRdlgvbtIflhOWLrmMggh1cyucxKqNzmG01tZuYibzypj6u99YZVjyy8iNhyT2+ju1m4xVjfdudHGYDppVyQhWaq2EbDUhaOBnvHeuzAxbtthLqa2/t1IEMjq6YSzsGrrR9eL3kfbgF8EfRf0S9AXQLcBtZWGdWV1qn+9mnP7Q1lE3m1htZRdM9S6dWcDONhnaL0IGf6wyUcUV0I8IMPpWcrwXc+YD1cY8hAgek2hgvqzEVecWIO8Y1umYZK2jHH4AGtEWEme6VtRFCjjW34RVwTiUC2JkPQBXy3wgDCOOY2j0AefB5ap+UPfbZSuFdUwNUkQ7z+3fkeNH7BYNu+OVnEbOBfjgoXePSZTvbVYy/H8cCJJREzNWZKTRZytQdOxg8ksJcEJxhj24pteFsBYJfauY5hQj3ZFErx5lxlrbR6sH9dggsbx5nk2klKrfRTmJWXrI8m4zs+ACE0uwnGSeX83WSxoKy+Mroo2yuBeiwSjCPRQXCW/kxoJsLyJ1DJpen/Syaufs3suXLpYqzca68kUGHLR6DWLK3HsoOZXhGZ6NjL4Op/ZTd2po99zZRzjmB3E5prLXnQfbWNdU8qr8BXX0WWOlnSZ7hRNttHKW3fLjtMs9jTl+RrWvHWHO6pKSr93Gs8WgYLbNVt9L37+ssGM7UU5Gau86rMloV3Vw/nOZef/+6s0c+lZUUavNjrL97B1X+oPiY53LZkVi9up1OCPOVzVJokuCgx8EnxuMMyEcIjvwklG62Q8zYpYfrJbKUFgnmZD3xZKFFEOippiNJgR9rHWBvCC/RwNGzFNkaMIFLSf/+eKzeFGaZXP1qZbieG7xxVWU4guGt9kBLqcyJIE1kmFmRKErSAJbDdvRnTBs3TsWCRJ7o+11VST3wqky616iVxhnb78bqBI1qD2XnT2R9kohmOLgmwO8wO93qhubNIohm/+H5plPgEgoEueuDdLbJu2Xo72GygIhvavXpjCD3xg3XPl8yqo18lGBTlVxNHi1rI9g6Ur57edPjSfmMNJFIUHPASxSJnnE3oBOYM4u8MZDRcqfDNmsR5bMIut7osH9LDl5YbkdtFMYYoLeW9fW2XWACHpnJao6Vg6net5su3O2t0Wm8nWqW71Vw1ZcErMK4fGHxaYIKqBNmsZL7TFNsLt7cE9tM9hMSoDOHh02rqPEp+idVWrymtW27c5t+2RHLkoaxqiTlsVQWw26/5FIFEHBjFThtir2utyQ476jdbr7d1IKZe/OPK2siSMMlE1kY2Sud8f9TGJhhgt6DKNGk8WecrurcJMQ1cjdprh8satCUFS4YZ/T4fL1euzHxMjXpGLog6GS5wFL+v64EDY7lBo3bkbQYk9Tp2JYPUv/7fv4cPHvsYVMZsuAcLYm8MJ6pKqFgtnmhHBIdwBXMZ8HdzabuPTKb1f/sL2GSNltM2NCW1leYj3s0zVNMwnhwtK5UebEUJtkcInKZ3DmcFjYfOJXrHneZxbDhSanGiXeKa1XimvbZQpbbU7T0JJhq99igReTY+gMCWtVqQl6q1Y/wvuQCBUjDJr+QYmvZ3DX+n8zU0jRjmQsNywpQdvr+/Fw2EDRezVYPqh52s+/ebX7rZRfOEda9NPv3zbmkfQj8DL6frjkGmt+0pYjqXcABFA7ROMSkmpGFt5mdoylPV0luswgOgex+u2GlyV6z5pg/bWRpYpNKNc6YYsI1CwTAQG05rxE2M0WQI4eJOBFL2owAVurWhUTAncIJ5iYgkaSmCo9pbACQE5NzFKy+2ET7A1mPxSjzuaykAKDwnZIiOLwc3BkEKLIlXZVtBjXaDUM4K9UV5+IdipDPqI552K0ni26ctMzRrvR4IuvNyzo2xa2Jm+8KSqskTAcXHTm3//3qTfF0ocvJK7IriJU/PQbMOzrMDxmh97srWK1r7W2fZB6oJ2uT+HgHeu+y9g3JpvWhAw2xl1xFHInXJnfjXbZ/Xz5V5oHzCNZjVXLGi5gUbNyYYrzJaUcmlpz5hEeq9kHHN9YnEh/sTYmSDWhyuEDQGSN7OasRn62gZg5DufiNgGx73T6gO/kk5Wus3jRD4eSTd3LC26YIfMR+0Gmz0zkC9JD/7pbx9+iIqDndcg3fLKn776goHqo1Javf6q0lTd9JI8ts2QfxIm3ea4W70Mox53tM9NZGACDK75McujVW0SnJONsw9uXCvb0fNBTDajce8dVnpXzJbfLS1BZpmM1mFNC5Y/dS6kedG8KhN3CFH9W6MeJLaU3KUw1XzZQiigx0YnEw5hBB2lSM84raCeAGJYe8U14EGKEao9isLZFCVgds+sidrWMEu+HURRHIf0yab/bH3VbJErtyUpAolqmFKEu0EuEw+QlzCatBKOAFx4RC2kX1lqwSXpkR08JOQ7ERcWg/FQog2peVcEOS8TZluu1z4G9DZ/CvkTQz/De8ObEPC0g+sFoyJCcTCkFKqoBSziTWaAeyKsfHhOUef+rzz31aYgUcFtEkHODCuMTJVoLpdqMs3VU3z6dXhHvlndN9f/UlRMsXYTgCsbJ+7aoWzy1XN0vyNVM5fev3Q7RrpYjPNkvBt2D69Ei3VzigIGb+fJN41P7CI9YFi98+DGtXycT3ZPBGdDp7xqPMxuy1NF/Xx5mWUwz+o6iZO811FV5b1OtCrJVy9Ern+QubohHgyVpounO80af0lcxEEdnnZZPvVv+r56VbqN6MLCBwzhAz6gbpDuoKzg7VvIt+JaNv9ksN98j6oEPxc3r/4qrX8qkn5/kRDEIIygMbUbZAKz3hSH4sGA19XB2nAYycdM0nvJ3oe6xApPrFa9WDEz1d8zBbeCQ1hmHXHR0eJDd1e1pN1dqFsmLtzsRQ9Z7Tr1bF+5gUg5tpYSnPoLLbajXbn0w5tx65kCEOBDnRb0m9+8BDfJoMtiWiHSctAVQtGDFds0Mp6sx3F4Vncg2hEJ1+JEiSBeG9+Gl43rYgkQcDzGS0xS6vb10QQUBp9U4X8T+cjWtHeu68ZChIKTj5aUVMpKA+Z9bFcoZDHqrSSO3mxV48m4/7jXgWwn7QmLdkkhND185Wobwv1Eveg1G8VIc9JUjOfWrEGZtD9FKY+jWaeCKoLPStHQOxSVRYA0Z7O34gPto6Wo31LZpQZqfMlmbeRixAp0qiaUXgn3hhvpI2aBLgPMfrBAD13DQ0fYO0kckMXiSL8cZHG/nFfLs2S++hPvgXcl1z7pCBKWBsxIOKl3cuFOZg2h4YVhFAWO6xWzrRDHIedm5SkiuWoYOk8jyHUtz8qGpnymY6WL1XZUFOhLtkfhtaESGfCe7xmMSln5LlhNCaJBC4bLSWyIQA/sVmnr1rFK25EBo1Xu0fj44P2ColAqJrs3F7FvH7mZt5ibFnQ7yGk3ouRGShtkDwAsvCZochbAy4t9whmshh/Nf/gNJTmetRq4DHG2xjo6E01anc4T61o5PRmtJmiB68AFxpJMdI5pAREXqJ6eHmqNRNXAxMRqsDjMRrPV6s+MGgEaxQz4DHgXOMe2G9PeXE1A08qRHD6fXqEQQAvGhYFIVVGGhw0bRJlbxgcqspCc4AKgsgEUkoxWXpymWFFzo7iKOb88cLiMgPnq+wlPHLpe6DtBGG112b2DV83sTYXhBH4EtNVhotlpfZCqWF+CMwwpUMiuN6sSKEgge8qaFRchMuEIQn+OkxVVEzmez5bujqYMpvr/jnuGRT5ZLRe+yZ76+OmDvupyr9Ppo+YcW+94Y7tOvHUKypv67jfFevXyc5Ccvxf7HRJsnMdylbV0SX1Jx19EnqJnJpB/mCSWIvIsLTm2TZ9WvceumxQ7QzUcx1ZESY6esz/lOQWIH6bVOEHqSaUBUW2NEglCsl6HoQdYt/l0ul3/7rKHwO89T8+f1pPGMXNVQ++axjE0LRi6xuMQ8X0+iVsNK/IgWIqiWm48GY8l17cNy3FMncdgeUfmmTWJ82p921/NpcpzvWgUJvPlPhsOhyhv6gj4gCAh24Az4Le2O7LIMxhihziIsmi2F47+0F61bc+1nVuMZdIHpTiXIKmuOVdHkHSDR4gYsdiopiUTNEmWGF4OijhZbXEEj8k0pMrE73Ai3Qbfs9xC+FwgkewQOKGT+d0eb3yvfi5qrIsXI+k0ZXc4grTSaqvePVZO7Yqn4rQbXg6HF+zRiSFxZkeGlGhzxwsbRpOXCnRaKks4iXplbMd9Dtww52BQFxrILMeBJ0N//qBhaaw2QHCKgM3mZOFtUMFO7jNAr243EiLJUDjEOdrJP3tPN/J4VNojdFkawZWInx2lO5Qu+9RRls2LzN9Owu6NcpNw1niggE+vFPvKZIBaNFGLenThN4RZBCZWpa+oVkJ/vN/rwVKQXHFX2BtOZ2TG+sHSf5KeK4clrRLzD343CbfOUTfIh81+SoEbAFR4EX/xXs1/mRShxfXUKPHw6Wz5embnnP3D/3o2VxdJZaX5AFDEa1ckvTbeXt7xZyLeA1pHWHY9tZ9w0M/5QBFB13kQR7wo/t0tjglAlbaN4lLSed7FSy0YBI/s35fIUSvRaDZ62wuaFR6fXw1jHhgOc7UhdQf91q3XXgfha/mtvNaFzxFE9+Pc944mqWMnai7bQ9F0Lt8pFONhrRBGUxvGELmrHVzC/BSEaYVGPrgooyNKLeAAVaPHM+thb/OuumeOVQmUsUza/vHNFiXvxM4tHHZ/qsV+927fXaqGyiJiRP8we8zo5FvnLqu31FUulu8DUkyjq0EE9fBlU9TzIN2QkdlM9LCnK04xXry28NF6EvWeoGdhRUi2npOjrSorur643jAJDHH6GkqFScNNBx/8axsL7qcoDzYWb/m3OaAcqymhQAoXTznVQHej1PKfyK1h3La9OA7cHOgNsjUFukjyOqo7qk1Zpw3lw/nVg0m4FPIRApmldGHlVX+QOYGpUD4z+/9GdRwmZZnlktOsqZEPmkF97PUr8kq9kCTmGUCi+kfq8aQexlu3TCyAkkq8zy4JM7P6RWkERleUlBvBxb/y4QTg/7RzBNJa6WuYOyBIYe8j4qiLS6ZhffyBuDzLNjeNJR7+rYg3zsr9lVfGEdh1xlUiyGKxl5zO9uOJbOi6LGPs7laHfCkeTX6UTVMl9izDn5eRuLZT5kU+rkh5VrCiLvH20Vdv3giek8hwy6ZJSfUvzYQnYbFaH0N/pDIsV8xVCLwC323wsx8s7cAW29CnGAUSnTeuvRbknp2sEcOk/rLzg0iYdH8ombAWc7FJQ6ZfNV1Ku47FJn7lLTrexaVRgOCOP9zj7d37vxUonG0h/uKy1Os0wc8OrhFyC8ecUrDOzOlp7n/SWZ5AYHfneHH8pBwBz8u7YUqrwJ62Tff8u6OTvRyiaeZ2cIQ/K6/TUOvJ8Q3MHGVKgl6Vidqd305P3CJe6zzzOx9Y8/7LQqzCtp88nG8nc3KxzDRRQH1UFYE2XTnuexFCCssJeHZHThwSk+Ol+hko2ma+vF5r98aj/1k6c2mH7SMO3guot3IiVyMjebqrbfL9eBPzoX30IHpLc3wyrAI3rL76ozHu4yd2yGZzN8bDuxGUkZyqJsrWPs8QygixSnIFdJb8Oro4Xpp28VoSRpKMlkFg7DTKQ/O+clpw3NRffdVnHkZ2w9poVU12hkrRFKD241mGYDCf5njqfZzqhMLMyE529iBtyqEscxfTXZXiPPbNLJvvQDCbRvltxidMkhjbtPJOe7OebGEgWBzbDo9KOh3L15vd1a06C0qDH902o1RWTfGHswG62N82AFxBPnYUYasj3mQz2XTGZqHA2uByuBoUCm29ko3XAMPgGW58fGJicGi4zJha63dZGzxNTf56JR1LqaqilIxRnYpn1/ma+LwqcbVYPAz9P8vqshqM1u760NDwimR3Q18WLgzUzNYnmnnUbDigEhGA2z80BS04iq1SsCqxREyZTAWhN1Cnun5TLeYWwOgVWSBTVa8zmwPFv6dyCgL/Ej0kl3hnQhn+wdF6fBCxvmsJo4qmNV30s2XA3j6gAxjbEXyFJ9XjPZPhX0Iaf+AP/Ic/0T8GalFOsp8wJniWzqYaKuo0GBYwJM64NCapZ17YiUZ31e+dX9Xxdi2yTRN6VUV8qExBrbPE9p5yVHcjSzkXtlwd8d1gBgBX7bau50fvH+8av2NUq/U1DXodyeoOFrl0aE32221aJJWZ7W9x672GHg+2Th8M+RrOtjgERwD1gL5kxgkuQAlRy0mJ06jeY7d9L9YuhxyJeoEP7raE7i9/ouJWYnwiEfV49i9NRhPzmLJ0AAkAXXm3RjPqjyp6OxbP+E+uWwGkMT4BdFXQPbky+Y/UCkil1+smIbw5fp0v6Ez5N73p12CwBj1Rr+wcv1ZqEruCtD50lp8lG+1X7x9eFKABubX0YvDhRt2jTJHd86Z7gQ3fLHJx1G5wBIUNtFR2Q1V4EmIYIubLEtVKH+jQyCMZUWZEHjChS/2N2jP8XWrAhaC0krQJkO+6ukxhrnR3pLWZdC0IHLlzm0RQQpi5msL4xz3fWx3jqt5EK2sF7fRWMicPJjkJPXEMwxldS3CB1U6w8KNxJkgf79w6F4xgCZRdYD8AGHT9u/rxSXH76w+abHC2jmviPezZAsYweo4D34KljJndoU1jcPQGCWFTR6WmEnJ6zGn13Y10tznCAGRhvZjGHsLSaUEZq21Luww903ludk9sUfaWDfsgPv0pjx05umAFjOMDBAxQD8nx6rhBdUlFg7lv45Cq4EfrjTWq89D5e+LkuRbnfp42A8B2ivSMmKlmPSxFpvpmsQ2DOFrOGGWNV8y4MS4Ez4WOebM9epKIFFCS/SgIwyTL0iLP0xgAMdCR7Wx5DRa2Elbemm6coLRYSUFNUCpnlEXgbFvO3QnHAeyxMNaxLWqirN76pG+Z0i0a95Oba1FK9unD5KVEzBlo5s4PtFBus0Gj0lHVPtk064T46uix5vNDCBwn2AjHMDQX1B2PJ8eXM9N4XEMiBJatt4uSHyBR78VolZ7he78knph2GbgWPKmuiwcDV/+F+tGLaiz/ogcORaCjCHTQQXfRIQ7U9tovQuFAZ0PKZmboGyPcCaAH8J9fmTU1CzK+Zy0D/qO8+GjVAKjRsF4BD1xY0kGNRYvAb2hFG9rQhrYQ8tbKFSpZKX3Zb55dnzxot3ad26PNtiR3KQ1Vr4eklSmwHm+qRxI8Tbj26cAS2S3Bvt/lcSJcaJU6EPQan2kCPCgCsLuxJyAjn2FZ2t5QVD+5yWbng+XmSXHOLuO/w7WHfWHhWCD/XvdjpaWwP2rJkrL8DvfRAysUepjmjLe+W4pvvk5ej32VqXE8OoB/WyZbRHuIqtyTI2pV5/lbtVqTmlSY+NUCWDuH+WgtpbJ5pQ8ZD6hHSjGQTMS9BgfhVvLDxoFfjX78ccexdeP9mL064EbIM1o9kaJ34Oxa+cFAECUTFeUUI+GLvKTIEqCYdEjJTrI2xH5WJZtpf4BxTjJMGYKIZiGFyyJ1NWuF8az4GQcaX56VB70+jEFX/4SoGDnZUIoo+AwdZhzFi6Y44RpkWxsvviUbJtx5iJxIZd+2w4FupsYw6foDlrih01L0NmNB60aWpGlRlsNRVQ1zwJoOECKBjpV1OEwCk0M/z6awDlEwrSQvciH1TO0qE6gDNP+1phZwUyuyPA3jfyJwDMM5jWdZhieAXXRgZItFa/D/Py8X7u7IlBSRUb4TvvrWBVeycX56fXaDU/g9Rm+MBsR1RmvRAyNufNEiAsryOx4tb2DYuNsiAaPGnRYOkI01qw04c6H9FbhwAxtccMEFt0O4nG4sFRVzGvkB1WfAtbj5lEzDLjv/Cbt3+jcOinqlfmf5f+ovU2bHDuk43mBi1VtPxhfh3kPJg6zIPL1dYwZkSIKEWxLkW1EAz7tkn5S6sU1dc9LJWhmtwBiexoWFUtxCCMFROaPQBc1bmT0pVt5rB8pP7VVNplyqYVmOp9PJfDabjAD3B7CBmXJjx8dQUYvqTXIKxVQ5xRjRFmieqG8Va0LxRVUeMAQhWI8ABCAAAQho4R5JAcEdgd93jus8ICRmmXp9DI9bdLYsznBwJ16j6CxZsELP5YLWYdSOLOzkEkWMC4OKROwn16siuf+7h0ju1m8v/339VP1cXXz1mmy7KPjk4xQQPw4VIYYR32Sgo3mDqezhR5NH0E+vTlVSczX8ocl2UyIOuMb52G4OaNSiS9kSrn2uhjuuzzYqnTqOcX8+BBIlXHmXfNetXEYeQ9YUnuG5bAeZ3P8bTdWwTZOt+XaSp+xLmumjly3GvZwKENbjHKDLiwoICiXlqpA05BqnDOsOdFvEeo0jbrvUZOFDI2T2RF4fony21Uf6+DSARlL38vHCXVzkAqdS7Negsi9Xib45nzL3MOE+zRUxkqJjcjFfyMqYrdzNFNSClK226s1KAT7BqxHKhIGdit/OefQ9gegXSjpHM4Y74Jje63Zb9bOT55m636ZVZryOn9y/0jNTFAG0woOVhUHUq5FGjmhfpgbVyHn5YFGFg0kDWOCABRZYYIGVwD6MwN8Ko+5hB59cgIfoposm+t8OQydB5fVPs5QBV20bcgQodNa0HvysXm7CGZg9ebuDbtJ+z4HndL9TfRm4PmSqyLCeNhoCHHVg+hq8W1esQwUe1G1m3gDw9HVgMEyjQKVR85Lc321fO2zc0ENb3RvYRiLj1WYAaXa9Gg0MXzi9qdoBc/YIAP3rgAfvfyEuXnX5hrT9hs67qDSrtTIbMNX5Mh5YJJ6Vg5bLCKDR82V34HP6EErgexG+Qxe60IUudOV46z9yxeMHB2f9my6qHbiU38nmAyfqqzWLwUxtEq8PXtP8OtMBpuMto/i0OpIMswEfm1xyR2rtV8e2300Ei6xlsTBN4gaq4ANB2MoqBLa88CVDYwqMR0TWoT7OgxYQE5c3bRAtc4h5Z5VG1Oy0td/qA4LMR6bYdXuIP2JWdIiKcvTZ7g8Y6NSkPHSsx6VMSV1ruWiPSjTBJUvnM43SDMPDuZuOCNcMlrhJi1OWmon8eQpQo8aWw9VTAdKJWpF3LRb1SY4noYLDMBqjLLcVrrrAdsM0lFA+qWnGSt78n+6Fs7vcpH1D4/k2dvVb0PlMqCrTgAQnB4UnpnaAELXBxh53bOXFZJp7DITOvLWw/1lbO0R3BUM/m9mg6/4i0sD1/sbn1vN76XMETzaSjRoDHRQeuVLf4E8q9OjxJ8QGCNTaO95FwsOOj4HmEOk0YGskLywXuQziKuTwyYEjf7GmgZNS3cVywMcHcTayNsWO28cOERnA7+HTcjDgG4gD3UQt7yUhKk58x/bjYRq9nc8ndxm/XIUEY1TAkWVXM80suuZurK9cpmnKxO1Pt5+/PA3k88aJsyFtehuHh84ChNq4uaiCmaWkDlh/cZCR/Do8Fp2K+SQnMFwEwVAxeXQqYzlagKINKFCge8KtmJz0B47oC6NWmVHssEtypHP3pK281EdDejkbH1Jeyp2HUiVlNshG+/LlwXyPVgqc+mmr2+2r8G7aA7RNABZH1PMEUa9M4vFwSdeikjCaz6BZT+oQv3iJa1VoghpU+lpfswe5Q1RXH+1HBNbLvnX3JBdV3n64R69q4+tAKjhyuoJAohs1U3aaiuUGrtiVDBvQQzU5SBTexZdDkp1WjzLzhdOWeFSMJxPPj2tsqpYudsgaFgfFOkfZLfJqttxgi+MvYP6lE3ubfTN2WRyIbyrxWPpgEshaxeB+k0q37TCwefzV0PCsWWulSQJ2XI99WxbbjhvE+TBPiknA9wOW5QAnVAtkJe7ygsiTz4TxCRah6WvNBKN12cjXrbOCU4TWgiCpzrBgBPo81Gm2YN0Iqgy8ggoB5Ih540vh+BRHteM2TfJBMgQGMRQctY772YrscadobibL+XMMYuPx2C+L29xdhMBTVC9D6nIlWB2yDVtXurMzt7oXAD02uyy/eIhpp9DvMRakFTE4z+me8hm4+WjcYnEARuBsj5ZvrvvTGE9bDoBb+U21GwD3cUsIUOdvuhmsxyt4Di/iOTyD5+pAkPfwOJrijjzhVF6N4V9YkZmhSDVtvUuBJSVg/61V89+3BychDNyvzp+s/8Y9PR+Nwvnu3sgWfuOIUQi37vO66y/xKl8oHuok4kWoKEG/9VF4cf8YcwB/o7lFcMwlNquvRVDXHGjjsa9CQ2/xel3rrShY2qtoWxQl7EYXriBr3aI7SVIZUzTgN2u8JsQgEDUdsp0WI8ZZZuCCuTH3VPe698LVy5uMHGz9mIgKlHluQAR1f7Q6XV5/rwDNZwscZQ9IgaxCQh4sOMBl/K68eBTYN6td1DLNgXLEjfxf9+akNXffLlXzzbJ/t2bCmn18eTHg60RfNgcbn7ifkBpPX2O7yemgEXn7QLH07dfEU4CD8tY/dvBCABeXEWD4xxsJgW+9cXnVay09MNI7vt/HcMHskwwp8jiocxTN+j1GBUwQLv/GqmidDyO+fP+CMBcKvXkFOXUL7q4lY9ff5UZz/07p9RpQsvyiqozu2ecmFDBQbvyWi7ftbnEeI9D6AXgqrGDVVPv6/vINWiUHGjuis2jBGaMbTMb/qkF0BijkRE/xloArqvN/ABN6mh8HkhO+2yUkCOAx1MFrqIA3NGqLyhk1j8S1abiwUdPjXz/TPqyS9MkiCKHVk6gbB8XsrW8cEsOsF/OiSukC28kOazIiGu9Wj0KyY3n6rNQG3EtrslguV6NuqrI8r6pvpw7m1vEPHKL9aAVrk0n0ZG1ecXtI8zZAN7dWH4B+Qgo+++AxxCV33iuxx+upoWpqVHbnbFlIhcsrznBqlGslG7bV6vQQefHCZTPcEs1dItyQPt9uHmF7Rz5rrEXsJWkk4oPslu9dvsQsRhc2qswxjGWgXDNQtW59T3mXQLRF12pjj8vmb/PM5lXOQQyl+xXb9aRuzPDT736XENUXkX26z73jn5MchYR2ebQs4pOEqJSlZcMqwYoA8RFmwtbKfJVuL887J2EFYpv1rqpMuc5pBdX9CuPcfqi9XMAca9QYITGIytTEQUQCPT8otMRs3PGGBpV4IQ8iCA5uu7LIs5lOGTITMzfyEavGVppgzGAQZ0WeB7ahcRTN6V4QJmVZDQsLaxJsDC0GIWqrCu2SKwdZXcuyy10Cg9cD5l4tO8myfJCY4U5O0WahvApayYZtKDIL46B+iDeCMcdojTZwbScZzGoPkRc/g07D3JANcwzD+9lObX+NpD3viJpg31XUb8TdnhtzF/tP4tkK0kcUgAyH/dGnkODiR0J4mZucybxTMzos2Ph5WEEIfjyBuF0kIWwkXug+rnYRt9p5fngzEZVqvV4fB9KecMFd6CsNhEK1vEnmD7uqlG6HIN44TKMka6MlXC7NvLF4Yx4JxkgWw1lZo/dMCpOKldK4x53zXOtxi2a50oZQqvDrWn9Y8UIUZhmke7nx5MVen0N2/NqGoYrHS7XihIXg4aUBlg7uoRjmtSledJJqcZCKhkOhw8ZJGnN96p2zmsjc+MsVmF4VhHiTZYVPw0C2ZGfPdf8HqODUWndmHg7Ims3p6+G7Dfi1KD5H/cva+oaIw7FQtsEIHM/WACHWg9FV6tpFBJHzc/C2bC9zvJFp/i56fgaV+eKI4iTVLxNBdAp9EBPqdB4oRQXb/d7w0aehaDSeSsYzBGcSsa1EPBZbDz1Jv6yqbYWk8EZ17//aZiEHjEmPI1WOvkuk0BWJ7gzEovrB97gkiVgPKTdTVNtq8xj7DJcXBzaUDmoMDln/TUo4xRqKpR+alvmwMGTT1kSB7SxYHg24EIGYO//FdD67fjVbQnILf/NYN935U/eDwE79x/93Dg8wbDQey/V5AunWdwMhG85wzNJVNycn0effayFYMeh/3nQ9Mmx0Kss871bVe2YfPUSrAN2rFvwQFKMxaz149z7EJS1fVjm6vqTOgLZ7GW66HTpAKeJUs4agSzJ9dmWmM0TuqO3pfssbVveTbFSRUzGKvS2WwcJ+wzkIKIWeXmoPcBPZue6HF3SBD4J59Eb+J+Ayrn+C00Vd+/rbgq2wChbBKlgBi2CFHwbrFuCKbZkcPTtEbg9bprW6E1oPvVwAdtnAezSdU9bN8ugKGGCECTk5P/5mzdnUkO6qmsRObhI3nceW43mWxGAoRpCP5sT0mbVTCotspjw2TTIsxxfun3fMoBZgujJEltO8iHt3bFGVamJqYZXAcZ093mJMdxfnnbMHqcE8NHP1vXQWU3t4YZO/NrP1pxfDPHrI1BrH0LUty5Z7NcHauAhCWZaWQvhWNl9Wo3FVZAADtchxgnxWd6aXbnEsymrrvCZ7Uy8rRV51EcEKwpoypamppZISftw6smexTp2B4UehIdD+Gy0SSCw7G5Cx5A/gj009Fk+di/OtQ0oLb7VL+CEJKpsszk/XxjLResvkCrf2opqUZ7jpdC9MvX88J3QZOQmKIo/b51mqFHpPxFY0lEs2BAsYRM0RedWv5hmj2q8ZdFSB8m8il2JrGoxsaj7xOH9s1iRrTasoy4qqOaNqKBBCtaIYJlk+WDUq1esgKEowLGBDjeZmWUmCm4Y21gDFYJBKYXJf9wWSlZPlLFGJXiTt1nmkvpeun1+VQ8XMN2JJns8bOJj4hFCTpKTLG6ZyZ6ID96HusFzL9PKpL0Gv7qUafQg8zw+lAmJ0kg/3UqXSPBFOPXACO+ABD3jAA0e89Ezfydw7H0nTek3XGj8tHzc+RIC3Gv9N9qnacBkT1+ev4R/OC7xt5PiaV6o+FUxCFl4sgWF8xqku9TGFkEFo/g/HvzGzg4A7S8rUkgZAFedoG8Bc+Inj505RPAnYaaRn6+vjg9hoza+7Oycf53Y9ICqHJnzok8C4ZF1zXt4UhOrz3sgq6WBgdlehyrdEYJ0cMvGO5169Zs5l+/wy0LIuJhKM5mTT1WwrUCWAg5wZfufmXDCR7W4CHw7OkONOWrtVKnG2rdYSH7KYyHbPkL6Wx5/IXmXvPY4EEt/e/1DRw8ABHIE70c7iCpbHgd1E3zQuKuz7wfR5hyrX2poJSG01XsvuRBS17fF2/uGMoaNPj8lpMucIwc0vpbrp/FXwCPnd7uabTuxps/6sj2YUUnYsUrUNBcHNHgJseFDgQyTXFlfnpYqM12CevTHHgZal4Ops6aSXgi8u/J2LvLBPcQ887szar1EkYf0NX95HmdLh2U+ifWAHT/uwDPEJ0N9jnH5yWo/SEToFE3rUcIspoEFXL1NM53rz/Awi/KELBOj9FeL0FFI473TndbUwHuo7g3hqsVmyt95uEx2ftyN13O2ReJb/u363/qxeVRddBRjeX7mculXXy4NhzSpuUeD+SOvg6XwzMAvVI/GDq/dIQdRYXuEya5SlfLoC7YM/X79OBblTtMDVPChGUTi7OYydAgd/1Lp+NKNHMsY/9dlnU+9rFpcv1DrxG/6SzhM3g4/qFC3gcIf9HAB6a7DOuN1ACUA16MMOxgWC7HgI+DEgj1b5J2iMSnwzQBrRR14AnEFv4zPh5fZ9nWLDZ8M2agiaHgihAQbNB4cttivIZ1M4EVByIhATl5yYECft75IpRreAoligAYVOKxqbq+Nm2oN0eQNjt40xEaR0W49HPi00ND/CmohJ23Uij4jKeg+Ju7Lq2C9v6HQhwGdRyd/mHKYPxWjVauVwLhRWPd0cWerGsNk2XXtphwsT/pMsXYZDwimQ8AyuuTMraj0fjxOqSo8g6lYDFUzTHlzfT8Zwwpau2GoxM0S+bzc7Uvxv8wox1w8UOgPlqJLN/U0OH7Nn42DMg1PFpxBwbtRNGPDSbxKodjnQcGEQyJV7ugwn18l9kNeImIVa2NBs4FXrHEfandjNR9x0e9mbKm7VS6sFOmGDr2smJT76Va4oSChphc2y7ItHKicVh4y1IhKSAQpIXw6PczCSzcvgR5tWXW8NM0+OA+CvodaOCCAIhhpj4PKQw4Cee6dViA0vClJ/KFQqFcQhmjvZja23uMukwF35mZcQQBYzw9Roj3749R6ykZc/jMHM0EBjxMEjwoNXhu85/Gwjsi/kTWTTevWNM0QqMdLSDUIcwJQJbdjDS4Uvh+NPs3LhGAd+0l/hFQslwQSvhmNzY15DGkVxkjEeR1mSZvpJke/TXqrOFotJ5tmm4UWha7vjcRT4lio/yufbpD/RZEFQTdtPSmf0lXoROTxOiPl4WbrlLNZFDCS+F6fepbEd4o8zFoJCYJu6KOGoni+w1t6ooQnse5dOIefCPY1TCJee1KScwSsWPo0n3mbvEFX8DC3xnoNyZvs82eDZ3tTwUkdu7pxTTA4vu0SllKpU49Igw11NFnYJu/w7jLstTmZSpUGnx4MNhFfUtUIQW5PoOgirWj7ozv4Gq4xEOrVgiV7dQG+WzRr1rt/CmHMy5g+UfqUdVuYAqoTKQ7iWczVZiPFSTqnV1VRIKPUoEMQVBjEyXhaZZNt95tIOu3P4zPyQPrHivryiMr+VOVDDQMsN7kCcf0XhxW5Lbt2XbmwfLP/c14zsZrr1ec664vz+Ephn8UG1z7D1iu4cxT672Q2x9JlWRXtxpnsaD7Oo5SUrWhz07ly8BsfUva7Juh3db56CUgSk25rw2Mo62yJ+b4NFziLAsSSRvimqAXbznmlIp6OhcGu73+0PeBwWARrDb26SCDhkJCwQac8MBaSQAi0Wu0szp1bq0zxzgrl5p92sexVJom6QwcX+cTUgXuzVVSHh5XmgRr3tTA6NaQEaijaHAsqICgv2JcatFPRf7u/ZpJlJ9lkdmcw3/cvdF663G4RztQ8vNUPGTOP+oue351jERvyUevSy65DnO2SxuMyzPvY4g/Gmfu/yEHEEwSZDuhwxAwIEsEiOrOGZwjxFUJKucRiBd3uts3q3dd6H4H7nsYBdmBJUBW6ctDvdgw7FsLykYBQONY5bwz5My7rluuaXA7osqaati3SnftyBGk3GDgaVDzjqTGOQk1xUUTJ1XTn0N/tWIoiJZ5fBpi3F7iJPSGxAQ8klXE7ninD4ILcZDCNEKO2Qlf6f5kGIBrmxzqFw/cXLRZmyukETSCgEQ992OGR4vYsCW7/37XCY+0JFQuu4GklGtS6MuelMCLEpvLh/DqP1dK+KoEk86AqphbZe5q9uOA2jsVOhWLZU/hvDuQAULO6Fa90o+sO7eclHISBgOBdPV+/nWnCDq5QpGlLM2BW5JNnkqAYM9U1Mc1a0sfs+PyAiUlUas0fHjxjbErq1FEsqPu95Z084EvGoLkuT6kqEYJ9d2d6K81a6zOdrHWQzfnVQQQwmlhMDfqNikLOX2gor2X2hqR63U900+raSg+zaSHcK6LvW9YT1xM6wHoca5BHGBKKIIhrLvDOjM5kRi2XFgRTW3HPIKja9VCoIjru660DzQrMV7+Nt3d9rzeWTzTae6yEq2bv7Vr/DuBZuJZKFrs2BZZu9rpiRa3UTThw0sI+k77RWY6Kv0Rv0WkCqMgINx6Qlf4PraL+UryjuKPvAiZ/sCJaEK2PDMI4814P39SjegfDxx0vTLhjpLGf0RLle5SnPYkT6MmURlOSNFrOdWKZWL0ecDvEZqh7snn8C46/50dqZXS9fY5FpGttLeRYc63gIZWxlOLPT2W7WCf5/C9QVbeR73VrA5GdjCmmzw3LV0/Fi5sSjj6zK8TNCl2WB/w0sMwN65A/cXQGXEL7KroaAi3Gvd7pdH3dkO0rEX5jpjOusy8+0qUjEHzjzKA59KKf5Jq3eO50t9XHI2oPSLaWyRTcSjUsHCukcTdd0C4Hqylb3KLSyqHFnNuV/ePEGkDy7jIJbsMruIGxOTK++iFhwxgVTPtFGK8EW7VJtFYDUzshsXdBG4oZJx6RkXIc4RhasFIaTlvHizn+NADVV1llZrZAicrNBAAyBGKebqmhfqqlzGEgSjKjpGkdAzXa7tS+Tl4vNFpsgzsyVRYbAe/3WsZottrqdRusOhJE9nMS++rG80Wmd1wtZtdbr1/SZZLxiEk9L4fQKZrk2SdpP19BTE60jb7jZDvns5SRpfGsuHC2v8wrXrd9ztrO0v1vY4KdHRm9n7WW3vJMsWxNsx1QGQN5W60xjMMDO773Zjkeg25nWRVP09aMPxWScSbLkkGYXpFWu1+uwCg12m33WrBItGr7nsu4Cm8XQZ+2OWSU+gIImbmC6OmBBA7zMBc0/ZfUZ/hndVxmsEyYq6krVxqFAzJ/YIoV2mmNCo7N8UkCNkWmCXeFiY7WLYRzElhDehXCuxfN/Ws8OjUsmkREb600QSwrwG4uBNI3y9ctRCt8sGD6CXEWz2QbH8/Fg4amaqhqGOTN1TRYlMRxvRz2YTGA6cjyDAgmpTdewybicOKPJKHWt0NX4LsHG8GqAl0H1CaA1pHjx1iXwOoqIrEKIp4ZEobxK5W427xtLveuKZraVebDpm0R5SrdpmXS98XAlsCDCegrGMGoA7aGd/uflMIKy80u4LYyG4/oNxnMAwvgkmVNot5mNUbnYSuoFKyGJrKV0diXGkvY0KRYbb19m7TQ7vMQhviJK0/kuG+UuasiIqrNMhbHtuKzcWLoZDsBrvVcGxA5Jojlfto9uXd2nF5eViK2tUZOP8P7IbFSPgg7eHc2qW1sePV8azaKWZSeIR9jq0WgJC/AMMBKeeXOrohfHscOjjzzNB1iohxKkPwTSQxY3euJmlj0S2i46lcD6HVjw0jv+gCfaqzYb5nd12mDsbrHguaNpQcF06LiYB/+9tDuj61z/OF6sLwkSoU25JYU5kYJ0gGmF9hqDtg/KSyxwQ0jjWkVJVlB9gmt7LgWj8ugLPkkbkX7UfPOhjfONLiOs4kjRjqADDoWJ3B1n67T0l/vpxebWu74GiFDZdmvyjYPeygfLl+pV9Y6rxFr0XvvrCLjaOq2rZ3NAtZB2Uu/CQKWst7KeNtzldZEnrgKfbE59raZBcu1TJN5nTOKcYkpkRFMZzqSPIKQdoJoDPGoI6ZAamEQ5HNnHozSk6WUfdJpQmu2y45y0ZqTxTPPJrLD6mRkpgmXAGZko+JGAS4HtaDxBwNQCNqgRtO2H4sWNIhdRi0o+qIr45SnE43NxYbWD5nT3XE3zRYojLx4E1Chmu8rmoL3vnT6oDaHWKBvvpGngkSdgMVGrDEe1P4Sc4bQTEAjO/f//3WFi+oT5mSVrllPqUa0ZS3xD1cyomPdlGkAdNNmnWZUFyxiGeRJGcQx4UGs93fsFsLxEhNOmegJVZceASFzsNLqizXDRYDT2zCDQvZBbq8abntzH1YNI4DqW6mJnA86wcP1wClg+5NPdQVRaMOA6gyLkIdX97kS/3mkuqImM1T2+vuNthnj8i7fxPr7H2/icv/fnB5QC91+Hyu23h9aiBek5/TuHixYDGOlf1jA8crQT88KxuU0SI4sUyEZzCbCdtRTanbTKZp47PWRApFvuR93Mh96u/OoupsFZ8Q0IajqOSnGOgNDr3nxH4DBI3HhtIIT+4T944OrPiz5vrkS1XKK0Gid5Me2AAgwbXNh7lKJi2vuXHJj6HCNf47xAWSw4I9eSjhvZHZBjRIirMT6rXq25t7Vrp2nC51lYhl4tEutaTQrHiytlBMD+MDgqV/gNPYlu0T3UNAF8ihZPapqqD1y0hpYk6EPRai/6aAAovDvUWfjz27E0iZ1reC03crL1TZLmc78RXFgRhFGkfA4ducHD7BPOUIo7vkasUT4Y/51wf1jShfqCkJYITkO+e3JpfXzlDOtCBarB9xiN18pRufl2tW2oecwm1HLmdDcl11v15i86s9GwRuE2CQJ412EB36D997X2ic5SYXfOSZRc+yn/+Tg0ecXMKW/XO+8tcplPVMMRWuGV1zbPal0XoDlohfQ7xBkGbHJHvVbEKdds89XNRqc3RMGOXGosrFmhtZCu9c57s41X1jcrXAw/zo+zMPCz8Zo3xtrjOk6yclGHwXBuSxXwEtsYewPMFAGaCS+EJAnq5+FmG8ZUv4rkkqVCE90O1P84hDFGiAilHWfTL7bWHYbP5NPl8z7VtIvKmTXyqnAURWV5f5uwh5i/SclVFFDIKOLW41+eGRUSwGZ/2UAgKKm7tOxFebm14deaB8DjgIT7ceyViDnGfaG7LCuK12oDBGz9pyiHAudxBRUox+1w4Awze2om+TDHYKEsgYP6sOJEnhsP0muUFAUjzLMg23YtiULdG6t9N35+1ZeJ5lGuOQLPix1s+x22xkAQLmekAEyG3uoWD7HQGi0TK1CYh6SUbGbpw4UixMEmxUY47K+eZrNAPoILzMJSmX/FyDGhn7edXdOLxVdvTf7C6LprmDKlZad56zM4JCgoRNkNbXuXw5XTMSlKYV6ve6JQ6Vzs87fXoDV3qWdjjPJWDVTjzfA/vmAzmsRBk04IUc/Bw4qX6gF/xZPiYXew8o7tm8fJBrJxIinTCjxCOhUy8eg8IMhZw8QcTG86dZB9bLg3siEoSOwZxYCDnqWNNOP9QmPkSSDduFGu9P2kPDd4azQp0Om0QriBMphqtHg2n96S88HM+2qG0Vr6jx6fmbK8reK/NgBNUyKLtz6yOSpXA15WrFqTWY0oWfax0C0V2qJNPE+tzAOY2ErufZO6tUpIcs7gCpKNZ7frmHmfBXPCdJ402lLuvVGydTudjUeT4D4+tJnghQVyA8JXyY32VzO77Brsum+btDsqZ/14Ey/8aDlxwzQdAhIuCZYdKaph2nLzeFSLfcC1Tk8t8yd/Psekqk3U9EqYXqwt0R7dA9loXLht5GzA+JTbsdSXgo8DsN3DPvmpEZnCCqLm3EYVMmyTGXD1xWGukMi1X5ZgVs0R9xzVgsDvvnk+m4iD5KNkp3Ht7w+Cq1e6bLJIO/j+g8Xyg4M1JSInio3mFp9GJsdzZxaXVKy1ulwymuHTPbPzKINYQ/uGiFPO6Ozbl9PdZzX9UrZUWRIgSWF9sFst+YfgZXoEq8Nb/LvvO+/j1IP6sX0rWgIkASbmiEypbaH4m019lrZsbvmspEwe7T4GRNqr/3Hguga7I7S1LPYayoup/2EDY+VnqfytEFcPcotgSBfklTpC5vztDEKmaXXjx9KKUG+bruS28mAE6o3FsMB8/CZx1eah/GSyLpqbVlXRWjOsoAU994IY5aXmwEonJ504i8z7Za2OcKz9GQqH44Q11iV+WES+qna33FzuoWZwP3P5S281BgfxRJLnuEiEvQgZ0YricPJkhr8iUBRDcZDs0fFGn9qhwCdWLLkSTRkKe4rNcoqI8sghD5YA/XQIAfZ7iTaDLSCyNVLWPtPCgHs7UoXj7CIAXl98nUekcCQkaj736O1Jzj6lT7Ogq3Cr4lrK8fgd5LFAg8/7oumMlhM/mHz0uoaUGipxECdxGgdxcBva4ArMN+JwrBGzG392HSW1orzrknrrDw/ClWqr0MdQ1gyHp9JlO+br4OxnN0Ut9svMVv6J/vYbQ8vxjfOH0OsP3/n7tDgYXwC+sZuQkiYIiuVWilfgQw5P+Y44IeifrHSVi71FEX0OnSp/+Wni8d75/WhZMg9+yF7jVtsZ+pNtpr8PS0JUspxuaxkhvZhXGzuMGl+U29dVXfjTg6auoqLm6zmOb77687d/8qn+xPbbkS6Pwyeha9j/W89ziBn7/j1/H79xfpDeR0sLZ1VWHmgPmo7ATIxQW2UiGnuJV/y9r0eubzEPvyBJfw26+BrsgR1w5/yXIZ6M4XO3GwOgV6VEPxBABu6aXKyZ5rPLlckaOILml4uA6CpJSgX9qMoPApogMBJWiiNTRkw70wuH5feElpVvxS7br4lsS946GYUYjPMdwGO3ohCWbUvhtmCTRdLlzKYWA2+5Kya1dg6LSnZhhdO1uyRtV+6vbGvIDtIac0zCDnzgtQvOtuQBAp4ji197yNc5imieXQ/mW16bZpDmvb46NzXLfXVny+lOPPkywLiYlWMjfzTrxW/0jg351dXzGwqFjDpACuOdKDtkWbSpKXBBo50zmKnIO3hz27Jshz1pziFu5Zce+rkP4qjBZbYJgXHh++MNeBZxfwkE37PgcnlDNRG48L3IObaUSeCKF9j+eNvu2ORJL0+NfH0vmp56f41Hwc+0sas4NulDaO4+569Ff3DeDRPoN9EGculxg01EdUPtIU7pNrjc90/Kp0cY2MQde5LRp594n2JrLfwE9aWlUyffN/eS89msfe1rYMCI+8mXGR5hOBQoON0JXA7beZLtMkPgjBAlghqjTEi4vBZhq0QEP98/PJ0Gk5BVYaS8meD1DJY8gwFUk/Msh9W8knZWZ7SUVORMd2bJW+N9o87tJxRtwEf+ti064RvdGQvxQ3Vk+rBp7nh7DS8uHoVEtL1sqQkc8dvUclqdQy8LNLFatiuqE7B3i3awnCXSz0zaXDTHR4bG2JIBflf+cUsblll4Df4N452DukS0DA4vQU6ljRafRD4LwxaPxx3ZKL0SRJuB3zX+6CM+9ZCtYVnJgx2mZv7NV9u0juH5rsCwDFIY4IIUplk+/F1Ks/CclYK9sT02HU4kqlGCi+20/PksWBGGdPKh1DVij9/vC9DMfkpm4mQjolwBzNd7Z29IcWEpr9vHkee/mAwMgwlN7IZHAvbz9IkBfJNnGFtUDnW6T/f6W7XJqFITbbx29MDmDmBK2+kJ0iemtlVcL5u/9oE23GodjtYJtmR6BwnYGPrAyF1Rl+MbFyOgYfG2S0DDGCQwIU2rwfmCu2hTnNzaTZE2Ubm36SDatz4OegugVFVSVldT4M9xeR2pZbEN+Gfij4s/4iF+EnJq0SA2QbARcBHyLCB10dj1qDA749KoA9ks6erzPV1ISKouh0G60LpOhHxel/1oNw96J6CTFwGbYuxi6a26XKf4pIWtoy5NW5pDsLbF4/F6OWWw3Pb2TXo4d5rv86vYZ8AshmVxTpX4Tpqt27yC2vZp9qHPR3WM+boysCReFIjAgTqmKg6qYxgXuRt1ARhivbSnvd9PO7DF/odEmCUCiU7UXWQj3SC5MC9djjd8i6HF0QQc7djmDH/ezWXi2qKL6s93MrU1kCje+4srRjCq1Nbj6+Mqq/jLowzjDpD57quKhN+UKWM+V4KT0DZR1ffEXfcrWZfonRIbr643XizQJnAz7ojkNeNDr7ZkQjV/pnGRB/qiPq2wcr4QI9SH432ZZCzRqwaoyy0DUYuAice4vlCOsUX82F5FPCij/lazSCQUOmJpDcCG9zpfjdaEG/cWT7af3HSgHjpoAsWUmnP4ohIJ5bdmzBbraJA40s8o4J/G8iwaCxKeqoFElYvLggDWMva/soArzO+JFEBKcTZe4MYs9ksVjD398JEuzV/ebM7ulea+3nSTgQqiMlPqGBhcMaIB6LC1gliHr0UvoPFJZfaA69TrI/wrOmASbnm6sXAVM9Z4MhpArdZHjdoSt/gFQ5mVxYTrlmaYdbnq89QE/Bk36oZxMjRKKi0gyYRmWIWp26UIl/EGNIKcWg/txSOIYs2zx0Yu/XTyMtTuIKTqlVFXwVVwuNVCiPZ5udUacXaQVhzL63lgmP3D5Q4s2AVloe5BZiVMrcM80r62qYghFAedRD44C2xt2tTVE7zIuF8q7612eahJ3nQtb1pQD6cJGvQb5luJ52XnPD1sHPcvEV0/Be6C9E1k9tNzolHaANlM733HMivK5Z5xBaUT+tTKEAHYJCmpRnkkGLSe8S+Yic3435/5JSFu2FitGxRNn0WD3RWeV7EIl1GNclzF1VPlxfSotDsnMq2ptuBm+ZRZnqDLpx/eq8rxisLE2kd2vB6zBebSfT9VzyIyn05NiI6Tvb4Zb7+nvCYqrun4frKmhKvrFOwCGo12S6YY9k9oKdnSbhL29AJktHj5L84bhPRHwOlfMiURLDh8twA/4DDuL6/IDj2MGOwZDFZEdtgVETUmcCCQ1Rx15xzqwogE7dz1Cg4tAxqvr20lXtk2+PP18QVbPiqPe1WyAHSviX9o3NyHTWnlrDsOUVpvPjlJrxp/WdtptuLqUTYTTyQX00zlyFC+IaneNph3tO/Qmpi+h1L5VImqEX33UrZAi9KPLoYgRqYkFF9f+BrnaD48eCkwi8FykvMJ/KPlj/10Mt8KuWitovekU0d4TCuAWoJAnr3hBEomFoc7DkXUOmdeuHE+G0pLWclTklfWEhNF/qaBawTGua3AiwbH09CrJmsM+tX5bgrTa8jaXwwFxjd+Zbj7Pt7aGejI0Apk9V1UFXwgfjjb7WXStgiSRESD95Gd/d4rM3myp/8XT0W350fGxkZG5kMTP369+GwPq+Hh8Ugyd8so0OuWtxP3rXJZ9tLRdDxPSecl5R++fhZCNEPBN/6lebAIWq4jaT062wjvqBhTS8Ned8siHhh7hmx0CS/jhjt6t9TouVhVa5jOqs+SUITL0Bmo/IW3ZJyQhG5PBBNaa7Mp4DRc7qRn2XB5cCmTx1d4vdXBio1UQHdn50YLA05XXFNSDnj9/39jjCu2yUgORrjX47/XvVLw1jQytt9nOcGwLFgB3gO3Jbxp92Q6ffNMt/HckOJFDt9qObMSeDRvfPnWgoxw4ybTGI/KlJ53hy0OkvhCvhzzjYVIFiHK2eVVjcHkEXIbkOSqIpXgUttOk2O6BSC202XksbbCdeDpmuPG5cR3TM00g2q81n87WTAGQANgFnV6cmvfswAEAJNKRBX1uKchctweqTIOUSLVV+rbhCDMKRMG2rKdltxdcQj79uXaKiSS4Ry7khdU6wgIYecpwVkaizvD6n5wugiy2VI/BSKwH/l5cHYh9o4rLXlDXB2gnsrFyH5y8PQ687OlZ0mKqvTk/oakODJKkAL+AJe6d46I5puTHgrvrBk3KMXaU4/47hfpDTK1rE2mAMSVs2xwcZuD+r+5jjI0LLLXPhpMa/P40dYiCoW4jzwUYw/ykNcBd40BlyK8+47l7Io3TJUBWeuaKsPjjf1Mq9MESY4TFTsZ5d9Ann3wl5M2LJZMZWdjozgjZ6fIHe+XCxVR+0OGHS1fJ948+qB3nkgI3eRa8aaas5yNUqeh2IkF6RKACj4eSytaihly3ZnikMxw43m6yaGPFAf5xQ++ecR7+WiAAIlPr0qHW/bGjz7WH6deXXmrNdS4l+vz5ZvLdRARqGTXQtsBNY9aRumDQ0z54AWX7rX/LwI8b6wp7A/9fQysyLMnADS9DVZ0qoic0qfCzrLtuayw3rN/MwxoHH1H6YEJIW6WsDgk8fg0e3Y6n/XQ7cCU6T7Yc+eW0KELlaPkygkI1HUswRglsDZqG0z1puFoHMsy/VxQxnhsAA3D3Q6sjDjUxr6Gi9aGqlpRJpiDYoV0hnooIwZBWSmPDWNKzUFjfcYiNLCjYqDAa9IKs8deJ3GcRPGoHFW5Y7qezktBlo3XF5vBoUaesN3XDQbNDO2fDnnKPgwZ9/jpW+BODAbatrW2ohh1el8Urob5jLAS1HZ102s7MV7h/QLY0YLE9V24KBbq82yuo56BCwmXG7L+gYV0W33xwt5Ct5xitohVqlegPi0WuE8xId+icIXseNT4Cb9PNDLIU4CYRrlAK0F2PWnI9xcGcXF9jry0Hb6uXy+A9+C20+5rfzU8ThcmZy4PoNUQMEpjIR6PDai1mPW0wG2IKKu5neV5Ma+EUi3ah+r4jmX9Nr0XBHE+zgq8XJAETvOSpITTPATv0ALAMajyoJT8s6WWIMr9FanGtJrtXaE03JdkJ09gJMQqwQSEjQqDmtTXzFE+67GjOnY/Wt02RqPFcpoXj9eAGm0UMV0BpccqvghJp6Xhp4glZaqcvWwQxpqiacUYwGJAC0+LigjF6XW1Kwp7g3H9LbOgXVpL39JzFjlH1sn6rBD2Cibml9eduEOd6F688Kh0KPEuPsI3eGfhh8Gp6Y8dK23lJbeobGdzTYKUQG2avPIKapLssuT+ObfUjo4GcymJCmBEtLqS8nvDcWodAKRHvq1+ZuXKB+qlkorv+DsYiv1wAQWnyPqFbK6fCYu7dW5Lxk4Nmr1tPgwIFLac+AmY45bCqzXV6uyzd2IdX1BGsuAM9/1vDKZEtk7rJv55mGFpK2KyrTWkatWUE98EpOTxq907wLtQ1D3gWXALeAx8GHwoZHQIlMBbNgbilWJzDqhhrz7vxmLDKoWoVVblDugi0s31A/uFHiw4tS2aNzroTTEf2QKE2Voddnv9wDHZ1vciOyzNCIqmqTw+qDMKASoCcII/MqBZa54I9ftyqqY1uYiGnjk+wOulcFQmhKHSPI53zLAo81p3/+3NxUxGy7r19lI954r8dGhjc9qJOIwiGEkzTE1msPOL0AchDUxackD78LsvmlgRV3McEy0O05q8t3fugI+LPM9ZZZrKpkHnkoQBfcN7aebfgH/Ik7J2DXfMywWiR2g6r2nb7r9ULoeHu3TJG3EnGBRwsqoZtss2LT37/PQMcBb+tZUM0Sb0OJJZjgbO1Grbs8ZFS9K7T/OATxmjKr02xzubL3qLUlLy0noLYfkpxQm04OaXGLoOzOO7dRAP6b1oWgxaqEwax60fEex0FBEYhE/xZjwAhvsk2a1viYgiqUY2tw1F4Ik+RaaespXtsBpu5jVd5gK902gCLDd3xuIdJY1uwqv683vNsHgtublhDHb/eIHK3hAlWRTM8tDI10kc0E74FmyJvFAdyHKOulaJmmGzn+lvXDZcm1pm2ZYCIrU3iNv8P2Pg/CaevzohurkZPMJ+HMQp7Mf+4+HOTkINxO6+PxeWwzwP2byww+P1U/Vzo6z3XF9vvjm6WNywMkzl9i3F+kdLq90enqgkT3Yax5kYOht2I1VdNLpBRgBhBJwlK2hI2TqHI2395V5jJThKMqK+Sa3lGa04iT7Y1CWskS9C27vdMiXmSk2F7Rw4K8eJFXE/fmwbSsL2B7+TPKLjgfdvcTme5MAKX//XJUW4orViUo6cR//oy2x68Q9iIxhqujLWQpwmyGs/nV+863tf0/dBTpefWr46aIfW6XLRyunmcnpVDdvGeFFuoIs2sQZbheVUbpa1QO6I+fXI7EDk/Klq0I05+HCiwlNsL1Q4cY0rzBJ750GpGI+otW1tqiMwyPu8WhVdVeAFSbQcw3RMQ1OIRqHDzKoc8k2KOInjNNaKEqEPtuZa6bgmPdSvHp+f7xUwl7o80zY1nY0LEYr1t7fHlVR1kaf6jocs+0SRyAkqK6PsWMtvrxQkALnUpb8rAGbTbHDfXeUFv7eyWwU0FOOoOHFVzHfYML4/0Ik/noyX17XWCgF69SXdfjNymobV3N0n/XO6o+XVpDIs6+FdYDq/JjaQUXu8axn4BXvglN0tTRbPsoIT++36PoG3WHQXn5+KVomddku0Xz3roTHi4XznD0Pp8UVFZ+A+OPdsJ9myGSFYbGcLQoI9N3k0PuOtJI7F1kHVXnAnrHa2PyFoEvwdf7enDsuhdLeHT0SiMeqWDg8fxS0P7UrkYDSiHecNOJhBcM+9uzJRT2Cd8ay0m9y6ceeERRpNkDCQel8Du7Ocg8uJHu+ON5W8jhTB+FwIglcL3jB0zZBEVeFohhX9cW6p5WLRRqLBNgj2IMHfn8yUqRckeRLHvi4g5yfbmLECfIND97H6DZeOb++cFVFniGy84LRx/TmY70elM2L4rMPi3VoyUNJho3sO5Zi5Dk/8iQCKCP5MtvyeH/MP7z48h9r7+W6jy4l6dl3zfEMWtXC5v98q4nzW917B7aJ6PR5IZJ4j4fUL9EmsUBuuGFxbaqslT0Fg/6o15PGMc4alZHVJiV604vUSrq9kcyyElyvuCmc/9OLcuFWQgq4A363OprXFB+ThKrKQhX3IWshn/t23E80xsR+ISMtIarHagfuC7+mqwmPdTq99tKbgqfZi90t3NwkeLoProA/soSBFF04B78SdhrYmlcRDc5Xr3msv31r2ReDBHl589siVI1kbmmbJWgIr2Uo3TmQyocqOOD8GW8Ei/Pff2OlC00XvE6X5tgq/8KMvrBCw5OUfny3P5X7QFNcUH1+Ory69uPnDDQntOI9fmoaRTcsCevl7smsvDwcnXC0Qe4xwPQvvoEV3sC1iz4W//Uj/37MVZsFMXtsSTtbO1VMfe/4foGDBrRVxuzhhYDJB8T1xvxw9Rp3IMNuH2agaBRzPCxJPUwSiNQOgm1ImbdtyfIYPfaGzhEmVSuUPuqKiKgq1BozRU7s0Eioin2T1TJAfX/EkLigVaBeXZ6SuRuDdkhFq8jm7izgxldEzQ8Nx4Vg495y+F3g+2Xe7qmwbqpumjqaJNDFoBLPbzNbhueyNsHQG41sMgXpH2IeAIfRSgjAloLFHqKWgP3yKQ6CgjMo3gplDZ2WIrLb6NkcQTNGR03QdmJGZgdmcm0ErXN7KK+aokWL3m6st3WuReKpyj2QJgmarmDrDdJ0tVhB8XBNPPPeiIYClEcXtnsPE9qRp3tK02euq1e8dfvEXU93hirw+e+4pHFwoaNpMUnYkBJfb9oZsklSuowAwT2SAOQFEK9r49T0njPwZbT0bPrhLnNZ8cBhbIxlrxITAAJS603RFEAV3Bh6g11VLlep7Jtek2pWCdkVJQAlZN5FjkDKTKJ8UOFkS+3mRpPIReGSANn2mm+2Y+m48Gauss5WvV7P13UseVkAPodMASxQ/WH4YBjIlylu56BXdXIldBBxGpbZkwdEkIpindp/Q+IfmS0Z7LxP3B6/+8dvQv/+2aaTPZwFOnix0dbI7HxeMXJ+QYsYtBfezmY+wpV+Prnkc3sm7tPyrji3AzctSTi7+HXHVYXbl311sMhzByFNf5f7mdwfYqBW9HpHKJbq5v06mwDoaW4X87iT8fRwYrKaTjvE61YBEM4/7Sqte14HR4DUG4YeKIUOyfEl6h9I1NFPFXHtlfhX7AKiKm/uteePnMBbX77yws6xRBunCfi4mug4vPRXaBSw/7l34XxjWtHThedA3FRTFWvzNSLD6VgMQMHiNgn0nfodBLR6Yx1RHcJE3gSOiaO9b7gGw/9E1UbPxuKdIcsPteXw8z8amweBsjArM919nntA9/xgHIfqSTXaaHXxh8QDe2KvBDwBSqxFd3c0A24Dff3Rm/iOyTu8aXAjQn7+suxpgKQIQgGBEIABhdwdy//nIhlq/f0AT7UhIG1+ZXlQfzh7hZCYyHlyfmdRrJfhibzdlTAk7fXvzLbvQ2vr+wltefrAel91N99JtOahbtG9GEpZ6iTxwyI2O9YNkN/9P7pAQXTGuKUOgKl4TTtr0d8F7qdKy9Dl674tME8vmvBUuM/9GkwYZqJ3dbHWZ9s+9R/aotdiNctSlMzAL8DVG/4Jk/+NkVY1s/hMqPHf2uIyUNZ9tVBM7EMfBhi/P3NBVTSG+yB94nz9FAOzyh0nicS8GX9mUf3Az/clSwhmY866DXwT0MnG8gmPtGmHdPi2y+L1tTbMoDuxye/THml+VeWb4vwcztjnkqdY6Af7RlHdcHe7LmddlMn7/He13PzHLyTJ3fHF8W07UWmaAHUjRcqfQnKzEt5UmewJ3+4jirA5CoA2lCYOIQ5mmKdm8BjdbyR7LE+L2U2K16Jt1EQ/Zo+6D+ZATTj4tOwV/e2vr1W4pf3mR0zvxCrA/XhO48oV3I3tzxlT8hHvVOUeWk01t9lEZc6Z9GrgmOw3cBSsjDdwe1gsRrI7Qx4qjt/cjnIB5vBraV8+8PengqAOd+lwVfw4QcpTm6t+s+ClxLK1yMVAVxkPCLpZdYG91X6i5aHiy0t9nJ0xv/QR3jMa/8Ortrku8LMsZMPh+7PTe0hoaVcqJFDvgI814yOxPbHDAyCX3dYc11tO9YTzE2uLyU6BvqG/WSAw4H1QghghJq+CfNjvG0vvi64Qw1QFox0KAENabaG/N2L2B2ixZYYH9r5qHhrpc9oC9VReEp8hcUlhg+gkLEGL6CSEPM2LeIu+7bXeLcHOJmJC38p0o9Swn94uH9b+xmREc0nMP6QTfUJieffLkeZwIV9ODd6OcSULuwH6+O3jh6MrVJk8uVmfvHF1QlxWV0o5K8ezrm2pjChUe059O3xozYPgMD8Rb/ytAQW0fIipGepddSgpjISm8RH642L3JWBu1Cgtlm7fnO2H6pvKI9ZwnW1XmXp1e5kPwlaaQJZsR2hfhuhKGR+7gaTh4wwYG8pFL4gWT2YQwvFrEwQQW4i8FxfDpJrBsbYx0+19xt0UJg5qhluZA0fHqcWC4Qo19unnEBbIYC4zC2tfF7aNAuWD2Zp3mqLPzVMVqhReFk89k325XzUV7bIwByA+cA5WIV4+tF1c+iGP6/Onx6wKdcGJ8fHWV2X5/29aMVJPjecUiJ8mM2lwVwr0qzU8q2QvwPU9CJ8erDcDki8yPRsCKQpoU1OJoGinQRRBXOJL1ZgFeHhyviUqTzW38cWhbuyGRJ+8/6jPTCcaPf2sUxkDvrEmx0bwf4F0f3jb5rcte8knc5zv0AA7YzwtDudaG7g+kXhBr+BmGISzAJz4yB7/ED2nAxxt64U5CUODylcl4d4fYBHmZ9PfYpgJQbRqubOkSuPDRSBy97U4FwO9UIPxUgz3l7v798DwRj1RKZufFT5dejmqij4PFu76A+/TTAQ2ZztWJQ8ruE9A9Wo7t4y/vL7cZ/anv4OplX3k73LV196ln56Yv6F38Vpao3z2+nm7MP+PPrtpFS/zrCxfsB0hESADo35wObezfcJ0TbtXZOxGvj27sjK5Oto/h2aKmWhR6353MV6UrXmx+FWuZ5ORsJZv5eFo4gA8KcP4RE0/UFRwPf/6QBNrHRqeibKe4Z9WqrPafrciqR56snoweUl4LcPh74ZODi7FJzAOeGF81dH4pmrXquDNh00Wef3H0DHZo1udGnrXuq7zEbvWXt6JSUF/7wJ/8dPVO3X7hTxIXN3ZTMncGrG8K6Oid5In89hpMhvo0Yavx/yyPtjfKdiiurWrVp1ZmsSQm2tk689wAkMDsTUXacxTB6gCMAnS2BQgvz3B+cWBPUdckJE+2WDejM1XZ6B2KucqGK+xB+9eSbVwDv9sDJ+8dptoMcC2Mr6JtXDHg6BS35d3PXljfSe2M9nyzh4P5YhI3kQISSCBfgOTqAVFzt5pNADQuBcEHlrbBnUur4MtLH9H0mvtICN2LK+Pj840vNcGEtQGwBmS6LZpesuc+jyyQfpddWgfCz4I4bxDmeIbVMBCliw/frJwkUko4nKtOGEmV74iS/3eaySeFEOowL4YljLagwvIZMyMYHbvLbIpZu6u+0+J0s+2v3z4utLrdHtjrwrQelouXHzgWu/gUBOZHK0/vJt39cWkmGLb5CXn9bvM0nY0wBGwHF5rrLhVnn7ZUQnOBIJ/SAaojIJVmJa6M26L8Q4hWw0FbhvLoO4b1ILrPH7k8RPGGskmyJCl3m/V6q49RJIkf6H+gU207jJWmPnNtR2laos0fMyhUbyJi6Bq27/EwQbvuqVjRPPygDZPcYZ5wBIaiW8df5/M993t3ttZ/6zWPwrF4pvngjTNjXOSwdlH7nMBCTw5OgVC/226fn6Vluyy/yjB4IpNQ+zAsYfYjpnUUutiHk+C3KvMUGy0mcrldz+dWRoIQPM3t96YUecfE4omYEs/Vut3W3uTRfMvtvoHd6TBt5tGf1zBWi8cbWvCAhdtn8RjnNR01HG60630qz+haVJ4FMWu0VWC2yivJKAJxcori+oiJ6ppoRwEOjgbmaYlAgSrT22w4zuXH37UwgpLKrSMVFTmWXZr8SfzYfYL6NVjnW8ko/D+2YkbjQhNdqv1QgVvPZQVJamMMH07XiYqT4VZzreK2+Pl8Nh0N8xpsQk+pGLYjdOMEVHm41NxymsRTU6E+xT6XRqRxiHue/3eWuYKgWEnV95BnmnDDN9b0la7JfOD7YZKXVch1fBxD7MDKc/tTdh+IPNQMyw3CkML6zHPdv1ajzQRBC7Jm2Z7vr/c+t1RVTZU4wBNQZGmMT3TT/c8XH7WFphqJ8J5vxU0wX0PmlA9wF6w5/tyetFVhl3Xbe4PXSr/9q37q0/5jK2winaQbyJ1uNFzMXlLy65td15RZUt9Quc7C8KzC7/3IPIBlouYW4AYNbtYEDwttQubB42JjhPVP2sJwsqRV7nqILpzKciuWKS/vVTeiTOy2GdfBFR5tKr/C4CeVZ5RL1nEBEoCQzdOp6BlE62xE8GQbNKFbqWFDY2/tsXp5cSHHEVqsiNcOv0dJK25HBjK8ZZeGev87wNxN8Xmrbyx1PjzIbNNm7vu+P9iJ+0PN3g/7aGr0rwULpXK5eNcxVonqNiCUxYS8+m3KcFt9Kvx/bYPTztxY/TFDoXuTrh9vDc500dia6wxJH8vuq2HJLCZVORxW49lcE9zuLqyxuJuirjvJZDuW9FA5/IW1Rk72lqaqDHgY5BjtYOulqh6HkrZWS6588kk5/ATGEBjJyYrIUuS22z8GX2RbNr8eFbPtWLZEPX18y6Y1h6EiG0x7LxjrRi9uh3FL9SKIAW3IxFt29jm7IvKibtmmIkpXXpu7agqPZnDADFAJrnOnq75qi1tlqNOQtl0NVztNeQ6QvwdLwaj0a9vBHNezb2cWi2mZhlGU5OVoPIYfGcavnLVtx72Zyd2eEQF+EwWXW2M2QgyGVbhSFVWjuV3ZRezZvBvEaZaB7J4gSvL36k1gAFyXxS856Zs0mhAscqGM1Qq1k7faNkwYRxTXWYi0kYyBmHFXcNphzBOQu/bhyCqzAikinGa0zfPkrFaCa+edVtqLNsmS+HUKjI0sbIb10MDoDdnnB/LOhCEYz2KGIH3IDrxihCUy457WgSyqsOLSumgjjpgG7SJcscyD+26xsOYVX05KG4eSPIl6sf0Ht15uL8ES9qOe1eEfE9SIiFckr0hmpdwWu6UQuonDMA5leKw0iX7uxm9kUkml9GytFx79QNds123kTdZLV7WqLZbwjZdX2CtBHCCsJf74pAizRFqMfWST4Mz/z0Pj4/c3U3pyCRbrt7/pxkFdYFsGdYnd0B9c7Pa2XT1+UX50cPHS6gmR+GsSN+qhr++sTodnuVL12d0GVEM7Vqke3b6bbxqxOm7BfLKGr1h/cK+uj1RpfVkaQNbHHbrsbXpWMYxdUw7KERIRQf3zrz9K1Z2js9PTo73//vn7b3Sdq5/4Ugr+indHd/L6UOXWF6VJyfq4R9faphdR1jeDXiqpTWKt/sdnhc7GQZwkwdT28vFvru7laZpopXfAR4uEhISIpJLRBMjtG3paMALZ9iUcBYYddOmzJVfgwlDgl4Mpfx4B88WspKUBttnwD4y+2b3eUoKOib9o7Jv11JAEbDkMytvf3DZYKZ5o9Sn69JhOw/T6FSIg0KcxD36mZxoCP7ufntsCNw4WK3Uz9XvFLloxc+xyCZmHKXb5SL2vVYOL2R3VxgCp7qiQ0aQfzW8Vl0MOhcbyD2W/Rzw2izue5RvW8n/9s1ytPqAkf7QkWzHA37MF0wN1A24+ix47gUcCFtI38nJEv6A/Q76qHT7JH6/Ku2sh0eh1yQLyPPz7rDx3XJXtzA8GQZzRIEH7GDjf6bBcmT9o4Ziu9yqwrZMYZlUPC8wm2R9tzjbOry7dJnbxkct2KW8BEQpDG8+v9/bqckNEtf3eZrBKebLtnInNmgoRelns88DUebMHKeOzreF08wBavH2SWAHOosBZ5inbfezEdUVvaf3b4EBM16Uci917pte2sziC4axmhXmW+Lo1ONoWLpjsT1FAHIVSR7JsSzhcGKO/zNovUGUWl7qp1ioFWZlRtvCMybzK5ZabX2lyIXaWG+gJ8P4p88TPNmZzjbiYz+ssf45GfC7rxe4Gzj+JW3iCMhxCGcpQVl3b7fAltRImbq919HZLrfncSnnimnnt3R5qD42nn7elbdYF1qo97Cypqgl2Tkd1/+yIEw9HQ6JAUz6nHWEj9XySRhAdwN56nyxHJlpvN7uIt1Auf9m5lqkyDXmsJiRP1XRaMXl/uJszpl8fKxPbVLmZv64P+oAvztcTPBzf7bPl+bI8+JRtZGCtI2j7xvzg8a+SIUzoX2zkCuPeU/W5UewlYe/tf7BZefOQU6KmV8gMOICGjPEVSiO/8EqiCATiAzbfmOP4P0OnMGk6u1UyBmNZSVK66s2dHfXOQyy+5BUMVgwCmhNfnrTeemS9MhwuLk6viIX2Z8hn091+7mDR5EUtfQqK1OA8TIE0L4bDJAgea9Xo2knjIjlZRVEYpYHO4IgSFE2xcpp7jqUJvCJIsqJbjiHzOMW+3qkDuehNpmRy1zY0GUU3SgSKucQp7uE6OXtoQfapE3OPH4to82RL5BEtoTdVmZ6qBkx6cBVBVlRblERTkztUuIY8dJkjWYZjUc7ObiS8KjsPz9L1JPT+lhsE4tmJES/nOpQ3SyVYsy+BX3+phlFKaT7Kub0uEpHo/mQ3HLvHYQw+2gAmifexjfh7dMj26gc0xDyZIO4evYZZyFPVl6rpNVTz+WIeGWY2XF+NJ7PVdUb2JIpgDHKuCjxrx4FM0pOKIbB2KZ/1nMBPy8Lh0KIUZjUBJvTuZ3OqfIsLrZgGgjwiiOQlxS2P0rXziIWKg/w4gQ5Tbsn6h4ue+zbHiP6Ueh4+sO8ery5qaJNEcV9WLh6eE1RDv1s9aRRZVWXNirJqWWmK4VoU13GHI8sUz7acSBr7YeI5EsMABL0Pi6M8UBehaPa56kXC7+qrnRpPEMMZvSyf1zhemmUgd1uSbv5G6Tgxv65oaD9Q7b+9a9L/F6sXCuV8WSums4UReOzKyD6dKzVrtbE+rMzz03itW/9u7Izrx3He9wwFf2ZjtTXLheETf1Y3oPfIchqjjVlBMUo4IER0Vr0ti9LHdoJ43vkH7llyFYM8JZis9v+Ba4X4bJlavpHcvrL19j/CA0RhAyIQgQhEIEKBM3oYjbF+ujLjZCMa0sXfKU2qz3lRMs735IGd0gGiY9uT4ElkSONwaSUrxb8IFfbWnBtqqZBH3vnIrg/UWda4PDB3axZUEPEDGzV+bZtnWfCjr2+sOo67xs7J/1o4oux+1suT5ehKGBroZN5ok7SzdiBZXo1EPCoxqJngb0QdOdljww5RVQfJrAPfYDhZl4k+p8gUzH1JOgzCYB2MiiaQFMCFNjjCCKg5E1opACvls2nAXlylQAhG1ZHny+sOUWiZIYW/yOSUmtWeIr5oQaZ0u4kQFGMvGr4YcIYDAqSnPrTgbekMnCJOvi4suo73/d1UJT8q7FuX1x1S2lf12CGFy3DakdSXSBVazgkM64Hq2HMFQCBtCIwpTGE+SARXNpPfFg8dXRzfccnRaC97rSOum2YwQo3np+WSGw+Y9ch282md3CYgauLeMQA7bXqgdEkiffClprUNrzjcWOtv+K7jyd1szdc6GAQiip0ZpmUMrPii+N84l99S/bSqKrs3fwEDY/EGPVioNNEl5z7ZrYz779n0dJObXo9wMQ/28LPDUwUhiITv5+qnA7gHSgdPvtjfmcm0pXIc8YcRrdWHG6fZTEyJJreG6lOI01F52JllgIPRqntOStemW8mim67UmA28TnmnjLXm5cefWVEyZy/+Qrb56vv9bbGFzSLfyD6dA478td44vZs4WIe/lM66O3rVFg2dzpDnaxVVD3xXY1BW+kgBQ6G2dnyS5niOBbjIDTRHOYw5qiySztHGHlWFrzG4o/LaiCcihDMyCYozszQL06isislLvsyBBU1BIfsiqYwcyRA6jZey1L5CiEtqPFOZaUHoGwyCEvIYva6p9MhtqYapMMDy//HWJLyP196xcf6jis5Olnq7RjVSF/AYTgqmn07WtLV13XE933VsQ68GoHlnuLGZEyQOmEn4gSRZO2BqWKWnJnNFd4ssbbIM1jJQ23YhZRtFZQ7+D+9ENkpHPS0HMcBJ/yIi22Cm4Be/ULv6QRKSUIJiJCH3/xLErvMORc+mOt73v4xD074QzYxiyW1zN+lpvOspwKQ9eoadwRJ5dz88IOPdsCjNBYd7OJzxGsnNlzs5GCBuDKoTvXVvlh3M9mMWMOYzW/cRsGynBFuvNn7IgHTM9adaZU/nLigsGvv7xxOAeYVUFzeK9c7XZ+WgHBmltR0Pi4j4X8/m+eYQp0n4nJDPGZgx6CMPAbu9sQvrinCqCKIqBWK6dSO/C6dGqXqmrUnNWd651jCNctxJHvVuMuTNzmwlC4JYoanywYTLSyYHbm0nl4cZgGwHPu3et0XyK3IUKpwxdveDd7tF4p1A/vXUrWImdGHQjOHJ4ESiAT7dVEQ4DSNbjPXWuZ1cxWDmRX2/qi67xMerlHQq0Qb1RcvGNtaJdXMrhOw0j9Vaw2rGFZheJj/46L1xwOr4m+dG+mRxwciFc/Pq21a5waA3+yYNQU0nlFRMhKZ4U94YAw+UvU4VnCJAoRtMiY6x358vBV7WK7hc1z90h2PF5WSl5w/waj+xe4ZlmVjDUzdTosgTl1RN5Uiu0CqfqNep914O14qvwMBDYC0rfRsqBi4yejx8zS0XMXky/NwvxyCuTpnmXInghdvVzOmjz2FAWrX473EBF4x5EKrEe0/62grdnBzOGqHswUr7M25xrLTuT1O98V7cbk5Wqcutec119tmZ6X+1CRaWj+mTfT6ZSgth7NpLwsB35AGuvGJ98aC7vxqLRtPVASFQJEVz5hA8pRuuFCdgtggFgSGJNpKeFCfFMHOpY0alDoO8tU0nTOcwIwsK6/cxMalRd0vrkooc1YT8ChdV/Y0+Xer2zmqXwJpPPc8JCbAjxFbzO0aDprrRnL4bTu4+9YRzU3sGvlhu7Db3U9+kwGa82MVdAX6hXuCJan8+aSUdKoc25XDstM8lgmDTxVh9toyHlOap6ws62MMDNrCBD2zgMxvyK/bpkt/LRgs77+TORIOnPPBK3PLYaveRpSlKiE+ypSRXanygfWAw2/+jDclxNmVC6zq1fzEblbgauEAdiTnNfx7iUlTv4cTBTfXFauwI5xHwdmXUrodqQcvXIKCzEQEGUh01McsmTsL1ZxlIa+DUInpwkFP1dJw9+PzMTRZWm/C/CP5p5amNneWruXO6FY/djfqb5cPRdKWWkiohxudAFt0UxojT5rqbEGiHHYTPFqaj3eqIQFlcXougivVpWiw4OHo7y73h4BQBS8RJRvc8L0J8EhYlm33TUp8sKiy6sDTUIRcqiqqO2o44oEP/4unle15zZ0Jb4fs9SyL2vE87wrEVIQjBeoRgbYi6fpYIUSR22Ey6F0c+ZeqaIiuGayL3aIsKmZR01njd+2Kz2VpLlRqW0Y5UvSH7F0PRYtLlzqnptgNH6Ug8Go1rU3X9/uqDUeN917N7W1dTtRkHaVcUZiDwRXWotXsHT2UEjKOZz7c//t2vYeDbhiWIjwponxUKn/DbhvAbS9O8LFLdPOY0K5KhQvsoGZlGagYQtGi91fJYQP2zHul6lrYci5aj4zurqlnbArGoKkq1a2aY7WE6syQCw7E+Iq3gemDbBaBoEflbo2+wkZx167y1JtixzOlk5u9yfk2hnsqr6DKywvjERaBWIcJ4EoitLRjpNsvpTIvSQp5E4ZBzXXXVpJ4aQVBWmb+xPk5ci3yy4Osrcb+PzKBtCSUXahDTepU3TqdknTOxE6EcnfLgNqnt0FeTrIIM1nXZWxSrpbs47vOcHiHsVlaSbsdnLbRxlx3btZOGGy2Q6VatUQj7MDaVZtzzl/UU/u5yQO96+I0yx1mrjJyy3q2PWA5ow1qJu2t8ac/TeszO+fEYHkM3HkV3yqLOVK2M5lWqpdHaktSygo24zxK81VZJzYu6rZ0yeWXv0+W0xO63kNKlxrEB8DYCByL0KEZQiv//2fUd2t0JoRirlFviJAl/ij/7TY9kNGNvvfxDf923syYtK575z2eMIwDqf6uNcQBHBvqIZdtug2ENUwABmdY7EAXQAhp/7BSefibnybwgqXaUxlE4zpIky6ebOIogcAVZI03so9bq9WswJC34aj8oUqDZg0uCFNptiXxKuHwOWdf3I6s3l26sJYnH4Oa6RycyjdNRHnElZ8qxx6rPBm/RhciBLoVAX07tw4StO1Srgbm9N+NkSdIbkCSZE1kxXv8gqJf4W/yeUWsHeBnCn+l3dm7Kyc9QWg4RipSqmQG9Cpk4HUzSfJ8gzYrxMVUf2hobJR3wPm+h5elZsrUqstnDE0E2esIBOgSf75m5xJDFZCMU2tpdcLwIcbovmfEe6taW1Fvlf3WqSj3ZElVQjC6qZtfJ9fL58V7wFJRki51XXaJKt4H1qaheU0EzTRiAI7BI18eZzkkiowiyGcy2zUQKtmpWVWj62KfG7bFXrgAVR69b+ul5rsXekhJRu5Ot1+jX24EZQ91ZtUvym0LIltS6SvH3HixR57p/TQSDEweubyhZoVVecQf2oBbhaArjdJAw8OTNNHOKgtlEgKr6QZZrLhwAtyrZODWsYuFjxvIkmo4hy7/k1lXT1leVG9CbEWAWnyjhQkHdalCU9wJ0jkHAxHWV9dj1sNph7rRuVYZxBdPLs+OAcVz1fH88YvfHaTqrw+M1LYDl2krzm54kV5fmekrhaoJT81K2qGXqK+bqw+2TKY/xng2RkoZh19akEB+AS/zZoShHViOFZFhhObiXeX7/K2YQ03zQPoit/l0Yxdt3GJLR4uoIU2X72USADqwpBapQNixZpkvbxcyOOIMSqmEGKecMHZLhOp8h0Uw+J7erKWI3TyYGMxBcxP7EtmEfhYAcCUcbK+5ixL+mafF2S+V67fl+rCxn36mpbCLkVkC0quBMVHfW+Ax0Mzg+VHgI1+5rB1PKOHk9y911qlRtaa67PeYKI9FYfLkaze9SS3jOGZcOtnrDGwHnD0WC59VDR/PsQ02ti0DoWVcUFgdiWSAac5FCHRpwsm38VrfkYVbm0mJ795XCqIcsKbwtju1RjoWVJXTlsJfVk7s1slVo40nrAmvDrKS87oDeEHP3Z9TILefP8PJMh1eMF7nhat/FePSiBO8tvayE2cfmVvWtUCIactl0Kq0BeZOIhPmgx6TCqxsHXDp3vKLVQVp06vMEOgvuODYIVpFBYCPpS4Qrjnygld76QidhGsBy38jtSUkv5Fmv2CbNZ//Me/s9Zbc5VZ3I0KnbXtPnBKeCJjuPALXhGiBnxSCknLGoFXlBVEzX9zwLwEO2IV4xLN9QOIE1O2v543l2Pd+2HE1VHVFUFJUXZJah5aQOvIhXqAzXVs4TWC2NMGz2g5LwxLF1RFRCRsqMMtWXWhrOzCCjYNlllVkmQV3oZmSdy5ue/wSeqcrCQE0uV4DnhIZZl2dpXhyEYRBdCbLQQitpNSCVJURWSDOoqfGiUr0PaN80kMzDm/wyklLD2oKS4EGkxH1DdRTRuKT2mCun7NiYQr1T4QsigmEC+vUPUGajz36Lg5768U3+bRdbjx4SlQ8Ba3RFRDWBH+gqEfWX0SvRHSJqAiStZ349A+657o1fRzwZgwQNEiRokEJP4s8e+3+JWQBAzfw3FB4CON+HcAxwBs8xEATz++UK+XE7MEmKW13Qvab4J/brf6HLiS3v54Rba9WsjwZr2uxrO+gRkXcw0rZ5L+zBoHcCn3QQXnyqGpp9LrwGm+Lwa2Mgb/D+b2BWD+2XzZW77ZB+Y2T3n2G6TtOvr9D2G66c/UHeGwy+uxImCH/oqA98Mdzwq9TscPh7kTwWX0iTk0uTv1LvUwa6TEE9EzbA5VVe5S1ePdp4/7cvcOezcTxQFJnSujMWaVS3242ri1w+kmSMJLZsS9CIyeTBE2qc1JmjMQXv6Oa+G9F+/YbUsmVNoeUr5L4nUf22kwlRdw4uvYsCIss4AdbhUP4xUjOHF440vzu783NHzecdQ0nJzfZkMdpxoB7KvlACA+F1PVTuJSKQqBqVorBxwHUKlBTaT0hm4A3vKIkzBkDWHPebCJzgdY4SdvjP9M/QZ0a5Rygy+zDhj0JR8fVIt2PuzOucA6V1cdSRK68LdAD+G1PuhgNpBziiCaQWQKENxVHnW42yGCazzaljaAbZc1q/82ljv4qLfssO4ni6vdaF5WR+VFr5xrGYThfHJVOXJcOmF5k73gTV1WqSp15gm4Bsos0YDPUfIbK1GAIm5tuNp7F0nCDb32pLPs4xfrzC1aRcNVqDtc6I0MQHIo4Ley7mh9u6LnUmfugGL8jtnt2HfLM1SaNsbgOQvjJevUeLqr8jpBsxLfH501oXbH84R8CkD3vJayEkX3izlOAl2o56/65a+GNHBDJLcisgEFclxwqGtUEm4wmOr93fUwqhDRBof/ZBrG5hxvhBS5Asy7T3RcHy/q4Q7tTUUzgK6sH9mq7XkNjVU6IPyXm8fEjQojWSLZxUX6ymlnoBl/O56yig2gP5yUDNdYG11bYIyeYwS/5V9cCkWj2N9yHnBAHf4i8s2WFot3kqWqzEEaB/1z6Xwxxczxydw9E5HJMjZRARzOpL7lHTkWwO8H/GzAR8gsslPkBGQQoFgLJJTQOAFX3mzCq3wdLb0JnPDbewzIATyva9TiCN8gk07zCVy3koa8P+HxtmrYALFAOAgInFP7BEewsinfuDus0zPBD8Pzh9DTMD+ASiz7Pwg6Rufn2wNRoLFgcMgM2/+vPImepTH9G1xxa1pd/7/7rlrb7Dt3p1fxwDI1yDW9duLgQGwEADBtAo41t6oQZEfNVrccYyrlH3Av+Co1ABXHQAKxu8oXSJMYDkKguPb6Y5CAJZ9F+jlwNPN90FmqgTeDlriqSj/p1ZPPwOzOBOwBtANn2mQkgA3YTH0bUVHeGig43kIPQHUiAJ3Alom254gMJonKzJMv//9seGWb800Ka8malR2cPXgGafxQAYxOp+pQYPJS2ZuIRExoEy4DazCXgf4OFm4PYSyEPTE28QEpA2GcOiy0cdtki7aHeDkv3B6iycOaL9ze61Q77Uz7l1//TV9oviIzv/jY5gZLJ2/9/rar5ya99VDqBU/ov7LoNH1ZBnePGG+cbBSch2rpklol91SZj6Xg7NgKwfjFVvDHX+Z3DHIcptGssT1wjbsKu/7LJ9wj7a4T7vYyv7CCDoWikX6r+E6uZef3nQa/qub1vvrQm7w49+kTDTFNWn9zdTxrGAr/5NVv0XWD1WsxlDM72LURLVLa1x0bo2Qn4Nw+rk77JVB5tTxrHumFleo0S84pyHq27VEw4ji/lVcb3qN7vOn6KhvQ3efBay3gdWPX+sfGU2xharnPyhIr930ztYec5CehIhv2It6rAZHO5FDjxb6NrSVV3g80YNmVayGma8j3uDVK9bll/fpJQyydM9NS5zXbfqPMI3/Sp7xFJfmKpvlsvKVBF7GcXk/VR0Rs0UErsiZqw0YJBi/mk+acluJieTsboped2ubf3yjdWdVXdySo1/aTyoYausBBp07jrLJBEoibS/WND5/e6X+0/rL9w3mFWRkP+8hq4HXOvB2zE0hPsI98exGuffzbhL5eSDwM8Y6KN9eyNR5lPYsEvz+Bps70o2zVcBRCGBq1EH8ULU9TxyUc8hNMjfm05hZI8x4DAJMOOxaELSa6KZ4PNoEaVPRCuWtdHaFvujjUzoaGsuDu0sKoiONYqKTuxpZ3TK6kx0wZYqoosy/Y0umWs4+tnHoLAoLoiJEqIUIFnPpJpsEaWpEk1mzl412S32ySiH9XSUJ+oIAvu1ILLfZErCTrpwsqZ/575o65joqauqGdhy5aLmbklOQDepVm7JkKlszb4AH25r0EmqixpmszajvaT0oar6K3meUp0rB99gMwLN7DmztGLqTXeiI1u2NbflI7isgRda6plL5y6q2V4puGQePy11xq2zCRiUJjW1xlexWxO32OQtl4o5mH1jttcnb1kpzFK5OLl50ZuO2gmZz4zGXuEQltwtgjGn26Y0aP2UErRVMjVNpUAlS37TpGy0bm+05Xy1s2TO0cLt2NJBBe+khFrKKGqY9qRHml7dNM5xxIg2wO616dGlGOo2XK6C45ccHG5NUGsmewb7wRAMZ16tJzG6vlC1BL1IDfutl/QwwIwy0T7F0hLZ85YvfAGWQKB8AAAA) format('woff2');
+}
+
+</style>
+<style>
+/* BTP DS v2.0 — 2026-07 · FUENTE ÚNICA DE TOKENS
+   «Beyond the Protocol» — editorial nocturno.
+   Decisiones de dirección de arte: Fable (auditoría 7-jul-2026).
+
+   REGLA DE ORO: no se añade NI UN HEX nuevo. Los 5 colores + 2 derivados
+   oficiales son los únicos átomos; todo estado/velo/trazo se deriva con
+   color-mix(). Si "hace falta" un color, la respuesta es no. */
+
+:root {
+  /* ── Paleta: 5 colores (disciplina máxima) ───────────────────── */
+  --color-bg:        #faf6f0; /* Crema — fondo claro siempre (nunca blanco) */
+  --color-bg-card:   #f5efe6; /* Crema profunda — superficies elevadas */
+  --color-text:      #2d1b3d; /* Berenjena — texto/trazo/fondo oscuro (nunca negro) */
+  --color-text-soft: #3a3340; /* Tinta — texto secundario */
+  --color-miriam:    #9d44ab; /* Violeta FIRMA (AA sobre crema) — COL-1 definitivo */
+  --color-miriam-soft:#e8d4ed;/* Violeta soft — fondo de badges */
+  --color-cta:       #ff6b47; /* Coral — SOLO acción (nunca porta significado sobre crema) */
+  --color-cta-hover: #e5573a;
+
+  /* ── Derivados oficiales (los 2 únicos "extra" permitidos) ───── */
+  --color-miriam-claro: #c77dd2; /* Violeta sobre fondo oscuro (berenjena); NUNCA sobre crema */
+  --cielo-resplandor:   #3a2450; /* SOLO fondos de "cielo" (universo constelación) */
+
+  /* ── Aliases semánticos de identidad/acción (usa estos) ──────── */
+  --color-link:     var(--color-miriam);
+  --color-emphasis: var(--color-miriam);
+  --color-action:   var(--color-cta);
+
+  /* ── Estados derivados (color-mix, sin hexes nuevos) — COL-5 ─── */
+  --cta-active:        color-mix(in srgb, var(--color-cta) 85%, var(--color-text));
+  --miriam-hover:      color-mix(in srgb, var(--color-miriam) 88%, var(--color-text));
+  --miriam-active:     color-mix(in srgb, var(--color-miriam) 78%, var(--color-text));
+  --secundario-hover:  color-mix(in srgb, var(--color-text) 6%, transparent);
+  --seleccionado-bg:   var(--color-miriam-soft);
+  --seleccionado-text: var(--color-text);
+
+  /* ── Velos (backdrops / cielos) ──────────────────────────────── */
+  --velo-berenjena-60: color-mix(in srgb, var(--color-text) 60%, transparent); /* backdrop de dialog */
+  --velo-berenjena-12: color-mix(in srgb, var(--color-text) 12%, transparent);
+
+  /* ── Sombra: sistema plano. UNA sombra, solo capas flotantes (LAY-3) */
+  --sombra-flotante: 0 8px 24px color-mix(in srgb, var(--color-text) 14%, transparent);
+
+  /* ── Tipografía ──────────────────────────────────────────────── */
+  --font-display: 'Fraunces', Georgia, serif;      /* italic = gesto de firma (eyebrow) */
+  --font-body:    'Hanken Grotesk', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono:    'JetBrains Mono', ui-monospace, monospace; /* SOLO datos tabulares */
+
+  /* Escala modular (base 17, ratio ~1.25) — TYP-2 */
+  --texto-xs:   13px;
+  --texto-sm:   15px;
+  --texto-base: 17px;
+  --texto-lg:   clamp(19px, 1.6vw, 21px);
+  --texto-xl:   clamp(22px, 2.2vw, 26px);
+  --texto-2xl:  clamp(26px, 3vw, 34px);   /* h2 canónico */
+  --texto-3xl:  clamp(32px, 4.2vw, 44px); /* h1 / hero */
+
+  /* ── Espaciado: escala base-4 con el 12 legitimado — LAY-2 ───── */
+  --sp-4:  4px;
+  --sp-8:  8px;
+  --sp-12: 12px;
+  --sp-16: 16px;
+  --sp-24: 24px;
+  --sp-32: 32px;
+  --sp-48: 48px;
+  --sp-64: 64px;
+  --sp-96: 96px;
+
+  /* ── Radios ──────────────────────────────────────────────────── */
+  --radius-sm:   6px;
+  --radius-md:   8px;
+  --radius-btn:  12px;
+  --radius-card: 16px;
+  --radius-pill: 9999px;
+
+  /* ── Breakpoints canónicos (doc; en @media van en literal) — LAY-1 */
+  --bp-sm: 480px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+
+  /* ── Movimiento — CRAFT-4 ────────────────────────────────────── */
+  --dur-micro:      150ms;  /* hovers, focos */
+  --dur-transicion: 300ms;  /* entradas, toasts, dialog */
+  --dur-ambiente:   5s;     /* parpadeo/respiración de estrellas */
+  --curva-salida:   cubic-bezier(0.22, 1, 0.36, 1);
+  --curva-entrada:  cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* ── Lectura ─────────────────────────────────────────────────── */
+  --measure: 65ch;
+
+  /* ── Tipografía compuesta (los componentes usan ESTOS) — TYP-3 ──
+     Atajo `font:` (familia+peso+tamaño+interlineado) por rol, para que
+     ninguna superficie declare fuentes a mano. El tracking va aparte
+     (no cabe en el shorthand `font`). */
+  --tipo-eyebrow: italic 600 var(--texto-sm)/1.3 var(--font-display);
+  --tipo-h1:      600 var(--texto-3xl)/1.08 var(--font-display);
+  --tipo-h2:      700 var(--texto-2xl)/1.15 var(--font-display);
+  --tipo-h3:      600 var(--texto-xl)/1.2  var(--font-display);
+  --tipo-body:    400 var(--texto-base)/1.6 var(--font-body);
+  --tipo-body-sm: 400 var(--texto-sm)/1.5  var(--font-body);
+  --tipo-dato:    500 var(--texto-base)/1.4 var(--font-mono);   /* SOLO tabular */
+  --tipo-cifra:   700 var(--texto-3xl)/1    var(--font-display); /* «Cifra Fraunces» */
+  --track-eyebrow: 0.08em;  /* versalitas espaciadas: único recurso «de sistema» */
+  --track-cifra:  -0.02em;  /* display grande: tracking negativo */
+
+  /* ── Data-viz clínica («pata 2») — DERIVADA, cero hex nuevos — VIZ ─────────
+     El color NUNCA es la única señal: icono + etiqueta + forma también. En
+     público, SOLO datos sintéticos (muro). CVD-safe: la rampa diverging va de
+     berenjena (frío) → crema (neutro) → coral (cálido), sin rojo/verde. */
+  --viz-eje:     var(--trazo-fuerte);
+  --viz-rejilla: var(--trazo-sutil);
+  --viz-tooltip-bg:   var(--color-text);
+  --viz-tooltip-text: var(--color-bg);
+  /* Diverging PuOr (7 pasos, berenjena ↔ neutro ↔ coral) */
+  --viz-div-1:   var(--color-text);
+  --viz-div-2:   color-mix(in srgb, var(--color-text) 55%, var(--color-bg));
+  --viz-div-3:   color-mix(in srgb, var(--color-text) 22%, var(--color-bg));
+  --viz-div-mid: var(--color-bg-card);
+  --viz-div-5:   color-mix(in srgb, var(--color-cta) 32%, var(--color-bg));
+  --viz-div-6:   color-mix(in srgb, var(--color-cta) 62%, var(--color-bg));
+  --viz-div-7:   var(--color-cta);
+  /* Severidad (secuencial, mono-hue sobre identidad) */
+  --viz-sev-1: color-mix(in srgb, var(--color-miriam) 16%, var(--color-bg));
+  --viz-sev-2: color-mix(in srgb, var(--color-miriam) 38%, var(--color-bg));
+  --viz-sev-3: color-mix(in srgb, var(--color-miriam) 60%, var(--color-bg));
+  --viz-sev-4: color-mix(in srgb, var(--color-miriam) 82%, var(--color-bg));
+  --viz-sev-5: var(--color-miriam);
+
+  /* ══ ROLES SEMÁNTICOS POR TEMA (los componentes usan ESTOS) ════
+     El componente no sabe en qué fondo vive: pinta con roles y el tema
+     los remapea. Modo oscuro = editorial y MANUAL (data-tema), nunca
+     prefers-color-scheme. — CMP-4 / A11Y-2 */
+  --fondo:        var(--color-bg);
+  --superficie:   var(--color-bg-card);
+  --texto-1:      var(--color-text);       /* texto principal */
+  --texto-2:      var(--color-text-soft);  /* texto secundario */
+  --texto-3:      color-mix(in srgb, var(--color-text-soft) 72%, var(--color-bg)); /* terciario / mute — 72% = 4.9:1 AA verificado (62% daba 3.7, fallaba) */
+  --identidad:    var(--color-miriam);     /* violeta que porta identidad sobre este fondo */
+  --anillo-foco:  var(--color-miriam);
+  /* Color con el que se ESCRIBE la acción en esta superficie.
+     Sobre crema NO puede ser coral (Consolidado D6: «coral nunca sobre crema»;
+     2.62:1 no llega ni al 3:1 de elemento gráfico) → berenjena.
+     Sobre berenjena sí es coral (ver bloque [data-tema="oscuro"]).
+     Retirado el coral-oscurecido derivado: inventaba un patrón que el canon prohíbe. */
+  --cta-texto:    var(--color-text);
+  --trazo-sutil:  color-mix(in srgb, var(--color-text) 8%,  transparent);
+  --trazo-medio:  color-mix(in srgb, var(--color-text) 12%, transparent);
+  --trazo-fuerte: color-mix(in srgb, var(--color-text) 20%, transparent);
+  --trazo-interactivo: color-mix(in srgb, var(--color-text) 55%, transparent);  /* borde de controles ≥3:1 sobre crema (3.59) — MCP/Ceci */
+}
+
+/* ── Tema oscuro: sección editorial sobre berenjena ─────────────── */
+[data-tema="oscuro"] {
+  --fondo:        var(--color-text);       /* berenjena */
+  --superficie:   color-mix(in srgb, var(--color-text) 88%, var(--color-bg));
+  --texto-1:      var(--color-bg);         /* crema */
+  --texto-2:      color-mix(in srgb, var(--color-bg) 78%, transparent);
+  --texto-3:      color-mix(in srgb, var(--color-bg) 58%, transparent);
+  --identidad:    var(--color-miriam-claro);
+  --anillo-foco:  var(--color-miriam-claro);
+  --cta-texto:    var(--color-cta);        /* coral pleno ≈5.6:1 sobre berenjena — AA */
+  --trazo-sutil:  color-mix(in srgb, var(--color-bg) 10%, transparent);
+  --trazo-medio:  color-mix(in srgb, var(--color-bg) 16%, transparent);
+  --trazo-fuerte: color-mix(in srgb, var(--color-bg) 26%, transparent);
+  --trazo-interactivo: color-mix(in srgb, var(--color-bg) 40%, transparent);  /* borde de controles ≥3:1 sobre berenjena (3.51) — MCP/Ceci */
+}
+
+/* ── Reduced motion: a11y, no opción — CRAFT-4 / A11Y ──────────── */
+@media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
-    <span class="c-key">animation-duration</span>: <span class="c-val">0.01ms</span> <span class="c-com">!important</span>;
-    <span class="c-key">animation-iteration-count</span>: <span class="c-val">1</span> <span class="c-com">!important</span>;
-    <span class="c-key">transition-duration</span>: <span class="c-val">0.01ms</span> <span class="c-com">!important</span>;
-    <span class="c-key">scroll-behavior</span>: <span class="c-val">auto</span> <span class="c-com">!important</span>;
+    animation-duration: 0.001ms !important;
+    animation-delay: 0s !important;          /* si no, con `backwards` el elemento falta y aparece de golpe */
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
   }
-}</pre>
-
-          <h3 style="margin-top: 40px">
-            Checklist de revisión — antes de publicar
-          </h3>
-          <div class="grid-2" style="display: grid; gap: 12px; max-width: 72ch">
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Tab navigation completa
-              </div>
-              <p style="font-size: 13px">
-                Todo el contenido alcanzable solo con teclado. Sin trampas de
-                foco.
-              </p>
-            </div>
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">Lighthouse / axe</div>
-              <p style="font-size: 13px">
-                Accessibility ≥ 95. Cero violaciones críticas.
-              </p>
-            </div>
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Lectura con NVDA/VoiceOver
-              </div>
-              <p style="font-size: 13px">
-                El orden lógico de lectura tiene sentido. Sin secciones
-                huérfanas.
-              </p>
-            </div>
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">Zoom 200%</div>
-              <p style="font-size: 13px">
-                Sin scroll horizontal. Sin contenido cortado.
-              </p>
-            </div>
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">
-                Modo alto contraste
-              </div>
-              <p style="font-size: 13px">
-                Forced-colors mode no rompe la jerarquía.
-              </p>
-            </div>
-            <div class="rule do" style="padding: 14px 16px">
-              <div class="rule-h" style="font-size: 13px">Reduced motion</div>
-              <p style="font-size: 13px">
-                Activar el flag del SO. Cero animaciones residuales.
-              </p>
-            </div>
-          </div>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 24px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)">Regla de oro.</strong> Si
-            una decisión de diseño solo se sostiene cuando el usuario está al
-            100%, no sirve. Miriam se diseña para el peor día — no para el
-            mejor.
-          </p>
-        </section>
-
-        <!-- 14 REPOSITORIO -->
-        <section class="ds-section" id="repo">
-          <div class="eyebrow">14 · Producción</div>
-          <h2>Repositorio.</h2>
-          <p class="lede">
-            Todo el caso vive en un único repositorio público. Esta guía de
-            estilo, la web, los mocks, los textos del informe AP, los retratos
-            del equipo, los prompts de IA. Si trabajas en el caso — diseño,
-            copy, código, traducción — empiezas clonando esto. Si quieres
-            entender cómo está hecho, leyendo esto. Si quieres aportar, abriendo
-            un issue o un PR aquí.
-          </p>
-
-          <div
-            style="
-              display: grid;
-              grid-template-columns: 1fr;
-              gap: 16px;
-              margin-top: 32px;
-              max-width: 76ch;
-            "
-          >
-            <a
-              href="https://github.com/ceciCoding/miriam-gonzalez-case"
-              target="_blank"
-              rel="noopener"
-              style="
-                display: flex;
-                align-items: center;
-                gap: 16px;
-                padding: 20px 24px;
-                background: var(--color-text);
-                color: var(--color-bg);
-                border-radius: 10px;
-                text-decoration: none;
-                transition: transform 120ms ease;
-              "
-              onmouseover="this.style.transform = 'translateY(-1px)'"
-              onmouseout="this.style.transform = 'translateY(0)'"
-            >
-              <svg
-                width="32"
-                height="32"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
-                style="flex-shrink: 0"
-              >
-                <path
-                  d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.4 3-.405 1.02.005 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-                />
-              </svg>
-              <div style="flex: 1; min-width: 0">
-                <div
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 12px;
-                    letter-spacing: 0.06em;
-                    opacity: 0.6;
-                    text-transform: uppercase;
-                  "
-                >
-                  github · público
-                </div>
-                <div
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 16px;
-                    font-weight: 500;
-                    margin-top: 2px;
-                  "
-                >
-                  ceciCoding/miriam-gonzalez-case
-                </div>
-              </div>
-              <div style="font-size: 13px; opacity: 0.7">Abrir →</div>
-            </a>
-          </div>
-
-          <h3 style="margin-top: 48px">Qué hay dentro</h3>
-          <div
-            style="
-              display: grid;
-              grid-template-columns: max-content 1fr;
-              gap: 4px 32px;
-              max-width: 76ch;
-              font-family: var(--font-mono);
-              font-size: 13.5px;
-              line-height: 2;
-              align-items: baseline;
-            "
-          >
-            <span style="color: var(--color-text)">/web</span>
-            <span
-              style="
-                font-family: var(--font-body);
-                color: var(--color-text-soft);
-              "
-              >— sitio público (Astro). Donde el lector llega.</span
-            >
-            <span style="color: var(--color-text)">/design-system</span>
-            <span
-              style="
-                font-family: var(--font-body);
-                color: var(--color-text-soft);
-              "
-              >— este documento. Fuente única de verdad para voz, color,
-              tipografía y reglas.</span
-            >
-            <span style="color: var(--color-text)">/clinical</span>
-            <span
-              style="
-                font-family: var(--font-body);
-                color: var(--color-text-soft);
-              "
-              >— informe AP, perfil molecular, traducciones legibles. Lo que
-              cita la web.</span
-            >
-            <span style="color: var(--color-text)">/illustrations</span>
-            <span
-              style="
-                font-family: var(--font-body);
-                color: var(--color-text-soft);
-              "
-              >— set "Beyond the Protocol": iconos, retratos del equipo,
-              openers. PNG + originales.</span
-            >
-            <span style="color: var(--color-text)">/prompts</span>
-            <span
-              style="
-                font-family: var(--font-body);
-                color: var(--color-text-soft);
-              "
-              >— plantillas A–F en versión <code>.md</code> lista para
-              pegar.</span
-            >
-            <span style="color: var(--color-text)">/social</span>
-            <span
-              style="
-                font-family: var(--font-body);
-                color: var(--color-text-soft);
-              "
-              >— recursos para Instagram, prensa, dossier para
-              colaboradores.</span
-            >
-          </div>
-
-          <h3 style="margin-top: 48px">Cómo trabajamos</h3>
-          <ol
-            style="
-              font-size: 15px;
-              line-height: 1.8;
-              max-width: 64ch;
-              padding-left: 20px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              <strong>main</strong> es siempre la versión publicada. Nada se
-              mergea sin revisión.
-            </li>
-            <li>
-              Cualquier cambio — texto, mock, ilustración — entra por
-              <strong>pull request</strong>. Aunque seas familia. Aunque sea una
-              coma. Da trazabilidad.
-            </li>
-            <li>
-              Si dudas si un cambio se sale del sistema — abre un
-              <strong>issue</strong> antes de empezar. Mejor discutir 5 minutos
-              que rehacer 3 horas.
-            </li>
-            <li>
-              Los <strong>textos clínicos</strong> los firma siempre la revisora
-              clínica del equipo antes de publicarse. Sin excepción.
-            </li>
-            <li>
-              Los textos en primera persona los firma siempre
-              <strong>Miriam</strong>. Si Miriam no puede revisarlos ese día,
-              esperan.
-            </li>
-          </ol>
-
-          <h3 style="margin-top: 48px">Para colaboradores nuevos</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-              margin-bottom: 16px;
-            "
-          >
-            Tres pasos antes de tocar nada:
-          </p>
-          <ol
-            style="
-              font-size: 15px;
-              line-height: 1.8;
-              max-width: 64ch;
-              padding-left: 20px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              Lee secciones <strong>00 → 11</strong> de este documento. En
-              orden. Tarda 25 minutos.
-            </li>
-            <li>
-              Lee la sección <strong>12 (Hablar con IAs)</strong> aunque no
-              vayas a usar IA — describe los antipatrones que también aparecen
-              escribiendo a mano.
-            </li>
-            <li>
-              Mira el set BTP (sección 09) hasta poder reconocer el estilo a
-              primera vista. Si propones una imagen nueva y no encaja con el
-              set, alguien lo notará — mejor que lo notes tú primero.
-            </li>
-          </ol>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 32px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)"
-              >Una nota sobre el repo público.</strong
-            >
-            El historial clínico privado no entra aquí — solo lo que ya es
-            público en la web. Datos médicos identificables, conversaciones con
-            el equipo médico, informes sin redactar: en almacenamiento privado
-            aparte. Si dudas si algo puede subirse — no lo subas y pregunta.
-          </p>
-        </section>
-
-        <!-- 15 MARCA & DOMINIO -->
-        <section class="ds-section" id="brand">
-          <div class="eyebrow">15 · Recursos</div>
-          <h2>Marca &amp; dominio.</h2>
-          <p class="lede">
-            Tres capas, tres usos. <strong>Miriam</strong> es el nombre del
-            proyecto y del sistema. <strong>helpmiriam.com</strong> es el
-            dominio funcional — el destino de cualquier CTA.
-            <strong>Beyond the Protocol</strong> es la marca paraguas que firma
-            todo. Si las separas bien, no se pisan.
-          </p>
-
-          <div
-            class="grid-3"
-            style="display: grid; gap: 16px; margin-top: 32px"
-          >
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                "
-              >
-                Marca / proyecto
-              </div>
-              <h3
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 32px;
-                  margin: 8px 0 12px;
-                  color: #2d1b3d;
-                "
-              >
-                Miriam<span style="color: #a44db2">.</span>
-              </h3>
-              <p
-                style="
-                  font-size: 13px;
-                  color: var(--color-text);
-                  line-height: 1.55;
-                  margin: 0;
-                "
-              >
-                Cómo se firma, se cita, se nombra en español. Aparece en
-                cabeceras, pies de email, prensa, créditos.
-              </p>
-            </div>
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                "
-              >
-                Dominio / CTA
-              </div>
-              <h3
-                style="
-                  font-family: var(--font-mono);
-                  font-weight: 500;
-                  font-size: 22px;
-                  margin: 8px 0 12px;
-                  color: #2d1b3d;
-                "
-              >
-                helpmiriam.com
-              </h3>
-              <p
-                style="
-                  font-size: 13px;
-                  color: var(--color-text);
-                  line-height: 1.55;
-                  margin: 0;
-                "
-              >
-                URL utilitaria. Aparece como destino de botones ("Donar →"), en
-                pie de RRSS, en QR de prensa. <strong>Nunca</strong> como nombre
-                del proyecto.
-              </p>
-            </div>
-            <div
-              style="
-                background: #2d1b3d;
-                border-radius: 12px;
-                padding: 24px;
-                color: #faf6f0;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.08em;
-                  text-transform: uppercase;
-                  color: rgba(250, 246, 240, 0.55);
-                "
-              >
-                Marca paraguas
-              </div>
-              <h3
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 500;
-                  font-size: 22px;
-                  margin: 8px 0 12px;
-                  color: #faf6f0;
-                "
-              >
-                Beyond the Protocol
-              </h3>
-              <p
-                style="
-                  font-size: 13px;
-                  color: rgba(250, 246, 240, 0.85);
-                  line-height: 1.55;
-                  margin: 0;
-                "
-              >
-                Aparece en pie como "Sub-marca de Beyond the Protocol" + el
-                linaje del set BTP en iconografía. No en cabecera de la web.
-              </p>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 48px">Wordmark — cómo se escribe Miriam</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Una sola forma canónica. No hay logo gráfico — la firma es
-            tipográfica.
-          </p>
-          <div
-            style="
-              display: flex;
-              gap: 24px;
-              margin-top: 16px;
-              align-items: center;
-              padding: 40px 32px;
-              background: #faf6f0;
-              border: 1px solid rgba(45, 27, 61, 0.08);
-              border-radius: 12px;
-              flex-wrap: wrap;
-            "
-          >
-            <div
-              style="
-                font-family: var(--font-display);
-                font-weight: 500;
-                font-size: 64px;
-                color: #2d1b3d;
-                line-height: 1;
-              "
-            >
-              Miriam<span style="color: #a44db2">.</span>
-            </div>
-          </div>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.8;
-              max-width: 70ch;
-              padding-left: 20px;
-              margin-top: 16px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              <strong>Tipografía</strong>: Fraunces 500 (Display medium). Nunca
-              otra fuente.
-            </li>
-            <li>
-              <strong>Punto final violeta</strong>:
-              <code
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 12px;
-                  color: var(--color-text);
-                "
-                >.</code
-              >
-              en color firma
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >#A44DB2</code
-              >. Es el único elemento gráfico permitido.
-            </li>
-            <li>
-              <strong>Tamaño mínimo</strong>: 24 px. Por debajo el punto se
-              pierde.
-            </li>
-            <li>
-              <strong>Variante en oscuro</strong>: texto crema
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >#FAF6F0</code
-              >
-              + punto violeta-soft
-              <code
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 12px;
-                  color: #2d1b3d;
-                "
-                >#E8D4ED</code
-              >
-              (no firma — pierde contraste).
-            </li>
-            <li>
-              <strong>No</strong>: outline, mayúsculas, expansión letterspacing,
-              italic, color en la palabra.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 48px">Cómo se cita en cada superficie</h3>
-          <div style="overflow-x: auto">
-            <table
-              style="
-                width: 100%;
-                max-width: 80ch;
-                border-collapse: collapse;
-                font-size: 13.5px;
-              "
-            >
-              <thead>
-                <tr style="border-bottom: 2px solid #2d1b3d">
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Superficie
-                  </th>
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Forma
-                  </th>
-                  <th
-                    style="
-                      text-align: left;
-                      padding: 10px 12px;
-                      font-family: var(--font-mono);
-                      font-size: 11px;
-                      letter-spacing: 0.06em;
-                      text-transform: uppercase;
-                      color: var(--color-text-soft);
-                    "
-                  >
-                    Ejemplo
-                  </th>
-                </tr>
-              </thead>
-              <tbody style="color: var(--color-text)">
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">Cabecera web</td>
-                  <td style="padding: 12px">Wordmark</td>
-                  <td style="padding: 12px; font-family: var(--font-display)">
-                    Miriam<span style="color: #a44db2">.</span>
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">Pie / footer</td>
-                  <td style="padding: 12px">Texto + URL</td>
-                  <td style="padding: 12px">Miriam · helpmiriam.com</td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">Prensa / cita</td>
-                  <td style="padding: 12px">Nombre completo</td>
-                  <td style="padding: 12px">
-                    <em
-                      >"Miriam González, paciente con cáncer de mama
-                      refractario, ha lanzado…"</em
-                    >
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">RRSS handle</td>
-                  <td style="padding: 12px">Personal</td>
-                  <td style="padding: 12px; font-family: var(--font-mono)">
-                    @miriamgonp
-                  </td>
-                </tr>
-                <tr style="border-bottom: 1px solid rgba(45, 27, 61, 0.08)">
-                  <td style="padding: 12px">Email firma</td>
-                  <td style="padding: 12px">Texto + URL</td>
-                  <td style="padding: 12px">
-                    Miriam · helpmiriam.com<br /><span
-                      style="font-size: 12px; color: var(--color-text-soft)"
-                      >Sub-marca de Beyond the Protocol</span
-                    >
-                  </td>
-                </tr>
-                <tr>
-                  <td style="padding: 12px">CTA / botón</td>
-                  <td style="padding: 12px">Acción + URL</td>
-                  <td style="padding: 12px">"Donar →" → helpmiriam.com</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 32px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)">Regla.</strong> Si dudas
-            si algo es marca o dominio, pregúntate:
-            <em>¿se hace clic aquí?</em> Si sí, es
-            <code style="font-family: var(--font-mono); font-size: 12px"
-              >helpmiriam.com</code
-            >. Si no, es <strong>Miriam</strong>.
-          </p>
-        </section>
-
-        <!-- 16 FOTOGRAFÍA -->
-        <section class="ds-section" id="photo">
-          <div class="eyebrow">16 · Recursos</div>
-          <h2>Fotografía.</h2>
-          <p class="lede">
-            La ilustración (BTP) construye el tono editorial. La foto construye
-            la realidad. Convive sin pisarse si sigues estas reglas — y se rompe
-            rápido si las olvidas. Nunca foto sintética / generada por IA: el
-            caso vive de su veracidad.
-          </p>
-
-          <h3 style="margin-top: 32px">Qué tipo de foto entra y qué no</h3>
-          <div
-            class="grid-2"
-            style="display: grid; gap: 16px; margin-top: 16px"
-          >
-            <div class="rule do" style="padding: 16px">
-              <div class="rule-h">Sí — qué buscamos</div>
-              <ul
-                style="
-                  margin: 8px 0 0;
-                  padding-left: 18px;
-                  font-size: 13.5px;
-                  line-height: 1.7;
-                  color: var(--color-text);
-                "
-              >
-                <li>Luz natural diurna, ventana lateral. Sombras suaves.</li>
-                <li>
-                  Retratos honestos: mirada directa, ½ sonrisa o expresión
-                  neutra. Sin pose forzada.
-                </li>
-                <li>
-                  Escenas reales: Miriam en su casa, en consulta, con su
-                  familia. Con consentimiento explícito.
-                </li>
-                <li>
-                  Tonos cálidos: cremas, beige, madera, verdes desaturados.
-                  Encaja con la paleta del sistema.
-                </li>
-                <li>
-                  Encuadre amplio o medio, manos visibles cuando aporten
-                  (apuntar a un informe, sostener una taza).
-                </li>
-                <li>
-                  Imperfecciones: una camiseta arrugada, pelo recién levantado,
-                  papeles del médico encima de la mesa. La realidad es el
-                  activo.
-                </li>
-              </ul>
-            </div>
-            <div class="rule dont" style="padding: 16px">
-              <div class="rule-h">No — qué descartamos</div>
-              <ul
-                style="
-                  margin: 8px 0 0;
-                  padding-left: 18px;
-                  font-size: 13.5px;
-                  line-height: 1.7;
-                  color: var(--color-text);
-                "
-              >
-                <li>
-                  Foto stock — gente sonriendo a cámara con bata blanca de
-                  catálogo.
-                </li>
-                <li>
-                  Filtros Instagram, presets cinematográficos saturados,
-                  viñeteados marcados.
-                </li>
-                <li>
-                  Blanco y negro de duelo — hace que el caso parezca un
-                  obituario.
-                </li>
-                <li>
-                  Foto sintética / IA generativa. Cero excepciones. La paciente
-                  es real.
-                </li>
-                <li>
-                  Logos de hospital identificables sin permiso firmado por la
-                  institución.
-                </li>
-                <li>Caras de menores sin consentimiento expreso de tutores.</li>
-                <li>
-                  Manos sostiendo lazos rosa, manos formando corazón, "warrior
-                  poses". Slop oncológico fotográfico.
-                </li>
-                <li>
-                  Selfies en cama de hospital. Reservar para Miriam si ella las
-                  quiere publicar — nunca usar en sec. periodísticas.
-                </li>
-              </ul>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Tratamiento</h3>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.8;
-              max-width: 70ch;
-              padding-left: 20px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              <strong>Color</strong>: corregido para temperatura cálida
-              (~5200K). Saturación normal — nunca subida. Negros no aplastados.
-            </li>
-            <li>
-              <strong>Crop</strong>: 4:5 vertical para retratos individuales,
-              3:2 horizontal para escena, 1:1 para grids RRSS. Mantener crops
-              consistentes dentro de una misma página.
-            </li>
-            <li>
-              <strong>Borde</strong>:
-              <code style="font-family: var(--font-mono); font-size: 12px"
-                >border-radius: 12px</code
-              >
-              en web (igual que cards). En prensa / impreso, sin radio.
-            </li>
-            <li>
-              <strong>Sin texto encima</strong>: los retratos respiran solos. Si
-              necesitas titular junto a foto, déjalo en una columna adyacente,
-              no superpuesto.
-            </li>
-            <li>
-              <strong>Crédito</strong>: pie pequeño (12 px, mono, 60% opacidad)
-              con el fotógrafo y la fecha. Excepción: fotos personales sin
-              autoría profesional → "Familia González · 2026".
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Foto + ilustración convivencia</h3>
-          <p style="font-size: 14px; color: var(--color-text); max-width: 70ch">
-            Foto y BTP nunca se mezclan en la <em>misma pieza</em>. Foto manda
-            en hero, retratos del equipo, eventos. Ilustración manda en iconos,
-            openers de sección, badges. La regla: si en una sección aparece
-            foto, los iconos de esa sección son tipográficos o invisibles — no
-            compiten.
-          </p>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 24px;
-              padding: 14px 16px;
-              background: rgba(255, 107, 71, 0.06);
-              border-left: 2px solid var(--color-cta);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: #2d1b3d">Test rápido.</strong> Pon la
-            foto en blanco y negro mentalmente: ¿sigue funcionando la
-            composición? Si la foto solo se sostiene gracias al color saturado o
-            al filtro, no es del sistema.
-          </p>
-
-          <h3 style="margin-top: 40px">Tratamientos del sistema (CSS) · ejemplo</h3>
-          <p style="font-size: 14px; color: var(--color-text); max-width: 70ch">
-            En código cada foto lleva la clase <code>.pic</code> + un modificador.
-            <strong>Un solo tratamiento por pieza.</strong> Las fotos viven en el CDN
-            (GoFundMe); el filtro son 5 líneas de CSS, no archivos duplicados. El
-            filtro SVG del duotono vive global en <code>app.vue</code>.
-          </p>
-          <svg width="0" height="0" style="position: absolute" aria-hidden="true"><defs><filter id="duotone-berenjena"><feColorMatrix type="matrix" values="0.299 0.587 0.114 0 0  0.299 0.587 0.114 0 0  0.299 0.587 0.114 0 0  0 0 0 1 0"/><feComponentTransfer><feFuncR tableValues="0.176 0.980"/><feFuncG tableValues="0.106 0.965"/><feFuncB tableValues="0.239 0.941"/></feComponentTransfer></filter></defs></svg>
-          <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-top: 16px">
-            <figure style="margin: 0">
-              <div style="aspect-ratio: 1; border-radius: 10px; overflow: hidden; background: rgba(45,27,61,.06)"><img alt="ejemplo firma" loading="lazy" src="https://d2g8igdw686xgo.cloudfront.net/102249769_177578535795770_r.png" style="width:100%;height:100%;object-fit:cover;filter:sepia(.12) saturate(.82) contrast(1.06) brightness(1.02) hue-rotate(-4deg)"></div>
-              <figcaption style="font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-soft); margin-top: 6px">.pic · firma</figcaption>
-            </figure>
-            <figure style="margin: 0">
-              <div style="aspect-ratio: 1; border-radius: 10px; overflow: hidden; background: rgba(45,27,61,.06)"><img alt="ejemplo subtle" loading="lazy" src="https://d2g8igdw686xgo.cloudfront.net/102249769_177578535795770_r.png" style="width:100%;height:100%;object-fit:cover;filter:sepia(.06) saturate(.92) contrast(1.03) brightness(1.01)"></div>
-              <figcaption style="font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-soft); margin-top: 6px">.subtle · press</figcaption>
-            </figure>
-            <figure style="margin: 0">
-              <div style="aspect-ratio: 1; border-radius: 10px; overflow: hidden; background: rgba(45,27,61,.06)"><img alt="ejemplo cool" loading="lazy" src="https://d2g8igdw686xgo.cloudfront.net/102249769_177578535795770_r.png" style="width:100%;height:100%;object-fit:cover;filter:saturate(.78) contrast(1.05) brightness(1.02) hue-rotate(8deg)"></div>
-              <figcaption style="font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-soft); margin-top: 6px">.cool · clínico</figcaption>
-            </figure>
-            <figure style="margin: 0">
-              <div style="aspect-ratio: 1; border-radius: 10px; overflow: hidden; background: rgba(45,27,61,.06)"><img alt="ejemplo bn" loading="lazy" src="https://d2g8igdw686xgo.cloudfront.net/102249769_177578535795770_r.png" style="width:100%;height:100%;object-fit:cover;filter:grayscale(1) contrast(1.08) brightness(1.02) sepia(.08)"></div>
-              <figcaption style="font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-soft); margin-top: 6px">.bw · B/N cálido</figcaption>
-            </figure>
-            <figure style="margin: 0">
-              <div style="aspect-ratio: 1; border-radius: 10px; overflow: hidden; background: rgba(45,27,61,.06)"><img alt="ejemplo duotono" loading="lazy" src="https://d2g8igdw686xgo.cloudfront.net/102249769_177578535795770_r.png" style="width:100%;height:100%;object-fit:cover;filter:contrast(1.1) brightness(1.05) url(#duotone-berenjena)"></div>
-              <figcaption style="font-family: var(--font-mono); font-size: 10.5px; color: var(--color-text-soft); margin-top: 6px">.duotone · editorial</figcaption>
-            </figure>
-          </div>
-          <p style="font-family: var(--font-mono); font-size: 12px; line-height: 1.9; color: var(--color-text); background: var(--color-bg-card, #f5efe6); border-radius: 10px; padding: 16px 18px; margin-top: 16px">
-            .pic <span style="color: var(--color-text-soft)">→ firma (default)</span><br>
-            .pic.subtle · .pic.cool · .pic.bw · .pic.duotone <span style="color: var(--color-text-soft)">→ un modificador por pieza</span>
-          </p>
-        </section>
-
-        <!-- 17 ESTADOS DE UI -->
-        <section class="ds-section" id="states">
-          <div class="eyebrow">17 · Recursos</div>
-          <h2>Estados de UI.</h2>
-          <p class="lede">
-            Lo que ve el usuario cuando algo pasa: un input con error, una
-            donación procesándose, una lista vacía. Cada estado tiene una
-            respuesta predefinida — para que ningún dev tenga que improvisar a
-            las 2am.
-          </p>
-
-          <h3 style="margin-top: 32px">Inputs — formulario de donación</h3>
-          <div
-            class="grid-2"
-            style="display: grid; gap: 16px; margin-top: 16px"
-          >
-            <!-- default -->
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.06em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                  margin-bottom: 8px;
-                "
-              >
-                Default
-              </div>
-              <label
-                for="input-default"
-                style="
-                  display: block;
-                  font-size: 13px;
-                  font-weight: 600;
-                  color: #2d1b3d;
-                  margin-bottom: 6px;
-                "
-                >Cantidad a donar</label
-              >
-              <div
-                style="
-                  display: flex;
-                  align-items: center;
-                  background: #fff;
-                  border: 1.5px solid rgba(45, 27, 61, 0.2);
-                  border-radius: 8px;
-                  padding: 10px 14px;
-                "
-              >
-                <span
-                  style="
-                    font-family: var(--font-mono);
-                    color: var(--color-text-soft);
-                    margin-right: 8px;
-                  "
-                  >€</span
-                >
-                <input
-                  id="input-default"
-                  type="text"
-                  value="50"
-                  style="
-                    flex: 1;
-                    border: none;
-                    outline: none;
-                    background: transparent;
-                    font-size: 16px;
-                    color: #2d1b3d;
-                  "
-                />
-              </div>
-              <div
-                style="
-                  font-size: 12px;
-                  color: var(--color-text-soft);
-                  margin-top: 6px;
-                "
-              >
-                Mínimo 5€. Sin máximo.
-              </div>
-            </div>
-
-            <!-- focus -->
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.06em;
-                  text-transform: uppercase;
-                  color: var(--color-text-soft);
-                  margin-bottom: 8px;
-                "
-              >
-                Focus
-              </div>
-              <label
-                for="input-focus"
-                style="
-                  display: block;
-                  font-size: 13px;
-                  font-weight: 600;
-                  color: #2d1b3d;
-                  margin-bottom: 6px;
-                "
-                >Cantidad a donar</label
-              >
-              <div
-                style="
-                  display: flex;
-                  align-items: center;
-                  background: #fff;
-                  border: 2px solid #ff6b47;
-                  outline: 3px solid rgba(255, 107, 71, 0.2);
-                  outline-offset: 0;
-                  border-radius: 8px;
-                  padding: 10px 14px;
-                "
-              >
-                <span
-                  style="
-                    font-family: var(--font-mono);
-                    color: #2d1b3d;
-                    margin-right: 8px;
-                  "
-                  >€</span
-                >
-                <input
-                  id="input-focus"
-                  type="text"
-                  value="50"
-                  style="
-                    flex: 1;
-                    border: none;
-                    outline: none;
-                    background: transparent;
-                    font-size: 16px;
-                    color: #2d1b3d;
-                  "
-                />
-              </div>
-              <div
-                style="
-                  font-size: 12px;
-                  color: var(--color-text-soft);
-                  margin-top: 6px;
-                "
-              >
-                Mínimo 5€. Sin máximo.
-              </div>
-            </div>
-
-            <!-- error -->
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.06em;
-                  text-transform: uppercase;
-                  color: #c2410c;
-                  margin-bottom: 8px;
-                "
-              >
-                Error
-              </div>
-              <label
-                for="input-error"
-                style="
-                  display: block;
-                  font-size: 13px;
-                  font-weight: 600;
-                  color: #2d1b3d;
-                  margin-bottom: 6px;
-                "
-                >Cantidad a donar</label
-              >
-              <div
-                style="
-                  display: flex;
-                  align-items: center;
-                  background: #fff;
-                  border: 2px solid #c2410c;
-                  border-radius: 8px;
-                  padding: 10px 14px;
-                "
-              >
-                <span
-                  style="
-                    font-family: var(--font-mono);
-                    color: #c2410c;
-                    margin-right: 8px;
-                  "
-                  >€</span
-                >
-                <input
-                  id="input-error"
-                  type="text"
-                  value="2"
-                  style="
-                    flex: 1;
-                    border: none;
-                    outline: none;
-                    background: transparent;
-                    font-size: 16px;
-                    color: #2d1b3d;
-                  "
-                />
-              </div>
-              <div
-                style="
-                  font-size: 12px;
-                  color: #c2410c;
-                  margin-top: 6px;
-                  display: flex;
-                  gap: 6px;
-                  align-items: start;
-                "
-              >
-                <span aria-hidden="true">⚠</span
-                ><span
-                  >El mínimo son 5€. La pasarela tiene comisión fija de 0,30€
-                  por debajo de eso.</span
-                >
-              </div>
-            </div>
-
-            <!-- success -->
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  letter-spacing: 0.06em;
-                  text-transform: uppercase;
-                  color: #1d8155;
-                  margin-bottom: 8px;
-                "
-              >
-                Success
-              </div>
-              <label
-                for="input-success"
-                style="
-                  display: block;
-                  font-size: 13px;
-                  font-weight: 600;
-                  color: #2d1b3d;
-                  margin-bottom: 6px;
-                "
-                >Cantidad a donar</label
-              >
-              <div
-                style="
-                  display: flex;
-                  align-items: center;
-                  background: #fff;
-                  border: 2px solid #1d8155;
-                  border-radius: 8px;
-                  padding: 10px 14px;
-                "
-              >
-                <span
-                  style="
-                    font-family: var(--font-mono);
-                    color: #1d8155;
-                    margin-right: 8px;
-                  "
-                  >€</span
-                >
-                <input
-                  id="input-success"
-                  type="text"
-                  value="50"
-                  style="
-                    flex: 1;
-                    border: none;
-                    outline: none;
-                    background: transparent;
-                    font-size: 16px;
-                    color: #2d1b3d;
-                  "
-                  disabled
-                />
-                <span
-                  style="color: #1d8155; margin-left: 8px"
-                  aria-hidden="true"
-                  >✓</span
-                >
-              </div>
-              <div style="font-size: 12px; color: #1d8155; margin-top: 6px">
-                Validado. Pasando a la pasarela…
-              </div>
-            </div>
-          </div>
-
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              margin-top: 16px;
-              max-width: 64ch;
-            "
-          >
-            Verde
-            <code
-              style="
-                font-family: var(--font-mono);
-                font-size: 12px;
-                color: #1d8155;
-              "
-              >#1D8155</code
-            >
-            y rojo error
-            <code
-              style="
-                font-family: var(--font-mono);
-                font-size: 12px;
-                color: #c2410c;
-              "
-              >#C2410C</code
-            >
-            son <strong>los únicos colores fuera de paleta permitidos</strong>,
-            y solo en estados de validación. Nunca en marketing, hero, copy
-            editorial. El sistema base sigue siendo de 5 colores.
-          </p>
-
-          <h3 style="margin-top: 40px">Loading — botón en proceso</h3>
-          <div
-            style="display: flex; gap: 12px; flex-wrap: wrap; margin-top: 16px"
-          >
-            <button
-              style="
-                background: #ff6b47;
-                color: #2d1b3d;
-                border: none;
-                padding: 12px 24px;
-                border-radius: 8px;
-                font-size: 14px;
-                font-weight: 600;
-                font-family: var(--font-body);
-              "
-            >
-              Donar 50€ →
-            </button>
-            <button
-              disabled
-              style="
-                background: #ff6b47;
-                color: #2d1b3d;
-                border: none;
-                padding: 12px 24px;
-                border-radius: 8px;
-                font-size: 14px;
-                font-weight: 600;
-                font-family: var(--font-body);
-                display: flex;
-                align-items: center;
-                gap: 10px;
-                cursor: wait;
-              "
-            >
-              <span
-                style="
-                  display: inline-block;
-                  width: 14px;
-                  height: 14px;
-                  border: 2px solid rgba(45, 27, 61, 0.25);
-                  border-top-color: #2d1b3d;
-                  border-radius: 50%;
-                  animation: ds-spin 700ms linear infinite;
-                "
-              ></span>
-              Procesando…
-            </button>
-            <button
-              disabled
-              style="
-                background: rgba(45, 27, 61, 0.15);
-                color: rgba(45, 27, 61, 0.5);
-                border: none;
-                padding: 12px 24px;
-                border-radius: 8px;
-                font-size: 14px;
-                font-weight: 600;
-                font-family: var(--font-body);
-                cursor: not-allowed;
-              "
-            >
-              Donar 50€ →
-            </button>
-          </div>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              max-width: 70ch;
-              padding-left: 20px;
-              margin-top: 16px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              <strong>Loading</strong>: spinner crema sobre coral, cursor wait,
-              copy "Procesando…" — nunca "Cargando" abstracto.
-            </li>
-            <li>
-              <strong>Disabled</strong>: berenjena al 15% sobre fondo, texto al
-              50%. El botón sigue legible pero no clickable.
-            </li>
-            <li>
-              <strong>Tiempo máximo</strong> antes de mostrar feedback
-              alternativo: 4 segundos. Si pasa, "Tarda más de lo normal — no
-              cierres la pestaña."
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Empty states</h3>
-          <div
-            style="
-              background: #f5efe6;
-              border-radius: 12px;
-              padding: 48px 32px;
-              text-align: center;
-              margin-top: 16px;
-              max-width: 600px;
-            "
-          >
-            <div
-              style="
-                font-family: var(--font-display);
-                font-style: italic;
-                font-size: 22px;
-                color: #2d1b3d;
-                margin-bottom: 8px;
-              "
-            >
-              Aún sin novedades.
-            </div>
-            <p
-              style="
-                font-size: 14px;
-                color: var(--color-text-soft);
-                max-width: 40ch;
-                margin: 0 auto 16px;
-              "
-            >
-              Cuando publiquemos avances del ensayo, los verás aquí. La
-              frecuencia es de 2–3 al mes.
-            </p>
-            <a
-              href="#"
-              style="
-                font-family: var(--font-mono);
-                font-size: 12px;
-                color: #2d1b3d;
-                text-decoration: underline;
-                text-underline-offset: 3px;
-              "
-              >Suscribirme a alertas →</a
-            >
-          </div>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.7;
-              max-width: 70ch;
-              padding-left: 20px;
-              margin-top: 16px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              Empty state nunca está vacío de verdad — siempre da una salida
-              (suscribirse, volver, contactar).
-            </li>
-            <li>
-              Tono editorial, no de error: "Aún sin novedades", no "No hay
-              datos".
-            </li>
-            <li>
-              Sin ilustración. La forma del bloque ya comunica vacío — añadir un
-              icono lo trivializa.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Mensajes globales — toast / banner</h3>
-          <div
-            style="display: grid; gap: 10px; margin-top: 16px; max-width: 70ch"
-          >
-            <div
-              style="
-                background: #1d8155;
-                color: #faf6f0;
-                padding: 14px 18px;
-                border-radius: 8px;
-                display: flex;
-                align-items: center;
-                gap: 12px;
-              "
-            >
-              <span aria-hidden="true">✓</span>
-              <span style="font-size: 14px"
-                >Donación recibida. Te llegará un email de confirmación en unos
-                minutos.</span
-              >
-            </div>
-            <div
-              style="
-                background: #c2410c;
-                color: #faf6f0;
-                padding: 14px 18px;
-                border-radius: 8px;
-                display: flex;
-                align-items: center;
-                gap: 12px;
-              "
-            >
-              <span aria-hidden="true">⚠</span>
-              <span style="font-size: 14px"
-                >La pasarela no respondió. Inténtalo de nuevo en 30 segundos o
-                escríbenos a hola@helpmiriam.com.</span
-              >
-            </div>
-            <div
-              style="
-                background: #2d1b3d;
-                color: #faf6f0;
-                padding: 14px 18px;
-                border-radius: 8px;
-                display: flex;
-                align-items: center;
-                gap: 12px;
-              "
-            >
-              <span aria-hidden="true">ℹ</span>
-              <span style="font-size: 14px"
-                >Hemos actualizado las cifras del ensayo. Ver
-                <a href="#" style="color: #e8d4ed; text-decoration: underline"
-                  >qué cambió</a
-                >.</span
-              >
-            </div>
-          </div>
-        </section>
-
-        <!-- 18 PRESS KIT -->
-        <section class="ds-section" id="press">
-          <div class="eyebrow">18 · Recursos</div>
-          <h2>Press kit.</h2>
-          <p class="lede">
-            Lo que entregas a un periodista, una marca colaboradora o un médico
-            que pide materiales. Una sola página, descargable, siempre con las
-            cifras actualizadas. Si tienes que improvisar lo que mandas, ya has
-            perdido al periodista.
-          </p>
-
-          <h3 style="margin-top: 32px">Bio de Miriam — tres versiones</h3>
-          <div
-            style="
-              display: grid;
-              grid-template-columns: 1fr;
-              gap: 16px;
-              max-width: 80ch;
-            "
-          >
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  display: flex;
-                  justify-content: space-between;
-                  align-items: baseline;
-                  margin-bottom: 12px;
-                "
-              >
-                <div
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 11px;
-                    letter-spacing: 0.08em;
-                    text-transform: uppercase;
-                    color: var(--color-text-soft);
-                  "
-                >
-                  Corta · 50 palabras · pie de foto, redes
-                </div>
-                <button
-                  onclick="
-                    navigator.clipboard.writeText(
-                      this.parentNode.nextElementSibling.innerText
-                    )
-                  "
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 11px;
-                    padding: 4px 10px;
-                    border: 1px solid rgba(45, 27, 61, 0.2);
-                    background: transparent;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    color: var(--color-text);
-                  "
-                >
-                  Copiar
-                </button>
-              </div>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.6;
-                  color: var(--color-text);
-                  margin: 0;
-                "
-              >
-                Miriam González (35, Murcia) tiene un cáncer de mama metastásico
-                refractario con un perfil molecular único: amplificación XLR2
-                ×9 sobre BC-SCC, poco frecuente en la literatura.
-                Busca financiar el acceso a un tratamiento experimental fuera
-                del SNS.
-              </p>
-            </div>
-
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  display: flex;
-                  justify-content: space-between;
-                  align-items: baseline;
-                  margin-bottom: 12px;
-                "
-              >
-                <div
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 11px;
-                    letter-spacing: 0.08em;
-                    text-transform: uppercase;
-                    color: var(--color-text-soft);
-                  "
-                >
-                  Media · 100 palabras · entradilla de noticia
-                </div>
-                <button
-                  onclick="
-                    navigator.clipboard.writeText(
-                      this.parentNode.nextElementSibling.innerText
-                    )
-                  "
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 11px;
-                    padding: 4px 10px;
-                    border: 1px solid rgba(45, 27, 61, 0.2);
-                    background: transparent;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    color: var(--color-text);
-                  "
-                >
-                  Copiar
-                </button>
-              </div>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.6;
-                  color: var(--color-text);
-                  margin: 0;
-                "
-              >
-                Miriam González, 35 años, vive en Murcia y tiene cáncer de mama
-                metastásico refractario a las líneas de tratamiento estándar. Su
-                biopsia revela un perfil molecular excepcional — amplificación
-                XLR2 ×9 sobre un subtipo BC-SCC — poco habitual en la
-                literatura científica internacional. Junto
-                con un equipo de doce especialistas y la sub-marca Beyond the
-                Protocol, ha lanzado una iniciativa para financiar el acceso a
-                un tratamiento experimental no cubierto por el sistema público.
-                Su web, helpmiriam.com, documenta el caso con rigor clínico y
-                transparencia financiera total.
-              </p>
-            </div>
-
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 12px;
-                padding: 24px;
-              "
-            >
-              <div
-                style="
-                  display: flex;
-                  justify-content: space-between;
-                  align-items: baseline;
-                  margin-bottom: 12px;
-                "
-              >
-                <div
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 11px;
-                    letter-spacing: 0.08em;
-                    text-transform: uppercase;
-                    color: var(--color-text-soft);
-                  "
-                >
-                  Larga · 200 palabras · reportaje
-                </div>
-                <button
-                  onclick="
-                    navigator.clipboard.writeText(
-                      this.parentNode.nextElementSibling.innerText
-                    )
-                  "
-                  style="
-                    font-family: var(--font-mono);
-                    font-size: 11px;
-                    padding: 4px 10px;
-                    border: 1px solid rgba(45, 27, 61, 0.2);
-                    background: transparent;
-                    border-radius: 6px;
-                    cursor: pointer;
-                    color: var(--color-text);
-                  "
-                >
-                  Copiar
-                </button>
-              </div>
-              <p
-                style="
-                  font-size: 14px;
-                  line-height: 1.6;
-                  color: var(--color-text);
-                  margin: 0;
-                "
-              >
-                Miriam González tiene 35 años, vive en Murcia y trabaja en
-                diseño. En febrero de 2026 le diagnostican cáncer de mama
-                metastásico. Tras varias líneas de tratamiento estándar, el
-                tumor responde mal — lo que la oncología llama "refractario". El
-                informe AP del hospital de referencia añade un detalle que cambia todo: el
-                tumor presenta una amplificación XLR2 de ×9 sobre un subtipo
-                BC-SCC — una combinación poco habitual en la
-                literatura científica internacional, lo que convierte su caso en
-                uno de los más singulares conocidos. <br /><br />Miriam, junto
-                con su equipo de doce especialistas y bajo el paraguas de Beyond
-                the Protocol, ha decidido no esperar a que un ensayo llegue a
-                España. Ha lanzado una iniciativa pública — helpmiriam.com —
-                para financiar el acceso a un tratamiento experimental
-                molecularmente dirigido. La web documenta cada paso con rigor
-                clínico, total transparencia financiera y voz directa, sin
-                retórica de "lucha" ni victimismo. La meta de la primera fase:
-                12.345 € para la siguiente prueba molecular y consulta
-                internacional.
-              </p>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Cifras clave actualizadas</h3>
-          <p
-            style="
-              font-size: 14px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Mantener actualizadas. Cualquier cifra que aparezca en prensa pero
-            no aquí, no se ha cruzado por el equipo. Estas son la fuente única.
-          </p>
-          <div
-            class="grid-4"
-            style="display: grid; gap: 12px; margin-top: 16px"
-          >
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 10px;
-                padding: 20px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 36px;
-                  color: #a44db2;
-                  line-height: 1;
-                "
-              >
-                ×9
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: var(--color-text-soft);
-                  margin-top: 6px;
-                "
-              >
-                XLR2 amplificación
-              </div>
-            </div>
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 10px;
-                padding: 20px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 36px;
-                  color: #a44db2;
-                  line-height: 1;
-                "
-              >
-                4
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: var(--color-text-soft);
-                  margin-top: 6px;
-                "
-              >
-                casos en literatura
-              </div>
-            </div>
-            <div
-              style="
-                background: #faf6f0;
-                border: 1px solid rgba(45, 27, 61, 0.08);
-                border-radius: 10px;
-                padding: 20px;
-              "
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 36px;
-                  color: #a44db2;
-                  line-height: 1;
-                "
-              >
-                12
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: var(--color-text-soft);
-                  margin-top: 6px;
-                "
-              >
-                especialistas en equipo
-              </div>
-            </div>
-            <div
-              style="background: #2d1b3d; border-radius: 10px; padding: 20px"
-            >
-              <div
-                style="
-                  font-family: var(--font-display);
-                  font-weight: 600;
-                  font-size: 36px;
-                  color: #ff6b47;
-                  line-height: 1;
-                "
-              >
-                80k€
-              </div>
-              <div
-                style="
-                  font-family: var(--font-mono);
-                  font-size: 11px;
-                  color: rgba(250, 246, 240, 0.55);
-                  margin-top: 6px;
-                "
-              >
-                meta fase 1
-              </div>
-            </div>
-          </div>
-
-          <h3 style="margin-top: 40px">Assets descargables</h3>
-          <ul
-            style="
-              font-size: 14px;
-              line-height: 1.9;
-              max-width: 70ch;
-              padding-left: 20px;
-              color: var(--color-text);
-            "
-          >
-            <li>
-              <strong>Headshot oficial</strong> de Miriam — 4:5, 2000 px, color
-              y B/N. <em>(carpeta /press/portraits/)</em>
-            </li>
-            <li>
-              <strong>Wordmark Miriam</strong>. — SVG + PNG fondo crema y
-              berenjena. <em>(/press/wordmark/)</em>
-            </li>
-            <li>
-              <strong>Logos del equipo</strong> — Beyond the Protocol,
-              hospitales colaboradores (con permiso).
-              <em>(/press/partners/)</em>
-            </li>
-            <li>
-              <strong>Hoja informativa clínica</strong> — PDF de 2 páginas con
-              el perfil molecular explicado para no especialistas.
-              <em>(/press/clinical-brief.pdf)</em>
-            </li>
-            <li>
-              <strong>Cifras en SVG/PNG</strong> — versiones de los datos clave
-              listas para incrustar en piezas de prensa.
-            </li>
-          </ul>
-
-          <h3 style="margin-top: 40px">Contacto de prensa</h3>
-          <div
-            style="
-              background: #f5efe6;
-              border-radius: 12px;
-              padding: 24px;
-              max-width: 60ch;
-            "
-          >
-            <div
-              style="
-                font-family: var(--font-mono);
-                font-size: 11px;
-                letter-spacing: 0.08em;
-                text-transform: uppercase;
-                color: var(--color-text-soft);
-                margin-bottom: 8px;
-              "
-            >
-              Punto único de contacto
-            </div>
-            <div
-              style="
-                font-family: var(--font-display);
-                font-size: 20px;
-                color: #2d1b3d;
-                margin-bottom: 4px;
-              "
-            >
-              [Nombre] · prensa
-            </div>
-            <div style="font-size: 14px; color: var(--color-text)">
-              <a
-                href="mailto:prensa@helpmiriam.com"
-                style="
-                  color: #2d1b3d;
-                  text-decoration: underline;
-                  text-underline-offset: 3px;
-                "
-                >prensa@helpmiriam.com</a
-              >
-              · respuesta en &lt; 24 h
-            </div>
-            <p
-              style="
-                font-size: 13px;
-                color: var(--color-text-soft);
-                margin: 12px 0 0;
-                line-height: 1.55;
-              "
-            >
-              Cualquier petición de entrevista, dossier ampliado, o uso de
-              imágenes pasa por aquí. <strong>No</strong> escribir directamente
-              a Miriam — ella no gestiona prensa.
-            </p>
-          </div>
-        </section>
-
-        <!-- 19 PLANTILLAS DE MENSAJE -->
-        <section class="ds-section" id="templates">
-          <div class="eyebrow">19 · Recursos</div>
-          <h2>Plantillas de mensaje.</h2>
-          <p class="lede">
-            Las que vas a copiar y pegar durante meses. Cubren las situaciones
-            más frecuentes: agradecer una donación, anunciar un hito, contactar
-            a un especialista nuevo, postear un avance. La voz ya está fijada —
-            aquí solo cambian los datos concretos.
-          </p>
-
-          <h3 style="margin-top: 32px">A · Agradecimiento tras donación</h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Email automático tras pasarela. Voz:
-            <strong>Miriam, primera persona singular</strong>. Sin urgencia, sin
-            pedir más.
-          </p>
-          <pre class="code" style="margin-top: 8px">
-<span class="c-com">Asunto:</span> Gracias, [nombre].
-
-[<span class="c-val">Nombre</span>]:
-
-Acabo de ver tu donación de [<span class="c-val">cantidad</span>] €. Te lo digo en serio:
-no es una respuesta automática, lo escribo yo desde casa.
-
-Cada euro entra en una cuenta auditada que verás reflejada en
-helpmiriam.com → Transparencia. Cuando alcancemos el primer
-hito ([<span class="c-val">meta</span>] €) te avisaré por aquí con lo que hayamos podido
-hacer con él.
-
-Si quieres saber algo concreto del caso, responde a este email
-sin más. Lo leo yo.
-
-Gracias.
-Miriam<span class="c-com">.</span></pre>
-
-          <h3 style="margin-top: 40px">
-            B · Anuncio de hito alcanzado · Instagram + GoFundMe
-          </h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Voz: <strong>nosotros plural</strong> (es logro colectivo). Sin
-            emoji. Sin "milagro".
-          </p>
-          <pre class="code" style="margin-top: 8px">
-<span class="c-com">Post / update:</span>
-
-Hemos llegado a los [<span class="c-val">meta</span>] €.
-
-[<span class="c-val">N</span>] personas han donado. Es la cifra más concreta que puedo
-darte hoy. Con ese dinero pagamos:
-
-— La siguiente prueba molecular en [<span class="c-val">centro hospitalario</span>] ([<span class="c-val">importe</span>] €)
-— La consulta internacional con [<span class="c-val">centro</span>] ([<span class="c-val">importe</span>] €)
-— Reserva para la primera dosis del tratamiento ([<span class="c-val">importe</span>] €)
-
-El plazo de la ventana clínica sigue siendo de [<span class="c-val">N</span>] semanas.
-La siguiente meta es [<span class="c-val">meta</span>] € — desglose detallado en
-helpmiriam.com.
-
-Gracias por estar aquí.</pre>
-
-          <h3 style="margin-top: 40px">C · Contacto a especialista nuevo</h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Email frío a oncólogo / investigador. Voz:
-            <strong>equipo en plural</strong>, registro clínico, sin súplica.
-          </p>
-          <pre class="code" style="margin-top: 8px">
-<span class="c-com">Asunto:</span> Caso refractario XLR2 ×9 / BC-SCC — consulta posible
-
-Dr./Dra. [<span class="c-val">apellido</span>]:
-
-Le escribimos desde el equipo clínico que sigue a Miriam González,
-paciente con cáncer de mama metastásico refractario. Su biopsia
-muestra una amplificación XLR2 ×9 sobre subtipo BC-SCC — un
-perfil poco frecuente en la literatura.
-
-Hemos visto su trabajo en [<span class="c-val">paper / línea de investigación</span>] y nos
-gustaría someter el caso a su criterio. Adjuntamos:
-
-— Informe AP completo
-— Perfil molecular con anotaciones de [<span class="c-val">especialista</span>]
-— Resumen del recorrido clínico hasta la fecha (2 páginas)
-
-Si dispone de 30 minutos para una llamada en las próximas dos
-semanas, le agradeceríamos enormemente la consulta. Si no es
-viable, una opinión por escrito es igualmente valiosa.
-
-Atentamente,
-[<span class="c-val">Nombre</span>] · equipo clínico Miriam
-prensa@helpmiriam.com / +34 [<span class="c-val">tel</span>]</pre>
-
-          <h3 style="margin-top: 40px">D · Post Instagram tipo · día normal</h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Voz: <strong>Miriam primera persona</strong>. Sin storytelling
-            forzado. Una imagen real (foto, no ilustración).
-          </p>
-          <pre class="code" style="margin-top: 8px">
-<span class="c-com">Imagen:</span> foto del informe encima de la mesa de la cocina,
-        con la taza al lado. Luz natural.
-
-<span class="c-com">Caption:</span>
-
-Mañana me hacen la siguiente analítica. Es de control,
-no de decisión, así que no espero noticias grandes.
-
-Me da tiempo a contaros que hemos pasado los [<span class="c-val">importe</span>] €
-(faltan [<span class="c-val">N</span>] para el primer hito), que la consulta con
-[<span class="c-val">especialista</span>] ya está pedida, y que llevo dos días
-durmiendo seis horas seguidas — pequeño récord.
-
-Gracias por seguir aquí.
-
-helpmiriam.com</pre>
-
-          <h3 style="margin-top: 40px">
-            E · WhatsApp — respuesta a alguien que pregunta cómo ayudar
-          </h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Mensaje breve, sin enlaces sospechosos, voz
-            <strong>Miriam o equipo</strong>. Para reenviar tal cual.
-          </p>
-          <pre class="code" style="margin-top: 8px">
-Hola [<span class="c-val">nombre</span>], gracias por preguntar.
-
-La forma más útil ahora mismo es donar en helpmiriam.com (a
-partir de 5 €) o compartir la web con alguien que pueda llegar
-a profesionales de oncología o medios de prensa.
-
-Si tienes un contacto concreto, escríbeme y te paso el press
-kit con los materiales para que lo reenvíes directamente.
-
-Cualquier cantidad ayuda — la transparencia y el desglose están
-todos en la web.
-
-Un abrazo,
-Miriam</pre>
-
-          <h3 style="margin-top: 40px">
-            F · Email a colaborador profesional · diseño / dev / traducción
-          </h3>
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              max-width: 64ch;
-            "
-          >
-            Para gente que ofrece su trabajo gratis. Voz:
-            <strong>equipo plural</strong>, sin sobreagradecer.
-          </p>
-          <pre class="code" style="margin-top: 8px">
-<span class="c-com">Asunto:</span> Bienvenido al equipo Miriam — siguiente paso
-
-Hola [<span class="c-val">nombre</span>]:
-
-Gracias por ofrecer tu tiempo. Te explico cómo trabajamos para
-que entres limpio:
-
-1. Lee el sistema de diseño completo (40 minutos):
-   helpmiriam.com/design-system
-
-2. Acceso al repositorio:
-   github.com/ceciCoding/miriam-gonzalez-case
-   (te añadimos en cuanto nos pases tu usuario)
-
-3. Tu primera tarea está aquí: [<span class="c-val">issue link</span>]
-   Cualquier cambio entra por pull request, aunque sea una coma.
-
-4. Si dudas si algo encaja con el sistema, abre un issue antes
-   de empezar. Mejor 5 minutos de discusión que 3 horas
-   rehaciendo.
-
-Cuando termines tu primera contribución te invitamos al canal
-interno (Discord) y al stand-up semanal de los miércoles.
-
-Cualquier cosa, respondes a este email.
-
-Equipo Miriam<span class="c-com">.</span></pre>
-
-          <p
-            style="
-              font-size: 13px;
-              color: var(--color-text-soft);
-              margin-top: 32px;
-              padding: 14px 16px;
-              background: rgba(168, 85, 181, 0.06);
-              border-left: 2px solid var(--color-miriam);
-              border-radius: 0 6px 6px 0;
-              max-width: 72ch;
-            "
-          >
-            <strong style="color: var(--color-text)">Mantenimiento.</strong>
-            Estas plantillas están vivas. Cuando uses una y notes que te falta
-            algo o sobra, edítala aquí mismo. La fuente única de verdad es esta
-            sección — no la copia que tú tengas en tu mail.
-          </p>
-        </section>
-
-        <!-- 20 · PUBLICACIONES DE INSTAGRAM -->
-        <section class="ds-section" id="instagram">
-          <div class="eyebrow">20 · Recursos</div>
-          <h2>Publicaciones de Instagram.</h2>
-          <p class="lede">
-            Cómo se construye un carrusel o un reel de @miriamgonp con el sistema:
-            mismo color, misma Fraunces, la voz de Miriam y el lenguaje de
-            anotaciones a mano. <strong>Una historia por publicación.</strong>
-          </p>
-
-          <h3 style="margin-top: 32px">Formatos y arco</h3>
-          <p style="font-size: 14px; color: var(--color-text); max-width: 72ch">
-            <strong>Post-carrusel 4:5</strong> (1080×1350) para contar ·
-            <strong>Reel/story 9:16</strong> (1080×1920) para pedir acción. El carrusel
-            es un relato: <em>gancho → contexto → tensión → dato → detalle → síntesis →
-            oportunidad → compartir + firma</em>. El reel comprime el arco a 4 beats.
-          </p>
-
-          <h3 style="margin-top: 28px">Ejemplo · slide de gancho (4:5)</h3>
-          <div style="display: grid; grid-template-columns: 300px 1fr; gap: 28px; align-items: start; margin-top: 14px">
-            <div style="aspect-ratio: 4/5; background: #2d1b3d; border-radius: 18px; padding: 30px; display: flex; flex-direction: column; overflow: hidden">
-              <div style="display: flex; justify-content: space-between; font-family: var(--font-mono); font-size: 11px; letter-spacing: .04em; color: #e8d4ed">
-                <span>// pet de galio-68</span><span style="opacity: .6">01 / 08</span>
-              </div>
-              <div style="flex: 1"></div>
-              <h4 style="font-family: var(--font-display); font-weight: 600; font-size: 28px; line-height: 1.05; letter-spacing: -.03em; color: #faf6f0; margin: 0 0 12px">mi cáncer tiene dos motores. y solo tratamos uno.</h4>
-              <p style="font-family: var(--font-body, 'Inter', sans-serif); font-size: 13px; line-height: 1.4; color: rgba(250,246,240,.84); margin: 0 0 14px">Una prueba acaba de demostrar el segundo, y que se puede atacar.</p>
-              <span style="font-size: 14px; font-style: italic; color: #e8d4ed">desliza para saber más →</span>
-            </div>
-            <ul style="font-size: 13.5px; line-height: 1.7; color: var(--color-text); padding-left: 18px; margin: 0">
-              <li><strong>Eyebrow mono</strong> arriba (<code>// sección</code>) + índice <code>01/08</code>.</li>
-              <li><strong>Gancho en Fraunces minúscula</strong>, voz en primera persona.</li>
-              <li>Se prueban <strong>4 ganchos</strong> (afirmación / prueba / metáfora / pregunta) y se elige el más fuerte.</li>
-              <li>Pista de <strong>deslizar</strong> abajo; "luminal" siempre legible como "de mama".</li>
-            </ul>
-          </div>
-
-          <h3 style="margin-top: 32px">Reglas</h3>
-          <ul style="font-size: 13.5px; line-height: 1.75; color: var(--color-text); max-width: 72ch; padding-left: 18px">
-            <li><strong>Alterna los fondos</strong> entre slides (berenjena → crema → violeta) para dar ritmo.</li>
-            <li><strong>Violeta = dato y firma</strong>; <strong style="color: var(--color-cta)">coral = solo el CTA</strong>, nunca decorativo.</li>
-            <li><strong>Una idea por slide</strong>, una sola acción al final.</li>
-            <li><strong>Anotaciones a mano</strong> (Caveat) como acento — una o dos por slide, desactivables.</li>
-            <li><strong>Caption</strong> largo que <strong>siempre cierra con helpmiriam.com</strong>.</li>
-            <li>Texto en imagen → repetir lo esencial en el caption. Animaciones con <code>prefers-reduced-motion</code>.</li>
-          </ul>
-        </section>
-
-        <footer class="ds-footer">
-          <p>
-            <strong
-              style="
-                font-family: var(--font-display);
-                font-weight: 600;
-                font-size: 16px;
-                color: var(--color-text);
-              "
-              >Sistema vivo.</strong
-            >
-            Si descubres una expresión nueva, una palabra que no encaja, una
-            plantilla que funciona mejor — añádela. El sistema se afina con el
-            uso.
-          </p>
-          <p style="margin-top: 16px">
-            helpmiriam.com · @miriamgonp · gofund.me/3e25cae99
-          </p>
-          <p
-            style="
-              margin-top: 16px;
-              font-family: var(--font-mono);
-              font-size: 11px;
-              letter-spacing: 0.05em;
-            "
-          >
-            Última actualización: mayo 2026 · v1.1 · añadido 00 (cómo usar) +
-            notas oklch/dark mode (02)
-          </p>
-        </footer>
-      </main>
+}
+
+</style>
+<style>
+/* BTP DS v2.0 — CAPA DE COMPONENTES (Fase 2)
+   «Beyond the Protocol» — editorial nocturno.
+
+   REGLA: los componentes pintan SOLO con tokens de ROL (--fondo, --superficie,
+   --texto-1/2/3, --identidad, --anillo-foco, --cta-texto, --trazo-*, --tipo-*).
+   NUNCA tocan primitivas ni hexes. Así una misma clase se ve bien en claro,
+   en oscuro (data-tema) y en banda oscura local (.oscuro) sin reescribirse.
+
+   Requiere btp-tokens.css cargado antes. Import:
+     @import "btp-tokens.css"; @import "btp-components.css";
+
+   Promueve (tras gate Diseño+Técnico) los candidatos del sprint Fable 7-jul:
+   error-sin-rojo · checkbox/radio propios · btn-secondary--inverse ·
+   alerts/toast · tabla accesible · modificador .oscuro · timeline · badge-genomic.
+
+   Muro a11y: WCAG AA como SUELO, foco visible siempre, objetivos ≥44px,
+   iconos SVG (nunca glifos Unicode), ningún botón tapa texto. Reduced-motion
+   ya lo fuerza el token layer. Colores = dominio de Ceci; aquí no se inventan. */
+
+/* ── Motivo firma: estrella contenida (SVG, no glifo). Reconciliar el path con
+   el BrandMark.vue canónico del repo vivo; este es el 4-puntas por defecto. */
+:root {
+  --estrella-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M10 1.6C10.8 5 11.4 6.2 12.6 7.4 14 8.8 16.4 9.4 18.4 10 16.2 10.8 14.2 11.4 12.8 12.7 11.5 13.9 10.9 15.7 10 18.4 9.3 15.9 8.5 14.2 7.2 12.9 5.8 11.6 3.4 10.7 1.6 10 3.8 9.1 5.8 8.4 7.2 7.1 8.4 6 9.2 4.2 10 1.6Z' fill='%23000'/%3E%3C/svg%3E");
+  --estrella-poli-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M10 1.6 12.1 7.9 18.4 10 12.1 12.1 10 18.4 7.9 12.1 1.6 10 7.9 7.9Z' fill='%23000'/%3E%3C/svg%3E");
+}
+
+/* ── Modificador de contexto oscuro (banda a sangre; utilidad oficial EPK) ────
+   Remapea los roles al tema oscuro SOLO dentro de este contenedor. No es un
+   toggle de conveniencia: es «noche editorial» con intención. */
+.oscuro {
+  --fondo:        var(--color-text);
+  --superficie:   color-mix(in srgb, var(--color-text) 88%, var(--color-bg));
+  --texto-1:      var(--color-bg);
+  --texto-2:      color-mix(in srgb, var(--color-bg) 78%, transparent);
+  --texto-3:      color-mix(in srgb, var(--color-bg) 58%, transparent);
+  --identidad:    var(--color-miriam-claro);
+  --anillo-foco:  var(--color-miriam-claro);
+  --cta-texto:    var(--color-cta);
+  --trazo-sutil:  color-mix(in srgb, var(--color-bg) 10%, transparent);
+  --trazo-medio:  color-mix(in srgb, var(--color-bg) 16%, transparent);
+  --trazo-fuerte: color-mix(in srgb, var(--color-bg) 26%, transparent);
+  --trazo-interactivo: color-mix(in srgb, var(--color-bg) 40%, transparent);  /* borde de controles ≥3:1 sobre berenjena (3.51) — MCP/Ceci */
+  background: var(--fondo);
+  color: var(--texto-1);
+}
+
+/* ── Foco visible (dual por token: violeta / violeta-claro on-dark) — A11Y ──── */
+:where(a, button, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--anillo-foco);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* ══ TIPOGRAFÍA (usa los tokens compuestos) ═══════════════════════════════════ */
+/* Eyebrow — CANÓNICO (Consolidado §3): JetBrains Mono, uppercase, tracking .12em, tinta.
+   (Lo tenía en Fraunces itálica: cruzado con el `lede`.) */
+.eyebrow {
+  font: 500 12px/1.4 var(--font-mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--texto-2);
+}
+/* Lede — AQUÍ va la itálica de Fraunces (bajada bajo el titular), no en el eyebrow. */
+.lede {
+  font: italic 400 clamp(18px, 1.6vw, 22px)/1.45 var(--font-display);
+  color: var(--texto-2); max-inline-size: 60ch;
+}
+.titulo-1 { font: var(--tipo-h1); letter-spacing: var(--track-cifra); color: var(--texto-1); text-wrap: balance; }
+.titulo-2 { font: var(--tipo-h2); color: var(--texto-1); text-wrap: balance; }
+.titulo-3 { font: var(--tipo-h3); color: var(--texto-1); }
+.cuerpo   { font: var(--tipo-body); color: var(--texto-1); max-inline-size: var(--measure); }
+.cuerpo-sm{ font: var(--tipo-body-sm); color: var(--texto-2); }
+.dato     { font: var(--tipo-dato); font-variant-numeric: tabular-nums; color: var(--texto-1); }
+.cifra    { font: var(--tipo-cifra); letter-spacing: var(--track-cifra); color: var(--identidad); } /* «Cifra Fraunces» */
+
+/* ══ BOTONES ══════════════════════════════════════════════════════════════════
+   Base: ≥44px de alto, un solo acento coral por vista, ningún botón tapa texto. */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: var(--sp-8);
+  min-height: 44px; padding: var(--sp-12) var(--sp-24);
+  font: 600 var(--texto-base)/1 var(--font-body);
+  border: 1px solid transparent; border-radius: var(--radius-btn);
+  cursor: pointer; text-decoration: none; white-space: nowrap;
+  transition: background var(--dur-micro) var(--curva-salida),
+              border-color var(--dur-micro) var(--curva-salida),
+              color var(--dur-micro) var(--curva-salida),
+              transform var(--dur-micro) var(--curva-salida);
+}
+.btn:disabled, .btn[aria-disabled="true"] { opacity: .5; cursor: not-allowed; }
+.btn:active:not(:disabled) { transform: scale(0.98); }  /* regla 7: press tangible */
+
+/* Primario = acción (coral). Único por vista.
+   TEXTO BERENJENA sobre coral (Consolidado D3: crema sobre coral = 2.62:1, FALLA AA).
+   La web viva ya lo tenía bien; el bug era de esta hoja. */
+.btn--primary { background: var(--color-cta); color: var(--color-text); }
+.btn--primary:hover:not(:disabled) { background: var(--color-cta-hover); }
+.btn--primary:active:not(:disabled){ background: var(--cta-active); }
+
+/* Secundario = identidad (violeta contorno). */
+.btn--secondary { background: transparent; color: var(--texto-1); border-color: var(--identidad); }  /* texto TINTA (10.64:1), identidad en el borde — Ceci valida (check_contrast); violeta como texto solo era AA-large */
+.btn--secondary:hover:not(:disabled) { background: var(--secundario-hover); }
+.btn--secondary:active:not(:disabled){ background: color-mix(in srgb, var(--identidad) 14%, transparent); }
+
+/* Secundario inverso: para bandas oscuras (candidato Fable). */
+.btn--secondary-inverse { background: transparent; color: var(--texto-1); border-color: var(--trazo-interactivo); }
+.btn--secondary-inverse:hover:not(:disabled) { border-color: var(--texto-1); }
+
+/* Fantasma = terciario, sin caja. */
+.btn--ghost { background: transparent; color: var(--texto-1); }  /* terciario silencioso: texto tinta (violeta como texto <4.5 sobre crema) */
+.btn--ghost:hover:not(:disabled) { background: var(--secundario-hover); }
+
+/* ══ FORMULARIOS ══════════════════════════════════════════════════════════════ */
+.campo-grupo { display: flex; flex-direction: column; gap: var(--sp-8); }
+.etiqueta { font: 600 var(--texto-sm)/1.3 var(--font-body); color: var(--texto-2); }
+
+.campo {
+  min-height: 44px; padding: var(--sp-12) var(--sp-16);
+  font: var(--tipo-body); color: var(--texto-1);
+  background: var(--fondo);
+  border: 1px solid var(--trazo-interactivo); border-radius: var(--radius-md);
+  transition: border-color var(--dur-micro) var(--curva-salida);
+}
+.campo::placeholder { color: var(--texto-3); }
+.campo:hover:not(:disabled) { border-color: var(--texto-1); }
+.campo:focus-visible { outline: none; border-color: var(--anillo-foco);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--anillo-foco) 30%, transparent); }
+.campo:disabled { opacity: .5; cursor: not-allowed; }
+
+/* Estado ERROR — sin rojo: trazo berenjena + texto coral-AA. El significado lo
+   carga la palabra + el filete, NO la estrella (la estrella es marca, no estado
+   — canon §3.5). Glifo neutro (punto grueso) dibujado a mano, no la firma. */
+.campo[aria-invalid="true"] { border-color: var(--texto-1); border-width: 2px; }
+.campo-error { display: flex; align-items: center; gap: var(--sp-8);
+  font: var(--tipo-body-sm); color: var(--cta-texto); }   /* coral-texto = AA por token */
+.campo-error::before { content: ""; inline-size: .5em; block-size: .5em; flex: none;
+  border-radius: var(--radius-pill); background: var(--cta-texto); }
+.campo-ok { color: var(--texto-1); }  /* éxito = identidad, sin verde clínico */
+
+/* Checkbox / radio propios (appearance:none; candidato Fable) — ≥ objetivo táctil */
+.check, .radio { appearance: none; -webkit-appearance: none;
+  position: relative;
+  inline-size: 24px; block-size: 24px; flex: none; margin: 0;
+  border: 2px solid var(--trazo-interactivo); background: var(--fondo); cursor: pointer;
+  display: inline-grid; place-content: center;
+  transition: border-color var(--dur-micro) var(--curva-salida),
+              background var(--dur-micro) var(--curva-salida); }
+.check { border-radius: var(--radius-sm); }
+.radio { border-radius: var(--radius-pill); }
+/* Diana de 44x44 centrada sobre la casilla de 24 (24 + 10 + 10). No pinta nada. */
+.check::before, .radio::before { content: ""; position: absolute; inset: -10px; }
+.check:hover, .radio:hover { border-color: var(--identidad); }
+.check:checked, .radio:checked { border-color: var(--identidad); background: var(--identidad); }
+.check:checked::after { content: ""; inline-size: 12px; block-size: 12px;
+  background: var(--color-bg); -webkit-mask: var(--estrella-svg) center/contain no-repeat;
+  mask: var(--estrella-svg) center/contain no-repeat; }
+.radio:checked::after { content: ""; inline-size: 9px; block-size: 9px;
+  border-radius: var(--radius-pill); background: var(--color-bg); }
+.check:disabled, .radio:disabled { opacity: .5; cursor: not-allowed; }
+
+/* ══ TARJETA ══════════════════════════════════════════════════════════════════ */
+.card {
+  background: var(--superficie); color: var(--texto-1);
+  border: 1px solid var(--trazo-sutil); border-radius: var(--radius-card);
+  padding: var(--sp-24);
+}
+.card--flotante { box-shadow: var(--sombra-flotante); }
+/* .card.oscuro hereda del modificador de contexto (banda oscura) — candidato Fable. */
+
+/* ══ BADGE ════════════════════════════════════════════════════════════════════ */
+.badge {
+  display: inline-flex; align-items: center; gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-12);
+  font: 600 var(--texto-xs)/1.4 var(--font-body);
+  border-radius: var(--radius-pill);
+  background: var(--seleccionado-bg); color: var(--seleccionado-text);
+}
+/* Genómico — CANÓNICO (Consolidado §7): fondo violeta-soft, texto berenjena, mono.
+   No se inventa: el patrón ya existía. (Mi velo al 14% fallaba AA, 3.2–3.8:1.) */
+.badge--genomic { font-family: var(--font-mono); font-variant-numeric: lining-nums tabular-nums;
+  font-size: 13px; font-weight: 600;
+  background: var(--color-miriam-soft); color: var(--color-text); }
+
+/* ══ ALERTAS / TOAST (semánticas; candidato Fable) ════════════════════════════
+   Nada de rojo/verde de sistema: el significado va por icono + etiqueta + borde
+   de identidad. Calma, no alarma (lo lee gente en tratamiento). */
+/* Sin icono-estrella (la estrella es marca, no estado → sería sparkle funcional).
+   Sin caja: filete fino + etiqueta en versales. El significado va por palabra, no por hue. */
+.alerta {
+  padding-inline-start: var(--sp-16); padding-block: var(--sp-4);
+  border-inline-start: 2px solid var(--identidad); color: var(--texto-1);
+}
+.alerta__label { display: block; margin-block-end: var(--sp-4);
+  font: 600 var(--texto-xs)/1.4 var(--font-body); letter-spacing: .08em;
+  text-transform: uppercase; color: var(--texto-2); }
+.alerta--accion { border-inline-start-color: var(--cta-texto); }
+.alerta--accion .alerta__label { color: var(--cta-texto); }
+.toast { position: fixed; inset-block-end: var(--sp-24); inset-inline-end: var(--sp-24);
+  max-inline-size: 380px; box-shadow: var(--sombra-flotante);
+  animation: btp-toast-in var(--dur-transicion) var(--curva-entrada); }
+@keyframes btp-toast-in { from { opacity: 0; transform: translateY(6px); filter: blur(2px); } to { opacity: 1; transform: none; filter: blur(0); } }  /* regla 5: entrada = fade + subida + blur que aclara */
+/* Regla 10: carga = barrido de luz sobre la etiqueta, no spinner. */
+.cargando { background: linear-gradient(90deg, var(--texto-2) 40%, var(--identidad) 50%, var(--texto-2) 60%); background-size: 200% 100%; -webkit-background-clip: text; background-clip: text; -webkit-text-fill-color: transparent; color: transparent; animation: btp-barrido 2s linear infinite; }
+@keyframes btp-barrido { from { background-position: 200% 0; } to { background-position: -200% 0; } }
+@media (prefers-reduced-motion: reduce) { .cargando { animation: none; background: none; -webkit-text-fill-color: var(--texto-2); color: var(--texto-2); } }
+
+/* ══ TABLA ACCESIBLE (scroll con foco; candidato Fable) ═══════════════════════ */
+.tabla-scroll { overflow-x: auto; border: 1px solid var(--trazo-sutil); border-radius: var(--radius-card); }
+.tabla-scroll:focus-visible { outline: 2px solid var(--anillo-foco); outline-offset: -2px; }
+.tabla { inline-size: 100%; border-collapse: collapse; font: var(--tipo-body-sm); }
+.tabla th, .tabla td { padding: var(--sp-12) var(--sp-16); text-align: start;
+  border-block-end: 1px solid var(--trazo-sutil); }
+.tabla th { font-weight: 600; color: var(--texto-2); position: sticky; inset-block-start: 0;
+  background: var(--superficie); }
+.tabla td.num { font-family: var(--font-mono); font-variant-numeric: tabular-nums; text-align: end; }
+
+/* ══ TIMELINE / CONSTELACIÓN (hitos; candidato Fable) ═════════════════════════ */
+.timeline { position: relative; padding-inline-start: var(--sp-32);
+  border-inline-start: 2px dotted var(--trazo-medio); }  /* «polvo de estrellas» */
+.hito { position: relative; padding-block: var(--sp-16); }
+.hito-nodo { position: absolute; inset-inline-start: calc(-1 * var(--sp-32) - 10px);
+  inline-size: 14px; block-size: 14px; border-radius: var(--radius-pill);
+  background: var(--superficie); border: 2px solid var(--identidad); }
+.hito.presente .hito-nodo { background: var(--color-cta); border-color: var(--color-cta); }
+.hito.presente .hito-nodo::after { content: ""; position: absolute; inset: -6px;
+  border-radius: var(--radius-pill); border: 2px solid var(--color-cta); opacity: .5;
+  animation: btp-respira var(--dur-ambiente) var(--curva-salida) infinite; }
+@keyframes btp-respira { 0%,100% { opacity: .5; transform: scale(1); } 50% { opacity: 0; transform: scale(1.6); } }
+
+/* ══ SPINNER firma: estrella que respira dentro de un círculo — el monograma ══ */
+.spinner { inline-size: 32px; block-size: 32px; border-radius: var(--radius-pill);
+  display: grid; place-content: center;
+  border: 2px solid var(--trazo-sutil); }
+.spinner::after { content: ""; inline-size: 16px; block-size: 16px; background: var(--identidad);
+  -webkit-mask: var(--estrella-svg) center/contain no-repeat;
+  mask: var(--estrella-svg) center/contain no-repeat;
+  animation: btp-latido var(--dur-ambiente) var(--curva-salida) infinite; }
+@keyframes btp-latido { 0%,100% { opacity: .6; } 50% { opacity: 1; } }
+
+</style>
+<style>
+  /* Layout del cuadernillo (no del DS). Autoría = jerarquía. Fantasía «en el hueso»
+     (tipografía + estructura), no en la superficie: cero movimiento salvo el presente. */
+  .saltar { position: absolute; inset-inline-start: var(--sp-8); inset-block-start: -60px; z-index: 20;
+    background: var(--superficie); color: var(--texto-1); padding: var(--sp-8) var(--sp-16);
+    border-radius: var(--radius-md); text-decoration: none; }
+  .saltar:focus { inset-block-start: var(--sp-8); outline: 2px solid var(--anillo-foco); outline-offset: 2px; }
+  .sr-cap { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+  body { margin: 0; position: relative; background: var(--fondo); color: var(--texto-1); font: var(--tipo-body);
+    font-variant-numeric: oldstyle-nums; }        /* cifras elzevirianas en texto corrido */
+  /* Grano de papel: DETRÁS del texto y a la altura del documento (acompaña el scroll,
+     no es cristal fijo). En noche cambia a soft-light (multiply se anula sobre berenjena). */
+  .grano { position: absolute; inset: 0; block-size: 100%; pointer-events: none; z-index: 0; opacity: .05;
+    mix-blend-mode: multiply;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E"); }
+  [data-tema="oscuro"] .grano { mix-blend-mode: soft-light; opacity: .09; }
+  .libro { max-inline-size: 1180px; margin-inline: auto; padding: var(--sp-32) var(--sp-32) var(--sp-96); position: relative; z-index: 1; }
+
+  /* Masthead + constelación-navegación (los capítulos SON cuatro estrellas) */
+  .masthead { display: flex; align-items: baseline; justify-content: space-between;
+    gap: var(--sp-16); flex-wrap: wrap; padding-block-end: var(--sp-16);
+    border-block-end: 1px solid var(--trazo-fuerte); }
+  .masthead__id { font: var(--tipo-h3); display: inline-flex; align-items: center; gap: var(--sp-12); }
+  /* Monograma canónico: disco + «m» Fraunces itálica + constelación. Pintado con roles,
+     así se invierte solo (día: disco berenjena/m crema · noche: disco crema/m berenjena). */
+  .monograma { inline-size: 34px; block-size: 34px; flex: none; border-radius: 8px; }
+  .masthead__meta { font: 600 var(--texto-sm)/1 var(--font-mono); color: var(--texto-3);
+    font-variant-numeric: tabular-nums; }
+  .modo { background: none; border: 0; cursor: pointer; min-height: 44px; padding: 0 var(--sp-8);
+    display: inline-flex; align-items: center;
+    font: 600 var(--texto-sm)/1 var(--font-mono); color: var(--identidad); letter-spacing: .04em; }
+  .modo .estrella { display: inline-block; transition: transform var(--dur-transicion) var(--curva-salida); }
+  /* Constelación-navegación REAL: 4 estrellas = 4 capítulos, enlaces enfocables (≥44px). */
+  .constelacion-nav { display: inline-flex; align-items: center; gap: var(--sp-16);
+    position: relative; margin-block: var(--sp-16) 0; }
+  .constelacion-nav::before { content: ""; position: absolute; inset-inline: 22px; inset-block-start: 50%;
+    block-size: 1px; background: var(--trazo-medio); z-index: 0; }
+  .cnav { position: relative; z-index: 1; inline-size: 44px; block-size: 44px;
+    display: grid; place-items: center; border-radius: var(--radius-pill); }
+  .cnav::after { content: ""; inline-size: 12px; block-size: 12px; background: var(--trazo-fuerte);
+    -webkit-mask: var(--estrella-svg) center/contain no-repeat; mask: var(--estrella-svg) center/contain no-repeat;
+    transition: background var(--dur-micro) var(--curva-salida), transform var(--dur-micro) var(--curva-salida); }
+  .cnav:hover::after, .cnav:focus-visible::after { background: var(--identidad); transform: scale(1.15); }
+
+  /* Portada: aire generoso arriba (sin capitular) */
+  .portada { padding-block: var(--sp-64) var(--sp-48); max-inline-size: 22ch; }
+  .portada h1 { font: var(--tipo-h1); letter-spacing: var(--track-cifra); margin: 0; text-wrap: balance;
+    font-variation-settings: "opsz" 40, "SOFT" 0, "WONK" 0; }   /* coherente con .titulo-1 (afinado) */
+  .cuerpo { text-wrap: pretty; }                                 /* sin viudas ni huérfanas */
+  .cita { hanging-punctuation: first last; }                     /* comillas al margen */
+  .spinner--muestra::after { animation-play-state: paused; }     /* espécimen: no late (doctrina «solo el presente respira») */   /* Fraunces variable (si carga) */
+  .portada .sub { font: var(--tipo-body); color: var(--texto-2); max-inline-size: 46ch; margin-block-start: var(--sp-16); }
+  /* (capitular retirada 9-jul, decisión de Miriam) */
+
+  /* Selección de texto: tinta propia (invierte roles; en noche se invierte sola) */
+  ::selection { background: var(--texto-1); color: var(--fondo); }
+
+  /* Ejes ópticos de Fraunces: display grande con opsz alto y un punto de WONK
+     (humanidad DENTRO de la fuente); el cuerpo queda recto. */
+  .titulo-1 { font-variation-settings: "opsz" 40, "SOFT" 0, "WONK" 0; }
+  .cifra    { font-variation-settings: "opsz" 84, "SOFT" 0, "WONK" 1; }
+  .titulo-2, .titulo-3 { font-variation-settings: "opsz" 40; }
+
+  /* Dos trazos de coral DISTINTOS (paths propios), con sobreimpresión multiply.
+     EL momento orquestado del sistema: el trazo de portada se dibuja UNA vez al
+     cargar (≤1s, detenible por reduced-motion vía token layer). Nada más se mueve. */
+  /* El trazo va POR DEBAJO de la linea base: no pisa ni un pixel de glifo.
+     SIN mix-blend-mode: `.libro` crea contexto de apilamiento (position+z-index) y AISLA el
+     blending -> el multiply era un no-op; y si algun dia dejara de estarlo, en noche fundiria
+     el texto crema contra la berenjena. No aporta nada y arriesga todo. Fuera. */
+  .trazo, .trazo-2 { background-repeat: no-repeat; background-position: 0 100%; background-size: 100% .30em;
+    padding-block-end: .30em; }
+  .trazo { animation: trazo-dibuja .9s var(--curva-salida) .35s backwards; }
+  @keyframes trazo-dibuja { from { background-size: 0% .30em; } to { background-size: 100% .30em; } }
+  /* Subrayado del hero: forma "two-faces" de helpmiriam.com (SVG inline, geometría exacta) — color coral (nuestro trazo aprobado) */
+  .two-faces { position: relative; white-space: nowrap; }
+  .two-faces__stroke { position: absolute; left: -1.5%; bottom: -0.22em; width: 103%; height: 0.34em; overflow: visible; pointer-events: none; }
+  .tf-line { fill: none; stroke: var(--identidad); stroke-width: 2.6; stroke-linecap: round; }
+  @media (prefers-reduced-motion: no-preference) {
+    .tf-line { stroke-dasharray: 1; stroke-dashoffset: 1; animation: tf-draw .55s var(--curva-salida, ease-out) .35s forwards; }
+    @keyframes tf-draw { to { stroke-dashoffset: 0; } }
+  }
+  /* CON PRESIÓN: paths RELLENOS de anchura variable (el stroke de grosor constante era
+     rotulador de máquina). Dos gestos distintos: el de portada carga al entrar y se afina
+     al soltar; el de la cita nace fino, engorda en medio y muere fino. Escrito a mano.
+     Trazo en VIOLETA identidad (coral = solo acción). Resuelto 10-jul por Miriam. */
+  .trazo   { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='8' viewBox='0 0 100 8' preserveAspectRatio='none'%3E%3Cpath d='M2 5.4C16 3.4,38 7,58 4.8C74 3.2,90 6,98 4.6' fill='none' stroke='%239d44ab' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E"); }
+  .trazo-2 { background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='8' viewBox='0 0 100 8' preserveAspectRatio='none'%3E%3Cpath d='M2 4.6C18 6.6,40 2.6,60 5C78 6.8,90 3.4,98 5.2' fill='none' stroke='%239d44ab' stroke-width='2.6' stroke-linecap='round'/%3E%3C/svg%3E"); }
+
+  /* Capítulo: rail de marginalia (folio + notas) + cuerpo. Orden DOM = lectura. */
+  .cap { display: grid; grid-template-columns: 12ch 1fr; column-gap: var(--sp-48); row-gap: var(--sp-16);
+    margin-block-start: var(--sp-96); align-items: start; }
+  .rail { grid-column: 1; text-align: right; }
+  .cuerpo-cap { grid-column: 2; max-inline-size: 68ch; }
+  h2.folio { margin: 0; }
+  .folio .num { display: block; font: 600 var(--texto-sm)/1.2 var(--font-mono); color: var(--texto-3);
+    font-variant-numeric: lining-nums tabular-nums; }
+  .folio .tit { display: block; margin-block-start: var(--sp-4);
+    font: var(--tipo-h3); font-variant: small-caps; letter-spacing: .06em; color: var(--texto-1);
+    font-variation-settings: "opsz" 40; }
+  .rail .marg { margin-block-start: var(--sp-24); font: var(--tipo-body-sm); color: var(--texto-3); }
+  @media (max-width: 760px) {
+    .cap { grid-template-columns: 1fr; }
+    .rail { text-align: left; } .cuerpo-cap { grid-column: 1; }
+  }
+  /* UNA página se desmadra: el capítulo 02 sale del rail y va a sangre (canon §3.5:
+     jerarquía > simetría; un cuadernillo real no repite el mismo ritmo cuatro veces). */
+  @media (min-width: 761px) {
+    #cap-2 .rail { grid-column: 1 / -1; text-align: left; margin-block-end: var(--sp-8); }
+    #cap-2 .cuerpo-cap { grid-column: 1 / -1; max-inline-size: none; }
+    #cap-2 .titulo-1 { font-size: clamp(44px, 7vw, 92px); }
+    /* Cada capítulo con su propio ritmo (no solo el 02) — sin cambiar el orden de lectura (ND-safe) */
+    #cap-1 { margin-block-start: calc(var(--sp-96) + var(--sp-32) + var(--sp-12)); }
+    #cap-1 .folio .num { font: 600 clamp(56px, 8vw, 100px)/.85 var(--font-display); color: var(--identidad); opacity: .13; letter-spacing: -.03em; }
+    #cap-3 { margin-block-start: var(--sp-64); }
+    #cap-4 { margin-block-start: var(--sp-96); column-gap: var(--sp-32); border-block-start: 1.5px solid var(--identidad); padding-block-start: var(--sp-32); }
+  }
+
+  /* Color como PROPORCIÓN trabajando (sin rótulo "60/30/10") */
+  .proporcion { display: flex; block-size: 132px; border-radius: var(--radius-sm); overflow: hidden;
+    font: 600 12px/1.3 var(--font-mono); }
+  .proporcion > div { display: flex; flex-direction: column; justify-content: flex-end; padding: var(--sp-8); }
+  .p-crema { flex: 60; background: var(--color-bg); color: var(--color-text); }
+  .p-ber   { flex: 30; background: var(--color-text); color: var(--color-bg); }
+  .p-coral { flex: 10; background: var(--color-cta); color: var(--color-text); }  /* canon D3: coral porta berenjena (5.57:1) */
+  /* Muestras de gouache de taller (no chips Pantone): borde irregular + nota de mezcla */
+  .taller { display: flex; gap: var(--sp-16); margin-block-start: var(--sp-16); flex-wrap: wrap; }
+  .muestra { flex: 1 1 120px; }
+  .muestra .mancha { block-size: 52px; box-shadow: inset 0 0 0 1px var(--trazo-medio); }
+  /* Desiguales a mano: ni el mismo alto ni el mismo contorno ni el mismo giro (la clonación exacta delata sistema) */
+  .taller .muestra:nth-child(1) .mancha { block-size: 60px; border-radius: 8px 13px 7px 15px/12px 6px 16px 9px; transform: rotate(-.9deg); }
+  .taller .muestra:nth-child(2) .mancha { block-size: 46px; border-radius: 14px 7px 12px 8px/7px 15px 6px 13px; transform: rotate(.7deg); }
+  .taller .muestra:nth-child(3) .mancha { block-size: 55px; border-radius: 9px 16px 8px 12px/14px 7px 13px 8px; transform: rotate(-.4deg); }
+  .taller .muestra:nth-child(4) .mancha { block-size: 43px; border-radius: 15px 8px 13px 7px/8px 14px 9px 15px; transform: rotate(1.1deg); }
+  .muestra .hx { display: block; margin-block-start: var(--sp-4);
+    font: 600 11px/1.35 var(--font-mono); color: var(--texto-3); font-variant-numeric: tabular-nums; }
+
+  .rampa { display: flex; block-size: 40px; border-radius: var(--radius-sm); overflow: hidden; }
+  .rampa > i { flex: 1; }
+  .umbral { margin-block-start: var(--sp-4); font: 600 11px/1.3 var(--font-mono); color: var(--cta-texto); }
+
+  /* Cita fuera de escala */
+  .cita { margin-block: var(--sp-48); max-inline-size: 24ch; border: 0; padding: 0;
+    font: italic 600 clamp(28px, 4.5vw, 52px)/1.12 var(--font-display); color: var(--texto-1);
+    text-indent: -.5ch; font-variation-settings: "opsz" 48, "WONK" 1; }
+
+  .grupo-btn { display: flex; gap: var(--sp-16); flex-wrap: wrap; align-items: center; }
+
+  /* Lámina nocturna: capítulo a sangre, con constelación REAL anotada (placa de observatorio) */
+  .lamina { margin-block-start: var(--sp-96); padding: var(--sp-64) var(--sp-32);
+    background: var(--fondo); position: relative; z-index: 1;
+    --astro: var(--color-bg); }
+  /* En NOCHE la Lámina SE INVIERTE: una placa de DÍA dentro de la noche. El concepto
+     de «lámina» sobrevive al toggle en vez de disolverse en el fondo. */
+  [data-tema="oscuro"] .lamina.oscuro {
+    --fondo: var(--color-bg); --superficie: var(--color-bg-card);
+    --texto-1: var(--color-text); --texto-2: var(--color-text-soft);
+    --texto-3: color-mix(in srgb, var(--color-text-soft) 72%, var(--color-bg));
+    --identidad: var(--color-miriam); --anillo-foco: var(--color-miriam);
+    --cta-texto: var(--color-text);
+    --trazo-sutil:  color-mix(in srgb, var(--color-text) 8%,  transparent);
+    --trazo-medio:  color-mix(in srgb, var(--color-text) 12%, transparent);
+    --trazo-fuerte: color-mix(in srgb, var(--color-text) 20%, transparent);
+    --trazo-interactivo: color-mix(in srgb, var(--color-text) 55%, transparent);  /* borde de controles ≥3:1 sobre crema (3.59) — MCP/Ceci */
+    --astro: var(--color-text);
+  }
+  .lamina-in { max-inline-size: 1180px; margin-inline: auto; position: relative; }
+  .placa { inline-size: 100%; max-inline-size: 420px; block-size: auto; margin-block-end: var(--sp-32);
+    display: block; }
+  .placa .via { stroke: color-mix(in srgb, var(--astro) 34%, transparent); stroke-width: 1; fill: none; }
+  .placa .indicador { stroke: color-mix(in srgb, var(--astro) 52%, transparent); stroke-width: .8; fill: none; }
+  /* Círculo a lápiz de la astrónoma sobre la placa: abierto, irregular, no cierra. */
+  .placa .lapiz { stroke: color-mix(in srgb, var(--astro) 58%, transparent); stroke-width: .9;
+    fill: none; stroke-linecap: round; }
+  .placa .anota { font: 600 10px/1 var(--font-mono); fill: var(--texto-3);   /* rol: AA en ambos sentidos (5.80 noche / 4.89 día) */
+    letter-spacing: .04em; font-variant-numeric: lining-nums; }
+  .lamina .texto { max-inline-size: 60ch; }   /* zona-segura: texto en columna, sin estrellas detrás */
+  .registro { vertical-align: -1px; margin-inline-end: 6px; opacity: .55; }
+  .pie-lamina { margin-block-start: var(--sp-32); padding-block-start: var(--sp-8);
+    border-block-start: 1px solid var(--trazo-medio);
+    font: 600 var(--texto-sm)/1.4 var(--font-mono); font-variant-numeric: tabular-nums; }
+</style>
+</head>
+<body>
+<a class="saltar" href="#main">Saltar al contenido</a>
+<div class="grano" aria-hidden="true"></div>
+<div class="libro">
+
+  <header class="masthead">
+    <span class="masthead__id">
+      <svg class="monograma" viewBox="0 0 64 64" role="img" aria-label="Beyond the Protocol">
+        <rect width="64" height="64" rx="14" style="fill:var(--texto-1)"/>
+        <text x="32" y="46" text-anchor="middle" font-size="40" font-weight="600" font-style="italic"
+              font-family="Fraunces, Georgia, serif" letter-spacing="-0.02em" style="fill:var(--fondo)">m</text>
+        <path d="M12 16 12.7 18 14.7 18.7 12.7 19.4 12 21.4 11.3 19.4 9.3 18.7 11.3 18Z" style="fill:var(--identidad)"/>
+        <path d="M52 14 53 17 56 18 53 19 52 22 51 19 48 18 51 17Z" style="fill:var(--fondo)"/>
+        <path d="M50 50 50.7 52 52.7 52.7 50.7 53.4 50 55.4 49.3 53.4 47.3 52.7 49.3 52Z" style="fill:var(--identidad)"/>
+        <circle cx="14" cy="48" r="1" style="fill:var(--fondo)" opacity=".7"/>
+        <circle cx="56" cy="32" r="1" style="fill:var(--fondo)" opacity=".5"/>
+      </svg>
+      Beyond the Protocol · <span class="masthead__meta">Design System v2</span></span>
+    <button class="modo" id="toggle" aria-pressed="false">DÍA <svg class="estrella" width="11" height="11" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 1.6C10.8 5 11.4 6.2 12.6 7.4 14 8.8 16.4 9.4 18.4 10 16.2 10.8 14.2 11.4 12.8 12.7 11.5 13.9 10.9 15.7 10 18.4 9.3 15.9 8.5 14.2 7.2 12.9 5.8 11.6 3.4 10.7 1.6 10 3.8 9.1 5.8 8.4 7.2 7.1 8.4 6 9.2 4.2 10 1.6Z" fill="currentColor"/></svg> NOCHE</button>
+  </header>
+  <!-- Constelación-navegación REAL: los 4 capítulos son 4 estrellas enlazadas -->
+  <nav class="constelacion-nav" aria-label="Capítulos">
+    <a class="cnav" href="#cap-1" aria-label="01 · Color"></a>
+    <a class="cnav" href="#cap-2" aria-label="02 · Tipografía"></a>
+    <a class="cnav" href="#cap-3" aria-label="03 · Componentes"></a>
+    <a class="cnav" href="#cap-4" aria-label="04 · Datos"></a>
+  </nav>
+
+  <main id="main">
+  <div class="portada">
+    <h1>Un lenguaje, no una <span class="two-faces">plantilla<svg class="two-faces__stroke" viewBox="0 0 100 8" preserveAspectRatio="none" aria-hidden="true"><path class="tf-line" pathLength="1" d="M2 5.4 C 16 3.4, 38 7, 58 4.8 C 74 3.2, 90 6, 98 4.6"/></svg></span>.</h1>
+    <p class="sub">Cada componente pinta con tokens de rol y se remapea solo en claro, en noche y en banda oscura. Los colores los fija Ceci; aquí no se mueve ni un hex.</p>
+  </div>
+
+  <!-- 01 · COLOR -->
+  <section class="cap" id="cap-1" aria-labelledby="t-1">
+    <div class="rail">
+      <h2 class="folio" id="t-1"><span class="num" aria-hidden="true">01</span><span class="tit">Color</span></h2>
+      <p class="marg">La paleta no es democrática: crema en masa, berenjena en estructura, coral en gotas.</p>
     </div>
-  </body>
+    <div class="cuerpo-cap">
+      <div class="proporcion">
+        <div class="p-crema">crema</div>
+        <div class="p-ber">berenjena</div>
+        <div class="p-coral">coral</div>
+      </div>
+      <div class="taller">
+        <div class="muestra"><div class="mancha" style="background:var(--color-miriam)"></div><span class="hx">#9d44ab · miriam</span></div>
+        <div class="muestra"><div class="mancha" style="background:var(--color-miriam-soft)"></div><span class="hx">#e8d4ed · soft</span></div>
+        <div class="muestra"><div class="mancha" style="background:var(--color-text-soft)"></div><span class="hx">#3a3340 · tinta</span></div>
+        <div class="muestra"><div class="mancha" style="background:var(--color-miriam-claro)"></div><span class="hx">#c77dd2 · on-dark</span></div>
+      </div>
+      <p style="margin-block-start:var(--sp-32);font:var(--tipo-body-sm);color:var(--texto-2)">Data-viz clínica — diverging berenjena↔coral (CVD-safe, sin rojo/verde). Solo datos sintéticos en público.</p>
+      <div class="rampa" style="margin-block-start:var(--sp-8)">
+        <i style="background:var(--viz-div-1)"></i><i style="background:var(--viz-div-2)"></i><i style="background:var(--viz-div-3)"></i><i style="background:var(--viz-div-mid)"></i><i style="background:var(--viz-div-5)"></i><i style="background:var(--viz-div-6)"></i><i style="background:var(--viz-div-7)"></i>
+      </div>
+      <p class="umbral">↑ el color nunca es la única señal: siempre icono + etiqueta + forma</p>
+    </div>
+  </section>
+
+  <!-- Cita fuera de escala -->
+  <blockquote class="cita">El sistema no es la misión: es lo que deja que <span class="trazo-2">llegue entera</span>.</blockquote>
+
+  <!-- 02 · TIPOGRAFÍA -->
+  <section class="cap" id="cap-2" aria-labelledby="t-2">
+    <div class="rail">
+      <h2 class="folio" id="t-2"><span class="num" aria-hidden="true">02</span><span class="tit">Tipografía</span></h2>
+      <p class="marg">Fraunces display, Hanken cuerpo, mono SOLO para datos y metadatos. Saltos de línea a mano.</p>
+    </div>
+    <div class="cuerpo-cap">
+      <p class="eyebrow">Beyond the Protocol · especimen</p>
+      <p class="titulo-1">Fraunces, la voz</p>
+      <p class="cuerpo">El cuerpo va en Hanken Grotesk: cálida, legible, sin pose. La medida se limita a 65ch para que el ojo no se pierda. La tipografía trabaja; no posa.</p>
+      <p class="cifra" style="margin-block-start:var(--sp-24)">1.247 <span class="cuerpo-sm">personas alcanzadas · ejemplo sintético</span></p>
+    </div>
+  </section>
+
+  <!-- 03 · COMPONENTES -->
+  <section class="cap" id="cap-3" aria-labelledby="t-3">
+    <div class="rail">
+      <h2 class="folio" id="t-3"><span class="num" aria-hidden="true">03</span><span class="tit">Componentes</span></h2>
+      <p class="marg">En contexto, no en matriz. Primario coral: 1 por vista. Foco visible al tabular. ≥44px.</p>
+    </div>
+    <div class="cuerpo-cap">
+      <div class="grupo-btn">
+        <button class="btn btn--primary">Enviar</button>
+        <button class="btn btn--secondary">Guardar borrador</button>
+        <button class="btn btn--ghost">Descartar</button>
+      </div>
+
+      <div class="card card--flotante" style="margin-block-start:var(--sp-32);max-inline-size:460px">
+        <div class="campo-grupo">
+          <label class="etiqueta" for="e">Tu correo</label>
+          <input class="campo" id="e" placeholder="nombre@dominio.com">
+        </div>
+        <div class="campo-grupo" style="margin-block-start:var(--sp-16)">
+          <label class="etiqueta" for="e2">Con error (sin rojo de alarma)</label>
+          <input class="campo" id="e2" aria-invalid="true" aria-describedby="e2-error" value="correo mal escrito">
+          <span class="campo-error" id="e2-error">Revisa el formato del correo</span>
+        </div>
+        <div class="grupo-btn" style="margin-block-start:var(--sp-16);gap:var(--sp-24)">
+          <label style="display:flex;gap:var(--sp-8);align-items:center"><input type="checkbox" class="check" checked> Acepto</label>
+          <button class="btn btn--secondary">Confirmar</button>
+        </div>
+      </div>
+
+      <div style="margin-block-start:var(--sp-32);display:flex;gap:var(--sp-16);flex-wrap:wrap;align-items:center">
+        <span class="badge badge--genomic">marcador · ejemplo</span>
+        <span class="badge">etiqueta</span>
+      </div>
+      <div style="margin-block-start:var(--sp-24);max-inline-size:520px">
+        <div class="alerta"><span class="alerta__label">Nota</span>El significado va por palabra, no por color de alarma.</div>
+        <div class="alerta alerta--accion" style="margin-block-start:var(--sp-16)"><span class="alerta__label">Acción</span>Filete coral, calmado. Ningún icono-estrella (la estrella es marca, no estado).</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 04 · DATOS -->
+  <section class="cap" id="cap-4" aria-labelledby="t-4">
+    <div class="rail">
+      <h2 class="folio" id="t-4"><span class="num" aria-hidden="true">04</span><span class="tit">Datos</span></h2>
+      <p class="marg">Cifras tabulares alineadas a la derecha. Datos sintéticos (muro). Scroll enfocable por teclado.</p>
+    </div>
+    <div class="cuerpo-cap">
+      <div class="tabla-scroll" tabindex="0" role="region" aria-label="Tabla: métricas del flujo (datos sintéticos)">
+        <table class="tabla">
+          <caption class="sr-cap">Métricas del flujo de muestra (datos sintéticos)</caption>
+          <thead><tr><th scope="col">Etapa del flujo</th><th scope="col">Gate de calidad</th><th scope="col" class="num">Valor</th></tr></thead>
+          <tbody>
+            <tr><td>Preservación / QC</td><td>DV200</td><td class="num">74%</td></tr>
+            <tr><td>Extracción / secuenciación</td><td>Profundidad</td><td class="num">118×</td></tr>
+            <tr><td>HLA / expresión</td><td>%rank</td><td class="num">0.47</td></tr>
+            <tr><td>Priorización</td><td>Candidatos</td><td class="num">23</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="timeline" style="margin-block-start:var(--sp-32)">
+        <div class="hito"><span class="hito-nodo"></span><p class="titulo-3">Antes del protocolo</p><p class="cuerpo-sm">El mapa arranca aquí.</p></div>
+        <div class="hito presente"><span class="hito-nodo"></span><p class="titulo-3">Presente</p><p class="cuerpo-sm">Solo el presente respira (detenible; respeta reduced-motion).</p></div>
+        <div class="hito"><span class="hito-nodo"></span><p class="titulo-3">Más allá del protocolo</p><p class="cuerpo-sm">A donde va todo esto.</p></div>
+      </div>
+    </div>
+  </section>
+  </main>
+</div>
+
+<!-- LÁMINA I — NOCHE · constelación real anotada (placa de observatorio) -->
+<section class="lamina oscuro" aria-label="Lámina I — Noche">
+  <div class="lamina-in">
+    <svg class="placa" viewBox="0 0 420 150" aria-hidden="true">
+      <path class="via" d="M40 44 L120 100 L210 40 L300 104 L380 54"/>
+      <circle cx="40"  cy="44"  r="3.6" style="fill:var(--astro)"/>
+      <circle cx="120" cy="100" r="3.8" style="fill:var(--astro)"/>
+      <circle cx="210" cy="40"  r="4.1" style="fill:var(--astro)"/>
+      <circle cx="300" cy="104" r="2.8" style="fill:color-mix(in srgb, var(--astro) 55%, transparent)"/>
+      <circle cx="380" cy="54"  r="2.1" style="fill:color-mix(in srgb, var(--astro) 55%, transparent)"/>
+      <path class="lapiz" d="M386.5 47.4c4.6 2.4 5.6 8.4 2.2 12.2-3.6 4-10.6 4.2-14.6.4-3.8-3.6-3-9.8 1.2-12.6 2.4-1.6 5.4-1.8 8-.8"/>
+      <path class="indicador" d="M362 71C368 66,372 62,377 57"/>
+      <text class="anota" x="250" y="90" transform="rotate(-3 250 90)">Cas · ε — Segin · 3.37 mag</text>
+    </svg>
+    <div class="texto">
+      <p class="eyebrow">Bitácora · Lámina I</p>
+      <h2 class="titulo-1" style="max-inline-size:16ch">El cosmos, contenido</h2>
+      <p class="cuerpo" style="margin-block-start:var(--sp-16)">Los mismos componentes, remapeados por el modificador <code style="font-family:var(--font-mono)">.oscuro</code>. La noche no es un filtro: es un lugar diseñado, y el cielo solo vive aquí.</p>
+      <div class="grupo-btn" style="margin-block-start:var(--sp-24)">
+        <button class="btn btn--primary">Acción</button>
+        <button class="btn btn--secondary-inverse">Secundario inverso</button>
+        <span class="badge badge--genomic">marcador · ejemplo</span>
+        <span class="spinner spinner--muestra" aria-hidden="true"></span>
+        <span style="font:600 11px/1 var(--font-mono);color:var(--texto-2)">(late solo al cargar)</span>
+      </div>
+      <p class="pie-lamina"><svg class="registro" width="11" height="11" viewBox="0 0 12 12" aria-hidden="true"><circle cx="6" cy="6" r="4.2" fill="none" stroke="currentColor" stroke-width=".7"/><path d="M6 .8v10.4M.8 6h10.4" stroke="currentColor" stroke-width=".7"/></svg> Lámina I — Noche · la estrella orienta, no decora · #9d44ab → #c77dd2 on-dark</p>
+    </div>
+  </div>
+</section>
+
+<footer style="position:relative;z-index:1;max-inline-size:1180px;margin-inline:auto;padding:var(--sp-24) var(--sp-32) var(--sp-32);border-block-start:1px solid var(--trazo-medio);font:500 var(--texto-sm)/1.5 var(--font-mono);color:var(--texto-3)">
+  <p>Cuadernillo construido en colaboración con Claude (Anthropic) · <a href="https://github.com/BeyondTheProtocol/miriam-gonzalez-case" style="color:var(--identidad);text-decoration:underline;text-underline-offset:2px">código en GitHub</a></p>
+</footer>
+
+<script>
+  const t = document.getElementById('toggle');
+  const root = document.documentElement;
+  const apply = () => {
+    const dark = root.getAttribute('data-tema') === 'oscuro';
+    if (dark) root.removeAttribute('data-tema'); else root.setAttribute('data-tema', 'oscuro');
+    t.setAttribute('aria-pressed', String(!dark));
+    const e = t.querySelector('.estrella');
+    if (e) e.style.transform = dark ? '' : 'rotate(45deg)';
+  };
+  t.addEventListener('click', () => {
+    const rm = matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (document.startViewTransition && !rm) document.startViewTransition(apply);  // día↔noche = LA transformación de la marca
+    else apply();
+  });
+</script>
+</body>
 </html>


### PR DESCRIPTION
**Unifica todo el trabajo del design system en una sola página.** Adopta el "cuadernillo v2" (de #151) como base y le injerta lo que le faltaba. **Supersede y cierra #160 y #151.**

## Por qué v2 como base
v2 es una reescritura minimalista y elegante (**819 líneas** vs las 6646 del export viejo): tipografía Hanken Grotesk + Fraunces embebidas (sin CDN), a11y verificada con el motor de Ceci, y datos de ejemplo sintéticos. Es mejor página que el fichero viejo que #160 pulía.

## Injertado sobre v2 (comité diseño + validación Ceci)
- **SEO / Open Graph** + canonical + twitter cards (no había ninguno → ahora un link compartido tendrá preview). Sin `og:image` todavía (asset a generar).
- **Colofón** con crédito «construido en colaboración con Claude (Anthropic)» + **link al repo vivo** (`BeyondTheProtocol/miriam-gonzalez-case`, no el fork obsoleto). Encaja como créditos de composición de un cuadernillo impreso, sin romper el minimalismo.
- `z-index:1` al colofón (aislamiento del grano; recomendación de Ceci).

## Datos
Cero datos reales **privados** (gmail, hospital, nombres de terceros, cifras de campaña). Los marcadores moleculares públicos no son un problema (tesis abierta), pero v2 usa ejemplos sintéticos genéricos — y de paso **saca del repo los ficticios XLR2/PLX9** de la vía anterior.

## Validación Ceci (a11y, su muro)
Colofón pasa AA en día y noche (texto 4.89/5.80, link 5.07/5.46), foco ≥3:1. Sin decisiones de color pendientes.

## Pendiente (aparte)
- `og:image` 1200×630 + `apple-touch-icon` PNG (assets a generar).
- Pase `voz-miriam` al copy nuevo (meta description + colofón).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
