### PR TITLE
fix(a11y): coherencia de coral — contador accesible + foco sin coral

### DIFF
--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -188,7 +188,7 @@ function jumpTo(e: Event, id: string) {
   background: var(--color-miriam);
 }
 .cn-d__link:focus-visible {
-  outline: 2px solid var(--color-cta);
+  outline: 2px solid var(--anillo-foco);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -238,7 +238,7 @@ function jumpTo(e: Event, id: string) {
 }
 .cn-m__summary:focus-visible,
 .cn-m__list a:focus-visible {
-  outline: 2px solid var(--color-cta);
+  outline: 2px solid var(--anillo-foco);
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/app/components/DaysWaitingCounter.vue
+++ b/app/components/DaysWaitingCounter.vue
@@ -18,8 +18,10 @@ const { days } = useDaysWaiting()
 </script>
 
 <style scoped>
+/* Sin velo de fondo coral: el texto coral-deep (#bb4128) se lee sobre crema
+   limpia → 5.0:1, pasa WCAG AA (el velo al 10% lo hundía a 4.53:1). El coral
+   se conserva como firma: borde + punto + texto. Auditado por Ceci (jul-2026). */
 .counter-tag {
-  background: rgb(var(--color-cta-rgb) / 0.1);
-  border: 1px solid rgb(var(--color-cta-rgb) / 0.3);
+  border: 1px solid rgb(var(--color-cta-rgb) / 0.35);
 }
 </style>

--- a/app/components/DnaDivider.vue
+++ b/app/components/DnaDivider.vue
@@ -9,7 +9,7 @@
         stroke-width="1.5"
         stroke-linecap="round"
       />
-      <!-- Hebra A (magenta, luminal) y hebra B (coral): las dos caras, trenzadas -->
+      <!-- Hebra A (magenta, luminal) y hebra B (coral), trenzadas -->
       <path
         class="dna-strand"
         d="M0 5 C13 5, 17 19, 30 19 S 47 5, 60 5 S 77 19, 90 19 S 107 5, 120 5 S 137 19, 150 19 S 167 5, 180 5 S 197 19, 210 19 S 227 5, 240 5"
@@ -32,7 +32,7 @@
 /**
  * Separador "doble hélice" — hermano del latido (EcgDivider) para el lenguaje
  * científico del sitio: estrellas (gratitud), ECG (vida), ADN (la ciencia).
- * Dos hebras —magenta y coral, las dos caras del tumor— se trazan al entrar
+ * Dos hebras —magenta y coral— se trazan al entrar
  * en viewport y los peldaños aparecen después. Decorativo (aria-hidden);
  * con reduced-motion se ve completo. Alto fijo → sin CLS.
  */

--- a/app/components/MapaSectionNav.vue
+++ b/app/components/MapaSectionNav.vue
@@ -179,7 +179,7 @@ function jumpTo(e: Event, id: string) {
   background: var(--color-miriam);
 }
 .mn-d__link:focus-visible {
-  outline: 2px solid var(--color-miriam);
+  outline: 2px solid var(--anillo-foco);
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -229,7 +229,7 @@ function jumpTo(e: Event, id: string) {
 }
 .mn-m__summary:focus-visible,
 .mn-m__list a:focus-visible {
-  outline: 2px solid var(--color-miriam);
+  outline: 2px solid var(--anillo-foco);
   outline-offset: 2px;
 }
 @media (prefers-reduced-motion: reduce) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,7 +43,7 @@ export default {
         // oscuras (cajas «Carlos Roca» / LinkedIn en /marcas). Texto crema: 12.8:1.
         'berenjena-2': 'rgb(var(--berenjena-2-rgb) / <alpha-value>)',
         coral: {
-          DEFAULT: 'rgb(var(--color-cta-rgb) / <alpha-value>)',     // var(--color-cta) — ÚNICO color de acción (fondos / decoración)
+          DEFAULT: 'rgb(var(--color-cta-rgb) / <alpha-value>)',     // var(--color-cta) — color de ACCIÓN + acento de marca (fondo de botón, punto/borde). Como TEXTO sobre claro usa coral.deep; NUNCA en anillos de foco (usa --anillo-foco) ni como texto/velo coral puro sobre crema (falla AA)
           hover: 'rgb(var(--color-cta-hover-rgb) / <alpha-value>)',
           // Coral accesible para TEXTO sobre fondos claros: pasa WCAG AA
           // (4.7:1 sobre cream-card, 5.0:1 sobre cream). El coral DEFAULT


### PR DESCRIPTION
Barrido de coherencia de coral detectado al documentar componentes reales en el design system. **Divisores intactos** (Miriam decidió conservar el coral decorativo). Solo se toca lo que era **fallo de a11y real** + la grieta que lo causó.

## Cambios
| Archivo | Cambio | Por qué |
|---|---|---|
| `DaysWaitingCounter.vue` | Quita el velo coral de fondo | Bug a11y: texto sobre el velo daba **4.53:1** (falla AA). Sin velo → **5.0:1**. Coral conservado en texto/borde/punto |
| `CienciaSectionNav.vue` | Anillo de foco `--color-cta` → `--anillo-foco` | Coral en `:focus-visible` ≈2.5:1 sobre crema → **falla WCAG 1.4.11 / 2.4.13**. Ahora violeta 5.07:1 |
| `MapaSectionNav.vue` | Foco `--color-miriam` → `--anillo-foco` | Anti-deriva: mismo token semántico que su gemelo; vira a `#c77dd2` en modo oscuro |
| `tailwind.config.js` | Aclara el comentario del token coral | Decía coral = "decoración" → grieta que llevó al mal uso. Ahora acota: acción + acento de marca, nunca foco ni texto/velo coral puro sobre crema |

## Auditoría
- **Ceci (muro a11y):** el fallo real era el **velo** del contador (no el tono del texto). Contrastes verificados con su motor. Divisores decorativos (`aria-hidden`) = limpios, sin muro.
- **Comité de Diseño:** recomendaba corregir los 3 a violeta; Miriam decidió conservar el coral en los divisores → se respeta.

## Pendiente antes de merge/deploy
- [ ] Visto de la **Ceci humana** sobre el color (muro). Todo son tokens ya validados o retirar coral, sin color nuevo.
- El deploy-preview de Netlify renderiza el contador y los focos para revisión visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)