### PR TITLE
Mapa de metástasis «al primer vistazo» en la home

### DIFF
--- a/app/components/MapaMiniPreview.vue
+++ b/app/components/MapaMiniPreview.vue
@@ -1,0 +1,69 @@
+<template>
+  <!-- Miniatura estática del mapa de metástasis para el teaser de la home.
+       NO carga el visor 3D: es un SVG dibujado a mano (trazo a lápiz, como el
+       subrayado «dos caras» del hero), no un icono de stock. Los puntos usan los
+       colores canónicos de los dos trazadores del mapa real (teal ⁶⁸Ga, ámbar
+       FDG). Es decorativo → aria-hidden; el significado vive en el texto y la
+       leyenda del componente que lo envuelve. Cero JS de cliente. -->
+  <svg
+    class="mapa-mini"
+    viewBox="0 0 130 250"
+    aria-hidden="true"
+    focusable="false"
+  >
+    <g
+      class="mapa-mini__bones"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <!-- cráneo + mandíbula -->
+      <path d="M65 14 C74 14 79 21 79 29 C79 37 74 43 65 43 C56 43 51 37 51 29 C51 21 56 14 65 14 Z" />
+      <path d="M60 44 L60 51 M70 44 L70 51" />
+      <!-- columna -->
+      <path d="M65 51 C64 70 66 92 65 116" />
+      <!-- costillas (pares, trazo suelto) -->
+      <path d="M52 58 C40 60 33 64 28 69 M78 58 C90 60 97 64 102 69" />
+      <path d="M56 64 C46 66 40 70 37 74 M74 64 C84 66 90 70 93 74" />
+      <path d="M55 76 C46 78 41 82 39 86 M75 76 C84 78 89 82 91 86" />
+      <path d="M56 88 C48 90 44 93 42 97 M74 88 C82 90 86 93 88 97" />
+      <path d="M58 100 C51 102 47 105 46 108 M72 100 C79 102 83 105 84 108" />
+      <!-- pelvis -->
+      <path d="M55 118 C50 128 50 136 54 146 L76 146 C80 136 80 128 75 118 Z" />
+      <!-- piernas + pies -->
+      <path d="M56 146 C48 168 44 196 42 232 M74 146 C82 168 86 196 88 232" />
+      <path d="M40 232 L46 234 M88 232 L82 234" />
+      <!-- brazos -->
+      <path d="M30 70 C22 92 20 116 22 138 M100 70 C108 92 110 116 108 138" />
+      <path d="M22 138 L20 150 M108 138 L110 150" />
+    </g>
+    <!-- lesiones · teal = ⁶⁸Ga-DOTATOC, ámbar = ¹⁸F-FDG (colores del mapa real) -->
+    <g class="mapa-mini__lesions">
+      <circle cx="65" cy="72" r="6.5" fill="#1c969e" />
+      <circle cx="65" cy="98" r="5.5" fill="#1c969e" />
+      <circle cx="42" cy="82" r="4.5" fill="#d66e1c" />
+      <circle cx="61" cy="130" r="6" fill="#1c969e" />
+      <circle cx="79" cy="122" r="4.5" fill="#d66e1c" />
+      <circle cx="58" cy="180" r="5" fill="#d66e1c" />
+    </g>
+  </svg>
+</template>
+
+<style scoped>
+.mapa-mini {
+  display: block;
+  width: 100%;
+  height: auto;
+  /* El hueso hereda el color del texto berenjena vía currentColor, atenuado
+     para que sea una silueta y no compita con las lesiones. */
+  color: var(--color-text);
+}
+.mapa-mini__bones {
+  opacity: 0.72;
+}
+.mapa-mini__lesions circle {
+  opacity: 0.92;
+}
+</style>

