### PR TITLE
Fase 3 · Migración DS: colores de componentes (<style>) → tokens

### DIFF
--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -153,7 +153,7 @@ function jumpTo(e: Event, id: string) {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  border-left: 1px solid rgba(45, 27, 61, 0.12);
+  border-left: 1px solid rgb(var(--color-text-rgb) / 0.12);
 }
 .cn-d__link {
   display: flex;
@@ -164,7 +164,7 @@ function jumpTo(e: Event, id: string) {
   border-left: 2px solid transparent;
   font-size: 13.5px;
   line-height: 1.3;
-  color: rgba(45, 27, 61, 0.58);
+  color: rgb(var(--color-text-rgb) / 0.58);
   text-decoration: none;
   transition: color 0.18s ease, border-color 0.18s ease;
 }
@@ -177,27 +177,27 @@ function jumpTo(e: Event, id: string) {
   transition: background 0.18s ease;
 }
 .cn-d__link:hover {
-  color: #2d1b3d;
+  color: var(--color-text);
 }
 .cn-d__link.is-active {
-  color: #2d1b3d;
+  color: var(--color-text);
   font-weight: 600;
-  border-left-color: #9d44ab;
+  border-left-color: var(--color-miriam);
 }
 .cn-d__link.is-active .cn-d__dot {
-  background: #9d44ab;
+  background: var(--color-miriam);
 }
 .cn-d__link:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
   border-radius: 2px;
 }
 
 /* Móvil */
 .cn-m {
-  border: 1px solid rgba(45, 27, 61, 0.12);
+  border: 1px solid rgb(var(--color-text-rgb) / 0.12);
   border-radius: 12px;
-  background: #f5efe6;
+  background: var(--color-bg-card);
 }
 .cn-m__summary {
   display: flex;
@@ -209,7 +209,7 @@ function jumpTo(e: Event, id: string) {
   font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #2d1b3d;
+  color: var(--color-text);
   cursor: pointer;
   list-style: none;
 }
@@ -232,13 +232,13 @@ function jumpTo(e: Event, id: string) {
   display: block;
   padding: 9px 0;
   font-size: 14px;
-  color: #2d1b3d;
+  color: var(--color-text);
   text-decoration: none;
-  border-top: 1px solid rgba(45, 27, 61, 0.07);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.07);
 }
 .cn-m__summary:focus-visible,
 .cn-m__list a:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/components/DaysWaitingCounter.vue
+++ b/app/components/DaysWaitingCounter.vue
@@ -19,7 +19,7 @@ const { days } = useDaysWaiting()
 
 <style scoped>
 .counter-tag {
-  background: rgba(255, 107, 71, 0.1);
-  border: 1px solid rgba(255, 107, 71, 0.3);
+  background: rgb(var(--color-cta-rgb) / 0.1);
+  border: 1px solid rgb(var(--color-cta-rgb) / 0.3);
 }
 </style>

