### PR TITLE
fix(og-image): leer la edad de caseData en vez de hardcodearla

### DIFF
--- a/app/components/OgImage/Default.takumi.vue
+++ b/app/components/OgImage/Default.takumi.vue
@@ -1,4 +1,9 @@
 <script setup>
+// Edad desde la fuente única (app/utils/caseData) en vez de a mano, para que la
+// share-card no se desincronice del resto del sitio. Import explícito: el runtime
+// aislado del og:image (takumi) no garantiza el auto-import de utils.
+import { caseData } from '~/utils/caseData'
+
 defineProps({
   colorMode: { type: String, required: false, default: 'light' },
   title: { type: String, required: false, default: 'title' },
@@ -56,7 +61,7 @@ defineProps({
         style="gap: 14px; margin-top: 12px; padding-top: 20px; border-top: 1px solid rgba(45,27,61,0.12);"
       >
         <span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; color: #2d1b3d;">
-          Miriam González · 35
+          Miriam González · {{ caseData.currentAge }}
         </span>
         <span style="color: #9d44ab;">·</span>
         <span style="font-family: 'JetBrains Mono', monospace; font-size: 16px; color: #5a4a68;">


### PR DESCRIPTION
## Qué

La plantilla del **og:image / share-card** (`app/components/OgImage/Default.takumi.vue`), que genera la imagen de compartir de **todas** las páginas (`defineOgImage('Default.takumi', …)`), tenía la edad **escrita a mano**: `Miriam González · 35`.

El resto del sitio (hero de la home, prensa, /ciencia) ya lee la edad de la **fuente única** `app/utils/caseData.ts` (`currentAge`). El og:image era el único que la duplicaba como literal → riesgo de que se desincronice al editar (el propio `prensa.vue` avisa de las «cifras que pueden desincronizarse: edad, nº de países»).

## Cambio

```diff
-          Miriam González · 35
+          Miriam González · {{ caseData.currentAge }}
```

+ import explícito de `caseData` (el runtime aislado del og:image con takumi no garantiza el auto-import de `app/utils`).

**No cambia el dato ni la política de divulgación.** La edad sigue siendo pública a propósito (confirmado por Miriam el 11-jul); esto es solo dejar de hardcodearla.

## Verificación

Preview local (`nuxt dev`), PNG real del og:image de la home (`/_og/d/c_Default.takumi,…png`): renderiza idéntico, **"Miriam González · 35"**, ahora leído de `caseData.currentAge`. El render sin error confirma que el import resuelve en el runtime de takumi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)