### PR TITLE
fix(mapa): el power-on del sigilo no corría en producción (keyframe perdido en @media)

### DIFF
--- a/app/pages/mapa-metastasis.vue
+++ b/app/pages/mapa-metastasis.vue
@@ -4660,15 +4660,20 @@ const manifestValidated = (() => {
 <style scoped>
 /* (B5 · power-on) El instrumento «se enciende» una vez al primer paint: el sigilo
    split-disc del héroe se asienta con un beat sobrio (fade + escala, ~460ms, expo-out).
-   Sin glow, lejos de cualquier marcador de dato. Colapsa a 0 con reduced-motion. */
+   Sin glow, lejos de cualquier marcador de dato.
+   A PRUEBA DE FALLOS (fix del bug de producción, 11-jul): el `@keyframes` va a NIVEL
+   SUPERIOR — anidado dentro de `@media` el scoped-CSS de Vue + la minificación lo
+   perdían y el sigilo quedaba en `opacity:0` (INVISIBLE) en vivo. La base es
+   `opacity:1`, así que si la animación no corre (keyframe ausente o reduced-motion),
+   el emblema SIEMPRE se ve. Sin `fill-mode` para que nunca se congele en el 0 %. */
+.split-disc-sigil { opacity: 1; transform-origin: center; }
+@keyframes sigil-poweron {
+  from { opacity: 0; transform: scale(0.82) translateY(4px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
 @media (prefers-reduced-motion: no-preference) {
   .split-disc-sigil {
-    animation: sigil-poweron 460ms cubic-bezier(0.16, 1, 0.3, 1) both;
-    transform-origin: center;
-  }
-  @keyframes sigil-poweron {
-    from { opacity: 0; transform: scale(0.82) translateY(4px); }
-    to   { opacity: 1; transform: scale(1) translateY(0); }
+    animation: sigil-poweron 460ms cubic-bezier(0.16, 1, 0.3, 1);
   }
 }
 


### PR DESCRIPTION
## El power-on (B5) no se reproducía en vivo

Miriam no veía la animación de entrada del sigilo split-disc. Causa: el `@keyframes sigil-poweron` estaba **anidado dentro de `@media (prefers-reduced-motion)`**, y el scoped-CSS de Vue + la minificación **lo perdían en el build** de producción → `animation-name` apuntaba a un keyframe ausente y el power-on no corría (sigilo estático).

### Fix (a prueba de fallos)
- `@keyframes` a **nivel superior** (se scopea correctamente), no anidado en `@media`.
- Base `.split-disc-sigil { opacity: 1 }` → **el emblema SIEMPRE se ve** aunque la animación no corra (keyframe ausente o `reduced-motion`).
- Sin `fill-mode` → nunca se congela en el 0 %.

### Verificación
- `nuxt build` OK.
- Keyframe **presente y scopeado** en el CSS de producción (antes: ausente).
- Base `opacity:1` confirmada → emblema visible.
- La **animación en movimiento** no la puedo verificar (mi navegador headless congela las animaciones) → la valida Miriam en vivo.

Nota: si prefieres, en vez de esto dejo el emblema **estático** (sin animación) — más simple y sin depender de verificar movimiento. Dímelo y lo dejo así.

🤖 Generated with [Claude Code](https://claude.com/claude-code)