--- a/app/components/SectionMapaTeaser.vue
+++ b/app/components/SectionMapaTeaser.vue
@@ -1,0 +1,115 @@
+<template>
+  <!-- Teaser del mapa de metástasis «al primer vistazo»: vive justo bajo el hero,
+       en el flujo crema, separado por el mismo filete fino que ya usa el hero.
+       No compite con los CTA del hero (Donar > entender): es un módulo propio,
+       más discreto que Donar y más protagonista que un enlace de pie. La
+       miniatura es un SVG dibujado a mano (MapaMiniPreview), sin cargar el 3D. -->
+  <section
+    v-reveal
+    class="bg-cream py-14 sm:py-16"
+    style="border-top: 1px solid rgba(45,27,61,0.08)"
+    :aria-labelledby="titleId"
+  >
+    <div class="section-wide">
+      <NuxtLink
+        :to="localePath('mapa-metastasis')"
+        class="card-base mapa-teaser flex flex-col sm:flex-row sm:items-center gap-6 sm:gap-8"
+        style="text-decoration: none"
+        @click="trackMapa('home_teaser')"
+      >
+        <!-- Miniatura · columna estrecha, centrada en móvil -->
+        <div class="mapa-teaser__preview shrink-0 self-center sm:self-start">
+          <MapaMiniPreview />
+        </div>
+
+        <!-- Texto -->
+        <div class="min-w-0 flex-1">
+          <p class="eyebrow mb-2 block">{{ $t('mapaTeaser.eyebrow') }}</p>
+          <h2
+            :id="titleId"
+            class="heading-display text-2xl sm:text-3xl text-berenjena mb-3"
+            style="letter-spacing: -0.02em"
+          >
+            {{ $t('mapaTeaser.title') }}
+          </h2>
+          <p class="text-base text-tinta leading-relaxed max-w-2xl mb-4">
+            {{ $t('mapaTeaser.lede') }}
+          </p>
+
+          <!-- Leyenda de trazadores · el color no es el único canal (texto al lado) -->
+          <ul class="mapa-teaser__legend" :aria-label="$t('mapaTeaser.legend_aria')">
+            <li>
+              <span class="mapa-teaser__dot" style="background: #1c969e" aria-hidden="true" />
+              {{ $t('mapaTeaser.tracer_ga') }}
+            </li>
+            <li>
+              <span class="mapa-teaser__dot" style="background: #d66e1c" aria-hidden="true" />
+              {{ $t('mapaTeaser.tracer_fdg') }}
+            </li>
+          </ul>
+
+          <span class="btn-dark mapa-teaser__cta mt-5">
+            <Icon name="ph:map-pin-fill" class="w-4 h-4" aria-hidden="true" />
+            {{ $t('mapaTeaser.cta') }}
+          </span>
+          <p class="mt-3 font-mono text-[11px] text-tinta">{{ $t('mapaTeaser.disclaimer') }}</p>
+        </div>
+      </NuxtLink>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+const localePath = useLocalePath()
+const { trackMapa } = useSupport()
+
+// id único (no hardcodeado) por si el componente se montara más de una vez:
+// evita colisión de id entre el aria-labelledby de la sección y el h2.
+const titleId = useId()
+</script>
+
+<style scoped>
+/* Lift sutil en desktop (mismo patrón que a.card-base del DS; el hover global ya
+   lo aplica, aquí solo fijamos el ancho de la miniatura y la leyenda). */
+.mapa-teaser__preview {
+  width: 88px;
+}
+@media (min-width: 640px) {
+  .mapa-teaser__preview {
+    width: 104px;
+  }
+}
+
+.mapa-teaser__legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.mapa-teaser__legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--color-text-soft);
+}
+.mapa-teaser__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+/* El CTA es visual (todo el card es el enlace real); en móvil ocupa el ancho. */
+.mapa-teaser__cta {
+  width: 100%;
+}
+@media (min-width: 640px) {
+  .mapa-teaser__cta {
+    width: auto;
+  }
+}
+</style>

--- a/app/composables/useSupport.ts
+++ b/app/composables/useSupport.ts
@@ -65,6 +65,14 @@ export function useSupport() {
     trackUmami('Pathway', { ruta: route })
   }
 