--- a/app/components/DonationReturnPrompt.vue
+++ b/app/components/DonationReturnPrompt.vue
@@ -92,8 +92,8 @@ onBeforeUnmount(() => document.removeEventListener('visibilitychange', maybeShow
   margin-left: auto;
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  background: #2d1b3d;
-  box-shadow: 0 16px 40px -12px rgba(45, 27, 61, 0.5);
+  background: var(--color-text);
+  box-shadow: 0 16px 40px -12px rgb(var(--color-text-rgb) / 0.5);
 }
 /* Sobre la barra de apoyo persistente (<lg). En desktop queda abajo a la derecha. */
 @media (max-width: 1023px) {
@@ -109,7 +109,7 @@ onBeforeUnmount(() => document.removeEventListener('visibilitychange', maybeShow
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.78rem;
   font-weight: 600;
-  color: #ff6b47;
+  color: var(--color-cta);
   text-decoration: none;
 }
 .drp__cta:hover {
@@ -123,11 +123,11 @@ onBeforeUnmount(() => document.removeEventListener('visibilitychange', maybeShow
   padding: 2px;
 }
 .drp__close:hover {
-  color: #faf6f0;
+  color: var(--color-bg);
 }
 .drp__cta:focus-visible,
 .drp__close:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
   border-radius: 4px;
 }

--- a/app/components/DonationsWall.vue
+++ b/app/components/DonationsWall.vue
@@ -306,7 +306,7 @@ function timeAgo(iso?: string): string {
   font-family: 'Fraunces', serif;
   font-size: 1.05rem;
   font-weight: 600;
-  color: #2d1b3d;
+  color: var(--color-text);
 }
 .dw-panel__search-row {
   display: flex;
@@ -330,7 +330,7 @@ function timeAgo(iso?: string): string {
   transform: translateY(-50%);
   width: 1.125rem;
   height: 1.125rem;
-  color: rgba(58, 51, 64, 0.45);
+  color: rgb(var(--color-text-soft-rgb) / 0.45);
   pointer-events: none;
 }
 .dw-search-field__input {
@@ -338,16 +338,16 @@ function timeAgo(iso?: string): string {
   min-height: 44px;
   padding: 10px 14px 10px 42px;
   border-radius: 12px;
-  border: 1px solid rgba(45, 27, 61, 0.14);
-  background: #faf6f0;
+  border: 1px solid rgb(var(--color-text-rgb) / 0.14);
+  background: var(--color-bg);
   font-size: 15px;
-  color: #2d1b3d;
+  color: var(--color-text);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .dw-search-field__input:focus-visible {
   outline: none;
-  border-color: rgba(157, 68, 171, 0.45);
-  box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.14);
+  border-color: rgb(var(--color-miriam-rgb) / 0.45);
+  box-shadow: 0 0 0 3px rgb(var(--color-miriam-rgb) / 0.14);
 }
 .dw-panel__submit {
   min-height: 44px;
@@ -372,13 +372,13 @@ function timeAgo(iso?: string): string {
   gap: 0.75rem;
   margin-top: 1.125rem;
   padding-top: 1rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.08);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.08);
 }
 .dw-segment {
   display: inline-flex;
   padding: 3px;
   border-radius: 9999px;
-  border: 1px solid rgba(45, 27, 61, 0.12);
+  border: 1px solid rgb(var(--color-text-rgb) / 0.12);
   background: rgba(250, 246, 240, 0.8);
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
@@ -390,16 +390,16 @@ function timeAgo(iso?: string): string {
   border: none;
   border-radius: 9999px;
   background: transparent;
-  color: #3a3340;
+  color: var(--color-text-soft);
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
 }
 .dw-segment__btn--on {
-  background: #2d1b3d;
-  color: #faf6f0;
+  background: var(--color-text);
+  color: var(--color-bg);
 }
 .dw-segment__btn:hover:not(.dw-segment__btn--on) {
-  color: #2d1b3d;
+  color: var(--color-text);
 }
 .dw-pager {
   display: inline-flex;
@@ -413,15 +413,15 @@ function timeAgo(iso?: string): string {
   width: 36px;
   height: 36px;
   border-radius: 9999px;
-  border: 1px solid rgba(45, 27, 61, 0.14);
-  background: #faf6f0;
-  color: #2d1b3d;
+  border: 1px solid rgb(var(--color-text-rgb) / 0.14);
+  background: var(--color-bg);
+  color: var(--color-text);
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 .dw-pager__btn:hover:not(:disabled) {
-  border-color: rgba(45, 27, 61, 0.28);
-  background: #f5efe6;
+  border-color: rgb(var(--color-text-rgb) / 0.28);
+  background: var(--color-bg-card);
 }
 .dw-pager__btn:disabled {
   opacity: 0.35;
@@ -431,13 +431,13 @@ function timeAgo(iso?: string): string {
   min-width: 4.5rem;
   text-align: center;
   font-size: 12px;
-  color: #3a3340;
+  color: var(--color-text-soft);
 }
 .dw-segment__btn:focus-visible,
 .dw-pager__btn:focus-visible,
 .dw-row:focus-visible,
 button:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
 }
 .dw-row {
@@ -446,14 +446,14 @@ button:focus-visible {
 }
 .dw-row:hover,
 .dw-row:focus-visible {
-  background: rgba(157, 68, 171, 0.06);
+  background: rgb(var(--color-miriam-rgb) / 0.06);
   outline: none;
 }
 .dw-row--active {
-  background: rgba(255, 107, 71, 0.08);
+  background: rgb(var(--color-cta-rgb) / 0.08);
 }
 .dw-row:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: -2px;
 }
 </style>

--- a/app/components/GoFundMeProgress.vue
+++ b/app/components/GoFundMeProgress.vue
@@ -373,7 +373,7 @@ function rowBg(i: number) {
   transform: translateX(2px);
 }
 .dw-donors-link:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
   border-radius: 4px;
 }
@@ -401,7 +401,7 @@ function rowBg(i: number) {
 }
 .ms-tick--dark {
   height: 8px;
-  background: rgba(45, 27, 61, 0.45);
+  background: rgb(var(--color-text-rgb) / 0.45);
 }
 .ms-amt {
   margin-top: 7px;
@@ -414,7 +414,7 @@ function rowBg(i: number) {
 /* Proyección «cuánto faltaría» al pinchar un hito del listado. Translúcida →
    se distingue del recaudado real (coral sólido) y no falsea la cifra. */
 .ms-ghost {
-  background: rgba(255, 107, 71, 0.32);
+  background: rgb(var(--color-cta-rgb) / 0.32);
   transition: width 0.35s ease, left 0.35s ease;
 }
 /* Filas del listado clicables (vista previa). */
@@ -425,10 +425,10 @@ function rowBg(i: number) {
   -webkit-tap-highlight-color: transparent;
 }
 .ms-row:hover {
-  background: rgba(255, 107, 71, 0.14) !important;
+  background: rgb(var(--color-cta-rgb) / 0.14) !important;
 }
 .ms-row:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: -2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/components/MapaSectionNav.vue
+++ b/app/components/MapaSectionNav.vue
@@ -144,7 +144,7 @@ function jumpTo(e: Event, id: string) {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  border-left: 1px solid rgba(45, 27, 61, 0.12);
+  border-left: 1px solid rgb(var(--color-text-rgb) / 0.12);
 }
 .mn-d__link {
   display: flex;
@@ -155,7 +155,7 @@ function jumpTo(e: Event, id: string) {
   border-left: 2px solid transparent;
   font-size: 13.5px;
   line-height: 1.3;
-  color: rgba(45, 27, 61, 0.72);
+  color: rgb(var(--color-text-rgb) / 0.72);
   text-decoration: none;
   transition: color 0.18s ease, border-color 0.18s ease;
 }
@@ -168,27 +168,27 @@ function jumpTo(e: Event, id: string) {
   transition: background 0.18s ease;
 }
 .mn-d__link:hover {
-  color: #2d1b3d;
+  color: var(--color-text);
 }
 .mn-d__link.is-active {
-  color: #2d1b3d;
+  color: var(--color-text);
   font-weight: 600;
-  border-left-color: #9d44ab;
+  border-left-color: var(--color-miriam);
 }
 .mn-d__link.is-active .mn-d__dot {
-  background: #9d44ab;
+  background: var(--color-miriam);
 }
 .mn-d__link:focus-visible {
-  outline: 2px solid #9d44ab;
+  outline: 2px solid var(--color-miriam);
   outline-offset: 2px;
   border-radius: 2px;
 }
 
 /* Móvil */
 .mn-m {
-  border: 1px solid rgba(45, 27, 61, 0.12);
+  border: 1px solid rgb(var(--color-text-rgb) / 0.12);
   border-radius: 12px;
-  background: #f5efe6;
+  background: var(--color-bg-card);
 }
 .mn-m__summary {
   display: flex;
@@ -200,7 +200,7 @@ function jumpTo(e: Event, id: string) {
   font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #2d1b3d;
+  color: var(--color-text);
   cursor: pointer;
   list-style: none;
 }
@@ -223,13 +223,13 @@ function jumpTo(e: Event, id: string) {
   display: block;
   padding: 9px 0;
   font-size: 14px;
-  color: #2d1b3d;
+  color: var(--color-text);
   text-decoration: none;
-  border-top: 1px solid rgba(45, 27, 61, 0.07);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.07);
 }
 .mn-m__summary:focus-visible,
 .mn-m__list a:focus-visible {
-  outline: 2px solid #9d44ab;
+  outline: 2px solid var(--color-miriam);
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/components/MarcasContactPrompt.vue
+++ b/app/components/MarcasContactPrompt.vue
@@ -207,8 +207,8 @@ onBeforeUnmount(teardownTriggers)
   margin-left: auto;
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  background: #2d1b3d;
-  box-shadow: 0 16px 40px -12px rgba(45, 27, 61, 0.5);
+  background: var(--color-text);
+  box-shadow: 0 16px 40px -12px rgb(var(--color-text-rgb) / 0.5);
 }
 /* Foco programático del contenedor al abrir: sin anillo (el aro accesible vive en
    los controles internos vía :focus-visible). El trap necesita un tabindex=-1
@@ -227,7 +227,7 @@ onBeforeUnmount(teardownTriggers)
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.78rem;
   font-weight: 600;
-  color: #c77dd2; /* miriam-claro — identidad sobre oscuro */
+  color: var(--color-miriam-claro); /* miriam-claro — identidad sobre oscuro */
   text-decoration: none;
 }
 .mcp__cta:hover {
@@ -241,11 +241,11 @@ onBeforeUnmount(teardownTriggers)
   padding: 2px;
 }
 .mcp__close:hover {
-  color: #faf6f0;
+  color: var(--color-bg);
 }
 .mcp__cta:focus-visible,
 .mcp__close:focus-visible {
-  outline: 2px solid #c77dd2;
+  outline: 2px solid var(--color-miriam-claro);
   outline-offset: 2px;
   border-radius: 4px;
 }

--- a/app/components/MobileSupportBar.vue
+++ b/app/components/MobileSupportBar.vue
@@ -137,7 +137,7 @@ onBeforeUnmount(() => {
   right: 0;
   bottom: 0;
   z-index: 40;
-  background: #2d1b3d; /* berenjena */
+  background: var(--color-text); /* berenjena */
   padding: 10px 16px 8px;
   padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
   border-top: 1px solid rgba(250, 246, 240, 0.12);
@@ -158,7 +158,7 @@ onBeforeUnmount(() => {
   padding-bottom: 2px;
 }
 .mobile-support-bar__more:hover {
-  color: #faf6f0;
+  color: var(--color-bg);
   text-decoration: underline;
   text-underline-offset: 3px;
 }

--- a/app/components/Nota.vue
+++ b/app/components/Nota.vue
@@ -28,16 +28,16 @@ defineProps<{ icon?: 'tap' }>()
   font-family: 'JetBrains Mono', monospace;
   font-size: 12px;
   line-height: 1.55;
-  color: rgba(58, 51, 64, 0.78);
+  color: rgb(var(--color-text-soft-rgb) / 0.78);
 }
 .nota-mark {
-  color: #9d44ab;
+  color: var(--color-miriam);
   flex-shrink: 0;
 }
 .nota-icon {
   width: 14px;
   height: 14px;
-  color: #9d44ab;
+  color: var(--color-miriam);
   flex-shrink: 0;
   align-self: center;
 }

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -375,7 +375,7 @@ const stats = computed(() => [
 .hero__portrait-frame {
   overflow: hidden;
   border-radius: 20px;
-  box-shadow: 0 18px 44px -22px rgba(45, 27, 61, 0.45);
+  box-shadow: 0 18px 44px -22px rgb(var(--color-text-rgb) / 0.45);
   aspect-ratio: 1;
 }
 
@@ -391,12 +391,12 @@ const stats = computed(() => [
   z-index: 2;
   padding: 0.35rem 0.7rem;
   border-radius: 999px;
-  background: #9d44ab;
-  color: #faf6f0;
+  background: var(--color-miriam);
+  color: var(--color-bg);
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;
   letter-spacing: 0.04em;
-  box-shadow: 0 8px 20px -8px rgba(45, 27, 61, 0.45);
+  box-shadow: 0 8px 20px -8px rgb(var(--color-text-rgb) / 0.45);
   transform: rotate(2deg);
 }
 @media (min-width: 640px) {
@@ -426,14 +426,14 @@ const stats = computed(() => [
 .hero__portrait-tag span {
   display: inline-block;
   border-radius: 999px;
-  background: #2d1b3d;
-  color: #faf6f0;
+  background: var(--color-text);
+  color: var(--color-bg);
   font-family: 'JetBrains Mono', monospace;
   font-size: 10px;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   padding: 0.4rem 0.9rem;
-  box-shadow: 0 10px 24px -12px rgba(45, 27, 61, 0.55);
+  box-shadow: 0 10px 24px -12px rgb(var(--color-text-rgb) / 0.55);
 }
 @media (min-width: 640px) {
   .hero__portrait-tag span {
@@ -491,7 +491,7 @@ const stats = computed(() => [
   margin: 0;
   font-size: 0.75rem;
   line-height: 1.45;
-  color: #3a3340;
+  color: var(--color-text-soft);
   min-height: 2.25rem;
 }
 /* En móvil los CTAs se apilan (1 col), no hay que igualar captions → sin hueco muerto. */
@@ -507,7 +507,7 @@ const stats = computed(() => [
 .hero__proof {
   margin-top: 2.5rem;
   padding-top: 1.75rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.1);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.1);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -568,14 +568,14 @@ const stats = computed(() => [
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.875rem;
   line-height: 1.45;
-  color: #9d44ab;
+  color: var(--color-miriam);
   text-decoration: underline;
-  text-decoration-color: rgba(157, 68, 171, 0.5);
+  text-decoration-color: rgb(var(--color-miriam-rgb) / 0.5);
   text-underline-offset: 3px;
   transition: text-decoration-color 0.15s ease;
 }
 .hero__latest:hover .hero__latest-title {
-  text-decoration-color: #9d44ab;
+  text-decoration-color: var(--color-miriam);
 }
 
 /* Stats · rejilla cerrada, alturas iguales. Sin divisor propio: cuelga de hero__proof. */
@@ -600,7 +600,7 @@ const stats = computed(() => [
 @media (min-width: 640px) {
   .hero__stat {
     padding-inline: 1.75rem;
-    border-left: 1px solid rgba(45, 27, 61, 0.14);
+    border-left: 1px solid rgb(var(--color-text-rgb) / 0.14);
     min-height: 5rem;
   }
   .hero__stat:first-child {
@@ -625,7 +625,7 @@ const stats = computed(() => [
   line-height: 1.35;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: #3a3340;
+  color: var(--color-text-soft);
   word-break: break-word;
 }
 @media (min-width: 1024px) {
@@ -658,7 +658,7 @@ const stats = computed(() => [
 }
 .tf-line {
   fill: none;
-  stroke: #9d44ab;
+  stroke: var(--color-miriam);
   stroke-width: 2.6;
   stroke-linecap: round;
 }
@@ -677,8 +677,8 @@ const stats = computed(() => [
   animation: hero-pulse 2s ease-in-out 3;
 }
 @keyframes hero-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 107, 71, 0.4); }
-  50% { box-shadow: 0 0 0 7px rgba(255, 107, 71, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgb(var(--color-cta-rgb) / 0.4); }
+  50% { box-shadow: 0 0 0 7px rgb(var(--color-cta-rgb) / 0); }
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-live-dot { animation: none; }

--- a/app/components/TeamPortrait.vue
+++ b/app/components/TeamPortrait.vue
@@ -58,14 +58,14 @@ const initial = computed(
   aspect-ratio: 1 / 1;
   overflow: hidden;
   border-radius: 16px;
-  background: #f5efe6; /* cream-card: el papel del retrato se funde con este tono */
-  border: 1px solid rgba(45, 27, 61, 0.08);
+  background: var(--color-bg-card); /* cream-card: el papel del retrato se funde con este tono */
+  border: 1px solid rgb(var(--color-text-rgb) / 0.08);
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .team-portrait:hover .team-portrait__frame {
   transform: translateY(-4px);
-  box-shadow: 0 16px 30px -18px rgba(45, 27, 61, 0.45);
+  box-shadow: 0 16px 30px -18px rgb(var(--color-text-rgb) / 0.45);
 }
 
 .team-portrait__img {
@@ -88,11 +88,11 @@ const initial = computed(
   font-weight: 500;
   font-size: 3.5rem;
   letter-spacing: -0.04em;
-  color: #9d44ab; /* miriam */
+  color: var(--color-miriam); /* miriam */
   background: linear-gradient(
     180deg,
-    rgba(157, 68, 171, 0.08),
-    rgba(157, 68, 171, 0.02)
+    rgb(var(--color-miriam-rgb) / 0.08),
+    rgb(var(--color-miriam-rgb) / 0.02)
   );
 }
 
@@ -120,14 +120,14 @@ const initial = computed(
   font-weight: 600;
   font-size: 20px;
   letter-spacing: -0.02em;
-  color: #2d1b3d; /* berenjena */
+  color: var(--color-text); /* berenjena */
   margin-top: 4px;
 }
 
 .team-portrait__desc {
   font-size: 13px;
   line-height: 1.55;
-  color: #3a3340; /* tinta */
+  color: var(--color-text-soft); /* tinta */
   margin-top: 8px;
 }
 

--- a/app/components/Term.vue
+++ b/app/components/Term.vue
@@ -382,7 +382,7 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
   text-decoration-style: dotted;
   text-decoration-thickness: 1.5px;
   text-underline-offset: 3px;
-  text-decoration-color: rgba(157, 68, 171, 0.6);
+  text-decoration-color: rgb(var(--color-miriam-rgb) / 0.6);
   transition: text-decoration-color 0.2s ease;
   white-space: normal;
   -webkit-tap-highlight-color: transparent;
@@ -392,10 +392,10 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
 .term:focus-visible,
 .term[aria-expanded='true'] {
   text-decoration-style: solid;
-  text-decoration-color: #9d44ab;
+  text-decoration-color: var(--color-miriam);
 }
 .term:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -403,8 +403,8 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
    de tooltip. Anula los resets de .term (sin subrayado, con fondo y padding). */
 .term--badge {
   display: inline-block;
-  background: #e8d4ed; /* miriam-soft */
-  color: #2d1b3d; /* berenjena */
+  background: var(--color-miriam-soft); /* miriam-soft */
+  color: var(--color-text); /* berenjena */
   border-radius: 9999px;
   padding: 4px 12px;
   font-family: 'JetBrains Mono', monospace;
@@ -422,8 +422,8 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
 .term--badge:focus-visible,
 .term--badge[aria-expanded='true'] {
   text-decoration: none;
-  border-color: #9d44ab; /* miriam */
-  box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.18);
+  border-color: var(--color-miriam); /* miriam */
+  box-shadow: 0 0 0 3px rgb(var(--color-miriam-rgb) / 0.18);
 }
 .term--badge:focus-visible {
   border-radius: 9999px;
@@ -438,13 +438,13 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
   z-index: 60;
   padding: 11px 13px;
   border-radius: 11px;
-  background: #2d1b3d;
-  color: #faf6f0;
+  background: var(--color-text);
+  color: var(--color-bg);
   font-family: 'Hanken Grotesk', system-ui, sans-serif;
   font-size: 13.5px;
   line-height: 1.5;
   white-space: normal;
-  box-shadow: 0 14px 34px -12px rgba(45, 27, 61, 0.55);
+  box-shadow: 0 14px 34px -12px rgb(var(--color-text-rgb) / 0.55);
   opacity: 0;
   transform: translateY(3px);
   transition: opacity 0.16s ease, transform 0.16s ease;
@@ -458,7 +458,7 @@ onClickOutside(triggerRef, () => hide(), { ignore: [popRef] })
   width: 10px;
   height: 10px;
   margin-left: -5px;
-  background: #2d1b3d;
+  background: var(--color-text);
   transform: rotate(45deg);
 }
 .term-pop--top .term-caret {

--- a/app/components/TimelineEntry.vue
+++ b/app/components/TimelineEntry.vue
@@ -94,7 +94,7 @@ const innerStyle = computed(() => {
    la línea hasta el aro; este anillo la tapa 3px MÁS ALLÁ del aro → hueco visible.
    (Pedido de Miriam: «la línea la atraviesa sucia».) */
 .tl-dot {
-  box-shadow: 0 0 0 3px #faf6f0;
+  box-shadow: 0 0 0 3px var(--color-bg);
 }
 /* «Vivo»: 3 latidos al entrar y calma (nada late para siempre). El moat se conserva
    como primera sombra para que el hueco del raíl no desaparezca durante el pulso. */
@@ -102,26 +102,26 @@ const innerStyle = computed(() => {
   animation: tl-pulse 2s ease-in-out 3;
 }
 @keyframes tl-pulse {
-  0%, 100% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 0 rgba(255, 107, 71, 0.35); }
-  50% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 6px rgba(255, 107, 71, 0); }
+  0%, 100% { box-shadow: 0 0 0 3px var(--color-bg), 0 0 0 0 rgb(var(--color-cta-rgb) / 0.35); }
+  50% { box-shadow: 0 0 0 3px var(--color-bg), 0 0 0 6px rgb(var(--color-cta-rgb) / 0); }
 }
 /* Eco de llegada: doble pulso más amplio, una sola vez, y vuelve a la calma. */
 .tl-dot-echo {
   animation: tl-echo 1.2s ease-in-out 2;
 }
 @keyframes tl-echo {
-  0%, 100% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 0 rgba(255, 107, 71, 0.5); }
-  50% { box-shadow: 0 0 0 3px #faf6f0, 0 0 0 14px rgba(255, 107, 71, 0); }
+  0%, 100% { box-shadow: 0 0 0 3px var(--color-bg), 0 0 0 0 rgb(var(--color-cta-rgb) / 0.5); }
+  50% { box-shadow: 0 0 0 3px var(--color-bg), 0 0 0 14px rgb(var(--color-cta-rgb) / 0); }
 }
 /* Afordancia del enlace: leve realce de fondo al pasar/enfocar (toque cómodo). */
 .tl-link:hover,
 .tl-link:focus-visible {
-  color: #2d1b3d;
-  background: rgba(157, 68, 171, 0.08);
+  color: var(--color-text);
+  background: rgb(var(--color-miriam-rgb) / 0.08);
   outline: none;
 }
 .tl-link:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/components/TwoFaces.vue
+++ b/app/components/TwoFaces.vue
@@ -319,12 +319,12 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 18px;
   font-weight: 700;
-  fill: #2d1b3d;
+  fill: var(--color-text);
 }
 .tf2__sub {
   font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 13px;
-  fill: #3a3340;
+  fill: var(--color-text-soft);
 }
 .tf2__genes {
   font-family: 'Caveat', 'Bradley Hand', cursive;
@@ -358,20 +358,20 @@ const ariaLabel = computed(() => t('twofaces.sr'))
 .tf2__known-n {
   font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 12px;
-  fill: #3a3340;
+  fill: var(--color-text-soft);
 }
 .tf2__pct {
   font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 34px;
   font-weight: 700;
-  fill: #2d1b3d;
+  fill: var(--color-text);
   opacity: 0.3;
 }
 .tf2__cgsyn {
   font-family: 'Caveat', 'Bradley Hand', cursive;
   font-size: 13px;
   font-weight: 700;
-  fill: #2d1b3d;
+  fill: var(--color-text);
   opacity: 0.4;
 }
 /* Leyenda en lenguaje llano bajo el esquema (sustituye al cierre). */
@@ -394,7 +394,7 @@ const ariaLabel = computed(() => t('twofaces.sr'))
   gap: 7px;
   font-size: 13px;
   line-height: 1.35;
-  color: #3a3340;
+  color: var(--color-text-soft);
 }
 .tf2-legend__g {
   width: 18px;

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -956,7 +956,7 @@ const snapshotRows = computed(() =>
   scroll-margin-top: 7.5rem;
 }
 /* Columna de referencia (VHIO) resaltada en la tabla de patología "3 lecturas". */
-.reads-vh { background: rgba(157, 68, 171, 0.07); }
+.reads-vh { background: rgb(var(--color-miriam-rgb) / 0.07); }
 
 /* Conmutador de nivel de lectura (ciencia en 3 capas). Sigue la paleta del
    sistema: berenjena para el activo, mono para las etiquetas. Tap target ≥40px. */
@@ -971,7 +971,7 @@ const snapshotRows = computed(() =>
   font-size: 11px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(45, 27, 61, 0.55);
+  color: rgb(var(--color-text-rgb) / 0.55);
 }
 .reading-level__seg {
   /* Móvil: ocupa el ancho y las pastillas se reparten la fila (etiquetas largas
@@ -981,8 +981,8 @@ const snapshotRows = computed(() =>
   max-width: 440px;
   padding: 3px;
   border-radius: 999px;
-  background: rgba(45, 27, 61, 0.05);
-  border: 1px solid rgba(45, 27, 61, 0.1);
+  background: rgb(var(--color-text-rgb) / 0.05);
+  border: 1px solid rgb(var(--color-text-rgb) / 0.1);
 }
 .reading-level__btn {
   appearance: none;
@@ -996,7 +996,7 @@ const snapshotRows = computed(() =>
   font-size: 12px;
   letter-spacing: 0.02em;
   line-height: 1.15;
-  color: rgba(45, 27, 61, 0.62);
+  color: rgb(var(--color-text-rgb) / 0.62);
   padding: 8px 12px;
   min-height: 40px;
   border-radius: 999px;
@@ -1014,15 +1014,15 @@ const snapshotRows = computed(() =>
   }
 }
 .reading-level__btn:hover {
-  color: #2d1b3d;
+  color: var(--color-text);
 }
 .reading-level__btn.is-active {
-  background: #2d1b3d;
-  color: #faf6f0;
+  background: var(--color-text);
+  color: var(--color-bg);
   font-weight: 600;
 }
 .reading-level__btn:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/pages/links.vue
+++ b/app/pages/links.vue
@@ -218,8 +218,8 @@ defineOgImage('Default.takumi', {
   padding: 0.85rem 1rem;
   border-radius: 16px; /* rounded-card */
   text-decoration: none;
-  border: 1px solid rgba(45, 27, 61, 0.1);
-  background: #faf6f0; /* cream */
+  border: 1px solid rgb(var(--color-text-rgb) / 0.1);
+  background: var(--color-bg); /* cream */
   transition:
     transform 0.18s ease,
     box-shadow 0.18s ease,
@@ -230,8 +230,8 @@ defineOgImage('Default.takumi', {
 /* Destacados — los 3 prioritarios: superficie cream-card + acento violeta en el
    icono, un punto más de presencia. El borde se tiñe de miriam al pasar/enfocar. */
 .bio-link--featured {
-  background: #f5efe6; /* cream-card */
-  border-color: rgba(157, 68, 171, 0.22);
+  background: var(--color-bg-card); /* cream-card */
+  border-color: rgb(var(--color-miriam-rgb) / 0.22);
 }
 
 .bio-link__icon {
@@ -242,12 +242,12 @@ defineOgImage('Default.takumi', {
   height: 2.6rem;
   flex-shrink: 0;
   border-radius: 12px;
-  background: rgba(157, 68, 171, 0.12); /* miriam soft tint */
-  color: #9d44ab; /* miriam */
+  background: rgb(var(--color-miriam-rgb) / 0.12); /* miriam soft tint */
+  color: var(--color-miriam); /* miriam */
 }
 .bio-link__icon--soft {
-  background: rgba(45, 27, 61, 0.06);
-  color: #2d1b3d; /* berenjena */
+  background: rgb(var(--color-text-rgb) / 0.06);
+  color: var(--color-text); /* berenjena */
 }
 
 .bio-link__body {
@@ -263,13 +263,13 @@ defineOgImage('Default.takumi', {
   font-size: 1rem;
   line-height: 1.25;
   letter-spacing: -0.01em;
-  color: #2d1b3d; /* berenjena */
+  color: var(--color-text); /* berenjena */
   text-wrap: balance;
 }
 .bio-link__sub {
   font-size: 0.8rem;
   line-height: 1.4;
-  color: #3a3340; /* tinta — AA sobre cream/cream-card */
+  color: var(--color-text-soft); /* tinta — AA sobre cream/cream-card */
 }
 .bio-link__arrow {
   width: 1.1rem;
@@ -286,19 +286,19 @@ defineOgImage('Default.takumi', {
 @media (hover: hover) {
   .bio-link:hover {
     transform: translateY(-2px);
-    box-shadow: 0 14px 34px rgba(45, 27, 61, 0.1);
+    box-shadow: 0 14px 34px rgb(var(--color-text-rgb) / 0.1);
   }
   .bio-link--featured:hover {
-    border-color: rgba(157, 68, 171, 0.4);
+    border-color: rgb(var(--color-miriam-rgb) / 0.4);
   }
   .bio-link--soft:hover {
-    border-color: rgba(45, 27, 61, 0.18);
+    border-color: rgb(var(--color-text-rgb) / 0.18);
   }
 }
 .bio-link:hover .bio-link__arrow,
 .bio-link:focus-visible .bio-link__arrow,
 .bio-link:active .bio-link__arrow {
-  color: #9d44ab; /* miriam */
+  color: var(--color-miriam); /* miriam */
   transform: translateX(2px);
 }
 /* Enlaces externos: la flecha apunta arriba-derecha → al pasar «se va» en diagonal. */
@@ -315,7 +315,7 @@ defineOgImage('Default.takumi', {
 
 .bio-rule {
   border: 0;
-  border-top: 1px solid rgba(45, 27, 61, 0.08);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.08);
   margin: 0.4rem 0;
 }
 
@@ -342,10 +342,10 @@ defineOgImage('Default.takumi', {
 /* Alto contraste: refuerza los bordes sin romper la marca. */
 @media (prefers-contrast: more) {
   .bio-link {
-    border-color: rgba(45, 27, 61, 0.28);
+    border-color: rgb(var(--color-text-rgb) / 0.28);
   }
   .bio-link__sub {
-    color: #2d1b3d;
+    color: var(--color-text);
   }
 }
 </style>

--- a/app/pages/marcas.vue
+++ b/app/pages/marcas.vue
@@ -526,7 +526,7 @@ export default { name: 'MarcasPage' }
 .m-signoff {
   margin-top: 1.5rem;
   padding-top: 1.25rem;
-  border-top: 1px solid rgba(232, 212, 237, 0.22);
+  border-top: 1px solid rgb(var(--color-miriam-soft-rgb) / 0.22);
   width: fit-content;
   margin-left: auto;
   margin-right: auto;
@@ -554,7 +554,7 @@ export default { name: 'MarcasPage' }
 
 /* Anillo decorativo del avatar (violeta-soft translúcido). */
 .avatar-ring {
-  border: 3px solid rgba(232, 212, 237, 0.5);
+  border: 3px solid rgb(var(--color-miriam-soft-rgb) / 0.5);
   box-shadow: 0 16px 40px -16px rgba(0, 0, 0, 0.6);
 }
 
@@ -562,7 +562,7 @@ export default { name: 'MarcasPage' }
 .marca-name {
   text-decoration: underline;
   text-decoration-style: dashed;
-  text-decoration-color: rgba(199, 125, 210, 0.8);
+  text-decoration-color: rgb(var(--color-miriam-claro-rgb) / 0.8);
   text-underline-offset: 4px;
 }
 
@@ -586,7 +586,7 @@ export default { name: 'MarcasPage' }
   gap: 0.55rem;
   margin-top: 0.2rem;
   padding-top: 0.85rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.08);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.08);
 }
 .pilar-gain__icon {
   transform: translateY(0.18em);
@@ -673,14 +673,14 @@ export default { name: 'MarcasPage' }
 }
 @media (hover: hover) {
   .encaje-tag:hover {
-    box-shadow: 0 0 0 3px rgba(157, 68, 171, 0.18);
+    box-shadow: 0 0 0 3px rgb(var(--color-miriam-rgb) / 0.18);
   }
 }
 
 /* Fila del dossier — cierre del bloque con filete fino superior (sin caja). */
 .dossier-row {
   padding-top: 1.75rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.1);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.1);
 }
 
 /* Fila de cierre de la sección de audiencia — MISMO filete fino superior que
@@ -693,7 +693,7 @@ export default { name: 'MarcasPage' }
   align-items: flex-start;
   gap: 1.1rem;
   padding-top: 1.75rem;
-  border-top: 1px solid rgba(45, 27, 61, 0.1);
+  border-top: 1px solid rgb(var(--color-text-rgb) / 0.1);
 }
 @media (min-width: 640px) {
   .audiencia-cta-row {
@@ -719,7 +719,7 @@ export default { name: 'MarcasPage' }
   pointer-events: none;
   overflow: hidden;
   opacity: 0.04;
-  background-image: radial-gradient(circle at 1px 1px, #faf6f0 1px, transparent 0);
+  background-image: radial-gradient(circle at 1px 1px, var(--color-bg) 1px, transparent 0);
   background-size: 32px 32px;
 }
 
@@ -733,8 +733,8 @@ export default { name: 'MarcasPage' }
    Decisiones de marca + VISIBILIDAD (lo que antes fallaba):
      · Estrellas VISIBLES: núcleos op. 0.78–0.85 (casi opacos), satélites
        0.5–0.65; enlaces op. 0.22–0.30 (NO 0.16). Se ve claro sobre berenjena.
-     · UN núcleo en miriam-claro (#c77dd2, énfasis sobre oscuro, único color
-       fuera del crema y dentro de marca); el resto crema (#faf6f0).
+     · UN núcleo en miriam-claro (var(--color-miriam-claro), énfasis sobre oscuro, único color
+       fuera del crema y dentro de marca); el resto crema (var(--color-bg)).
      · Líneas CURVAS finas (Q de Bézier, estilo penLine) → racimo, no malla rígida.
      · Estático salvo un único parpadeo sutil al entrar (off con reduced-motion).
    El <figure> es el lienzo: posición relativa para que el SVG se ancle al avatar. */
@@ -811,7 +811,7 @@ export default { name: 'MarcasPage' }
     font-family: 'JetBrains Mono', monospace;
     font-size: 12px;
     letter-spacing: 0.04em;
-    box-shadow: 0 12px 28px -10px rgba(45, 27, 61, 0.6);
+    box-shadow: 0 12px 28px -10px rgb(var(--color-text-rgb) / 0.6);
     transition: transform 0.15s ease, background 0.2s ease;
   }
   .m-print-btn:hover {

--- a/app/pages/timeline.vue
+++ b/app/pages/timeline.vue
@@ -247,8 +247,8 @@ const groups = computed(() => {
   display: inline-flex;
   align-items: center;
   position: relative;
-  background: #2d1b3d;
-  color: #faf6f0;
+  background: var(--color-text);
+  color: var(--color-bg);
   font-family: 'Fraunces', Georgia, serif;
   font-weight: 600;
   font-size: 15px;
@@ -265,32 +265,32 @@ const groups = computed(() => {
   min-height: 44px;
   padding: 8px 14px;
   border-radius: 9999px;
-  border: 1px solid rgba(45, 27, 61, 0.16);
-  background: #faf6f0;
+  border: 1px solid rgb(var(--color-text-rgb) / 0.16);
+  background: var(--color-bg);
   font-family: 'Hanken Grotesk', system-ui, sans-serif;
   font-size: 13.5px;
   font-weight: 600;
-  color: #3a3340;
+  color: var(--color-text-soft);
   cursor: pointer;
   transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease, transform 0.15s ease;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
 }
 .tl-chip:hover {
-  border-color: rgba(45, 27, 61, 0.32);
-  background: #f5efe6;
+  border-color: rgb(var(--color-text-rgb) / 0.32);
+  background: var(--color-bg-card);
 }
 .tl-chip:active {
   transform: scale(0.97);
 }
 .tl-chip:focus-visible {
-  outline: 2px solid #ff6b47;
+  outline: 2px solid var(--color-cta);
   outline-offset: 2px;
 }
 .tl-chip--active {
-  background: #f5efe6;
-  border-color: #2d1b3d;
-  color: #2d1b3d;
+  background: var(--color-bg-card);
+  border-color: var(--color-text);
+  color: var(--color-text);
 }
 .tl-chip__dot {
   width: 8px;


### PR DESCRIPTION
## Qué es
**Fase 3.** Tokeniza los colores de marca dentro de los bloques `<style>` de **18 componentes/páginas** (103 hexes → tokens).

- Solo contexto **CSS var-safe** (`<style>` blocks): NO toca template, SVG `fill=`, `<script>`, ni props.
- **Excluidos a propósito** (van en tandas con cuidado): `OgImage` (genera imágenes sociales desde hex literal — un `var()` las rompería), divisores SVG, visores pesados (mapa, MRI, StarMap).

**Neutro** — mismo color exacto. El preview debe verse idéntico.

## Para revisar
- [ ] Preview Netlify verde y pixel-idéntico (index/prensa/colabora/marcas, móvil/desktop, ES/EN).
- [ ] Sin regresiones de consola.

**Mergeas tú** tras revisar el preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)