### PR TITLE
Fase 4 · Migración DS: divisores SVG → tokens

### DIFF
--- a/app/components/BrandMark.vue
+++ b/app/components/BrandMark.vue
@@ -4,13 +4,13 @@
        fuente de verdad para cabecera y pie. Los destellos parpadean UNA vez al
        cargar (bienvenida) y se quedan quietos; reduced-motion los deja fijos. -->
   <svg viewBox="0 0 240 240" aria-hidden="true" role="img">
-    <path class="bm-star bm-star--1" d="M192.94 24.47 L199.74 37.67 L212.94 44.47 L199.74 51.27 L192.94 64.47 L186.14 51.27 L172.94 44.47 L186.14 37.67 Z" fill="#9d44ab" />
-    <path class="bm-star bm-star--2" d="M48.33 173.84 L52.75 182.42 L61.33 186.84 L52.75 191.26 L48.33 199.84 L43.91 191.26 L35.33 186.84 L43.91 182.42 Z" fill="#9d44ab" />
-    <path class="bm-star bm-star--3" style="--bm-o: 0.5" d="M55.05 44.24 L57.94 49.85 L63.55 52.74 L57.94 55.63 L55.05 61.24 L52.16 55.63 L46.55 52.74 L52.16 49.85 Z" fill="#9d44ab" opacity="0.5" />
-    <circle class="bm-star bm-star--4" cx="182.5" cy="184.7" r="3.4" fill="#9d44ab" />
-    <circle class="bm-star bm-star--5" style="--bm-o: 0.5" cx="212.8" cy="134.7" r="2.3" fill="#9d44ab" opacity="0.5" />
-    <circle cx="120" cy="120" r="76" fill="#2d1b3d" />
-    <text x="120" y="147" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-style="italic" font-weight="600" font-size="120" fill="#faf6f0">m</text>
+    <path class="bm-star bm-star--1" d="M192.94 24.47 L199.74 37.67 L212.94 44.47 L199.74 51.27 L192.94 64.47 L186.14 51.27 L172.94 44.47 L186.14 37.67 Z" fill="var(--color-miriam)" />
+    <path class="bm-star bm-star--2" d="M48.33 173.84 L52.75 182.42 L61.33 186.84 L52.75 191.26 L48.33 199.84 L43.91 191.26 L35.33 186.84 L43.91 182.42 Z" fill="var(--color-miriam)" />
+    <path class="bm-star bm-star--3" style="--bm-o: 0.5" d="M55.05 44.24 L57.94 49.85 L63.55 52.74 L57.94 55.63 L55.05 61.24 L52.16 55.63 L46.55 52.74 L52.16 49.85 Z" fill="var(--color-miriam)" opacity="0.5" />
+    <circle class="bm-star bm-star--4" cx="182.5" cy="184.7" r="3.4" fill="var(--color-miriam)" />
+    <circle class="bm-star bm-star--5" style="--bm-o: 0.5" cx="212.8" cy="134.7" r="2.3" fill="var(--color-miriam)" opacity="0.5" />
+    <circle cx="120" cy="120" r="76" fill="var(--color-text)" />
+    <text x="120" y="147" text-anchor="middle" font-family="Fraunces, Georgia, serif" font-style="italic" font-weight="600" font-size="120" fill="var(--color-bg)">m</text>
   </svg>
 </template>
 

--- a/app/components/DnaDivider.vue
+++ b/app/components/DnaDivider.vue
@@ -5,7 +5,7 @@
       <path
         class="dna-rungs"
         d="M30 8 V16 M60 8 V16 M90 8 V16 M120 8 V16 M150 8 V16 M180 8 V16 M210 8 V16"
-        stroke="#2d1b3d"
+        stroke="var(--color-text)"
         stroke-width="1.5"
         stroke-linecap="round"
       />
@@ -13,14 +13,14 @@
       <path
         class="dna-strand"
         d="M0 5 C13 5, 17 19, 30 19 S 47 5, 60 5 S 77 19, 90 19 S 107 5, 120 5 S 137 19, 150 19 S 167 5, 180 5 S 197 19, 210 19 S 227 5, 240 5"
-        stroke="#9d44ab"
+        stroke="var(--color-miriam)"
         stroke-width="2"
         stroke-linecap="round"
       />
       <path
         class="dna-strand dna-strand--b"
         d="M0 19 C13 19, 17 5, 30 5 S 47 19, 60 19 S 77 5, 90 5 S 107 19, 120 19 S 137 5, 150 5 S 167 19, 180 19 S 197 5, 210 5 S 227 19, 240 19"
-        stroke="#ff6b47"
+        stroke="var(--color-cta)"
         stroke-width="2"
         stroke-linecap="round"
       />

--- a/app/components/EcgDivider.vue
+++ b/app/components/EcgDivider.vue
@@ -4,7 +4,7 @@
       <path
         class="ecg-path"
         d="M0 12 H88 l5 -8 l5 16 l5 -8 H240"
-        stroke="#ff6b47"
+        stroke="var(--color-cta)"
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"

--- a/app/components/StarDivider.vue
+++ b/app/components/StarDivider.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="root" class="star-divider" :class="{ 'star-in': inView }" aria-hidden="true">
-    <svg class="star-svg" viewBox="0 0 240 24" width="240" height="24" fill="#9d44ab">
+    <svg class="star-svg" viewBox="0 0 240 24" width="240" height="24" fill="var(--color-miriam)">
       <!-- Mini-constelación de destellos de 4 puntas (mismo motivo que la marca y
            que el muro de donantes-estrellas). Centrada, con caída de tamaño hacia
            los lados. Decorativa: aria-hidden. -->


### PR DESCRIPTION
Los hexes de marca en atributos `fill=`/`stroke=` de DnaDivider, EcgDivider, StarDivider y BrandMark → `var(--color-*)`. Verificado que var() resuelve en atributos SVG en el render. Neutro. OgImage sigue literal (genera imágenes sociales). **Mergeas tú** tras ver el preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)