+  // Mide quién abre el mapa de metástasis y desde dónde (teaser de la home,
+  // /ciencia, /links…). Mismo patrón que trackScience: un evento, el origen como
+  // propiedad → se ve si el acceso «al primer vistazo» en la home convierte.
+  function trackMapa(location: string) {
+    fire('VerMapa', location)
+    trackUmami('VerMapa', { location })
+  }
+
   function trackShare(method: string, from?: string) {
     trackUmami('Compartir', {
       metodo: method,
@@ -89,5 +97,6 @@ export function useSupport() {
     trackPathway,
     trackShare,
     trackBioLink,
+    trackMapa,
   }
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,10 @@
   <div>
     <SectionHero />
 
+    <!-- Mapa de metástasis «al primer vistazo»: banda-teaser en el flujo crema,
+         justo bajo el hero (no un tercer botón en el hero, que leería a SaaS). -->
+    <SectionMapaTeaser />
+
     <VisitorPathways variant="home" />
 
     <!-- La historia + en sus propias palabras (beat humano: persona antes que problema) -->

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -131,6 +131,16 @@
     "brief_cta_help": "See all ways to help",
     "hero_sr_summary": "Miriam González has an ultra-rare metastatic breast cancer with two biologies. This site funds precision tests that public healthcare does not cover. You can donate, read the science, collaborate by profile, or share the campaign."
   },
+  "mapaTeaser": {
+    "eyebrow": "Open tool",
+    "title": "See exactly where each lesion is",
+    "lede": "Interactive 3D bone-metastasis map with dual tracers (Gallium-68 and FDG): every point, with the real data — built to share with your medical team.",
+    "legend_aria": "Map tracers",
+    "tracer_ga": "Gallium-68",
+    "tracer_fdg": "FDG",
+    "cta": "Open the map",
+    "disclaimer": "Decision support, not diagnosis."
+  },
   "glossary": {
     "hint": "Tap or hover the highlighted words and markers to see what they mean."
   },

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -131,6 +131,16 @@
     "brief_cta_help": "Ver todas las formas de ayudar",
     "hero_sr_summary": "Miriam González tiene un cáncer de mama metastásico ultra-raro con dos biologías. Esta web financia las pruebas de precisión que la sanidad pública no cubre. Puedes apoyar económicamente, leer la ciencia del caso, colaborar según tu perfil o compartir la campaña."
   },
+  "mapaTeaser": {
+    "eyebrow": "Herramienta abierta",
+    "title": "Mira exactamente dónde está cada lesión",
+    "lede": "Mapa interactivo en 3D de las metástasis óseas con doble trazador (Galio-68 y FDG): cada punto, con los datos reales — pensado para compartir con tu equipo médico.",
+    "legend_aria": "Trazadores del mapa",
+    "tracer_ga": "Galio-68",
+    "tracer_fdg": "FDG",
+    "cta": "Abrir el mapa",
+    "disclaimer": "Apoyo a la decisión, no diagnóstico."
+  },
   "glossary": {
     "hint": "Toca o pasa el cursor por las palabras y marcadores resaltados para ver qué significan."
   },


### PR DESCRIPTION
## Qué
Hace **visible al primer vistazo** el mapa de metástasis: una **banda-teaser** justo debajo del hero, en el flujo crema, separada por el mismo filete fino del hero. Hoy el mapa solo se alcanzaba desde `/ciencia` y el pie.

Pedido de Miriam (12-jul). Opción elegida por ella tras ver la maqueta: **banda dentro del hero (B1)** — no un tercer botón en el hero (leería a plantilla SaaS). Jerarquía intacta: **Donar > entender > el mapa**.

## Cómo
- `SectionMapaTeaser.vue` — tarjeta-enlace a `/mapa-metastasis`: eyebrow, título, lede, leyenda de trazadores y CTA berenjena (`btn-dark`). Encuadre **«apoyo a la decisión, no diagnóstico»**.
- `MapaMiniPreview.vue` — miniatura **SVG estática dibujada a mano** (silueta de esqueleto a lápiz + puntos), **sin cargar el visor 3D**. Colores canónicos de los dos trazadores del mapa real: teal ⁶⁸Ga, ámbar FDG.
- `useSupport` — evento `VerMapa` para medir el acceso desde la home.
- i18n ES/EN (bloque `mapaTeaser`).
- Insertado en `index.vue` entre `SectionHero` y `VisitorPathways`.

## Comités
- **Diseño**: recomendó B1 respetando el DS anti-IA (nada de barras de acento/corchetes/patrón SaaS; miniatura dibujada, no icono de stock).
- **Ceci (a11y)**: **sin bloqueantes**. Contrastes AA con holgura (botón 14.6:1, textos 10.6:1), foco visible ≥3:1, SVG decorativo con la info en la leyenda textual.

## Verificación
- Dev server: sin errores de consola; `lint` 0/0.
- DOM comprobado: enlace → `/mapa-metastasis`, miniatura con sus 13 trazos y 6 puntos (3 teal + 3 ámbar), leyenda Galio-68/FDG, CTA berenjena, disclaimer.
- El screenshot del panel local sale en blanco por el falso negativo conocido (IntersectionObserver suspendido en el panel con `v-reveal`) → **verlo en el preview de Netlify de este PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)