### PR TITLE
fix(forms): postear a la ruta actual, no a "/" (el catch-all 404 tragaba el envío)

### DIFF
--- a/app/components/CaseFollowSignup.vue
+++ b/app/components/CaseFollowSignup.vue
@@ -141,7 +141,10 @@ async function onSubmit(e: Event) {
   ).toString()
   sending.value = true
   try {
-    await $fetch('/', {
+    // POST a la ruta actual, no a "/": el catch-all `/* → /404.html 404` del
+    // `_redirects` de `nuxt generate` intercepta el POST a "/" antes de que
+    // Netlify Forms lo procese. La página actual es un fichero real (200).
+    await $fetch(window.location.pathname, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,

--- a/app/pages/contacto.vue
+++ b/app/pages/contacto.vue
@@ -301,8 +301,14 @@ const roleLabel = computed(() => {
   return role.value ? map[role.value] ?? '' : ''
 })
 
-// Envío AJAX a Netlify Forms: mismo endpoint (POST a "/" con urlencode), pero
-// mostramos el agradecimiento en la propia página en vez de redirigir.
+// Envío AJAX a Netlify Forms (urlencode), mostrando el agradecimiento en la
+// propia página en vez de redirigir. Posteamos a la ruta ACTUAL, no a "/":
+// `nuxt generate` termina el `dist/_redirects` con un catch-all
+// `/* → /404.html 404` que intercepta el POST a "/" ANTES de que Netlify Forms
+// lo procese (devolvía 404 → el remitente veía "error" aunque el envío sí se
+// registraba, y algunos reescribían por duplicado). La página localizada
+// (/contacto, /en/contact) es un fichero prerenderizado real (200), intocada
+// por el catch-all.
 const sent = ref(false)
 const sending = ref(false)
 const failed = ref(false)
@@ -348,7 +354,7 @@ async function onSubmit(e: Event) {
   const body = new URLSearchParams(new FormData(form) as unknown as Record<string, string>).toString()
   sending.value = true
   try {
-    await $fetch('/', {
+    await $fetch(window.location.pathname, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body,


### PR DESCRIPTION
## Problema
Los formularios `contact` y `case-follow` hacían `POST` a `/`. En este sitio, un POST a `/` devuelve **404**: el `dist/_redirects` que genera `nuxt generate` termina con un catch-all `/* → /404.html 404` que intercepta el POST **antes** de que Netlify Forms lo procese.

Consecuencia: el `$fetch` lanzaba y el remitente veía "error al enviar" **aunque el envío sí quedaba registrado** en Netlify. De ahí que llegaran mensajes reenviados por duplicado (gente que pensaba que había fallado).

> Contexto adicional: la razón por la que Miriam llevaba ~1 mes sin recibir nada era, además, que la **notificación por email** del formulario no existía en el proyecto de Netlify (se perdió al migrar la cuenta). Eso ya está arreglado por separado en el dashboard. Este PR arregla el 404 del POST, que es un bug distinto pero relacionado (la mala UX del remitente).

## Fix
Postear a `window.location.pathname` (la página localizada actual: `/contacto`, `/en/contact`) en vez de a `/`. Esas rutas son ficheros prerenderizados reales (200) que el catch-all no toca, así Netlify Forms procesa el envío y el remitente ve el agradecimiento correcto.

Cambio de una línea en cada formulario (+ comentario explicando el porqué).

## Verificación
- `POST /contacto` con `form-name=contact` → **200** y el envío aparece capturado en Netlify Forms (verificado en producción).
- `POST /` con el mismo cuerpo → **404** (comportamiento actual, roto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)