### PR TITLE
fix(fundraiser): /fundraiser.json y /donations.json en vivo (routeRules, no netlify.toml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ Thumbs.db
 .netlify
 
 # data
-public/fundraiser.json
-public/donations.json
+seed/fundraiser.json
+seed/donations.json
 
 # Config local de agentes (sesiones de Claude)
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,13 +48,13 @@ The website has two audiences: scientists/physicians (science page, molecular pr
 - Netlify Forms integrated (no backend, no Formspree). The form lives in `app/pages/contacto.vue`.
 
 ### GoFundMe Data Sync (live endpoints)
-- `/fundraiser.json` (total) and `/donations.json` (donor list → stars + table) are served by **on-request Netlify Functions** that query GoFundMe live and are cached at Netlify's CDN (`Netlify-CDN-Cache-Control` with `stale-while-revalidate`/`stale-if-error`), so the data refreshes **without a redeploy**. `netlify.toml` redirects map those paths to the functions (`force = true`); the Vue components keep fetching the same URLs on mount.
+- `/fundraiser.json` (total) and `/donations.json` (donor list → stars + table) are served by **on-request Netlify Functions** that query GoFundMe live and are cached at Netlify's CDN (`Netlify-CDN-Cache-Control` with `stale-while-revalidate`/`stale-if-error`), so the data refreshes **without a redeploy**. Those paths are routed to the functions via **`routeRules` in `nuxt.config.ts`** (302), NOT `netlify.toml`: a `netlify.toml` redirect — even `force = true` — loses to the `/*` catch-all in the generated `dist/_redirects` (processed first), the same trap as the short links. The build seed lives in `seed/` (NOT `public/`) so no `dist/*.json` static file shadows the routeRule. The Vue components keep fetching the same URLs on mount.
   - `netlify/functions/fundraiser.mts` — one GraphQL call, CDN-cached ~15 min.
   - `netlify/functions/donations.mts` — the public feed fetched in **parallel** (bounded by `donationCount` so it stays within the function time budget), CDN-cached ~1 h with `stale-while-revalidate` (users always get the cached copy instantly; revalidation is background).
 - `utils/fundraiser.ts` defines the types (`GoFundMeFundraiser`, `GoFundMeAmount`, `GoFundMeResponse`, `PublicDonation`) and the fetchers: `getFundraiser()`, `getDonations()` (sequential, for the build seed), `getDonationsFast(total?)` (parallel, for the live endpoint), plus `saveFundraiser()/saveDonations()` that write the build-time seed.
-- `utils/seed.ts` `readSeed()` reads the build-time `public/*.json` (bundled into the functions via `included_files`) as a fallback when GoFundMe is unreachable, so the total and stars never go blank.
-- CLI `pnpm update-fundraiser` (runs at build via `pnpm generate`) regenerates the seed. `public/fundraiser.json` and `public/donations.json` are **gitignored** — never committed, auto-generated at build.
-- The previous hourly scheduled function was removed: a Netlify function cannot rewrite the already-deployed static files, so writing `public/*.json` at runtime never reached the served assets (the data only changed on redeploy). The live endpoints replace it.
+- `utils/seed.ts` `readSeed()` reads the build-time `seed/*.json` (bundled into the functions via `included_files`) as a fallback when GoFundMe is unreachable, so the total and stars never go blank.
+- CLI `pnpm update-fundraiser` (runs at build via `pnpm generate`) regenerates the seed. `seed/fundraiser.json` and `seed/donations.json` are **gitignored** — never committed, auto-generated at build.
+- The previous hourly scheduled function was removed: a Netlify function cannot rewrite the already-deployed static files, so writing the seed at runtime never reached the served assets (the data only changed on redeploy). The live endpoints replace it.
 
 ### Nitro Route Rules
 - `/colabora` and `/collaborate` → 301 redirect to `https://helpmiriam.notion.site/colabora`. This is the collaboration guide for new contributors.
@@ -198,7 +198,7 @@ Replace the placeholder content in `app/pages/historia/index.vue` with the real 
 pnpm dev               # local dev at http://localhost:3000 (auto-fetches fundraiser)
 pnpm generate          # generate static site to .output/public/ (auto-fetches fundraiser)
 pnpm preview           # preview static build
-pnpm update-fundraiser # manually fetch & write public/fundraiser.json (add --force to overwrite)
+pnpm update-fundraiser # manually fetch & write seed/fundraiser.json (add --force to overwrite)
 ```
 
 ### Code Standards

--- a/app/components/SectionHero.vue
+++ b/app/components/SectionHero.vue
@@ -163,7 +163,7 @@ const { data: gofundme, refresh: refreshFundraiser } = await useAsyncData<GoFund
     if (import.meta.server) {
       try {
         const { readFile } = await import('node:fs/promises')
-        return JSON.parse(await readFile('public/fundraiser.json', 'utf-8'))
+        return JSON.parse(await readFile('seed/fundraiser.json', 'utf-8'))
       } catch {
         return null
       }

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,24 +9,18 @@
 # ── Datos en vivo ────────────────────────────────────────────────────────────
 # El total y la lista de donantes (estrellas + tabla) se sirven desde funciones
 # que consultan GoFundMe al vuelo y se cachean en la CDN (no hace falta redeploy).
-# La semilla generada en build (public/*.json) se incluye en el bundle de las
-# funciones como fallback por si GoFundMe no responde.
+# La semilla generada en build (seed/*.json, FUERA de public/) se incluye en el
+# bundle de las funciones como fallback por si GoFundMe no responde.
 [functions]
-  included_files = ["public/fundraiser.json", "public/donations.json"]
+  included_files = ["seed/fundraiser.json", "seed/donations.json"]
 
-# /fundraiser.json y /donations.json apuntan a las funciones (force gana al
-# fichero estático del mismo nombre). El cliente sigue pidiendo las mismas URLs.
-[[redirects]]
-  from = "/fundraiser.json"
-  to = "/.netlify/functions/fundraiser"
-  status = 200
-  force = true
-
-[[redirects]]
-  from = "/donations.json"
-  to = "/.netlify/functions/donations"
-  status = 200
-  force = true
+# OJO: el enrutado de /fundraiser.json y /donations.json a las funciones NO vive
+# aquí. Igual que los enlaces cortos, un redirect en netlify.toml (aunque sea
+# `force=true`) PIERDE contra el catch-all `/* /404.html 404` del `dist/_redirects`
+# que Netlify procesa ANTES que este fichero. Por eso se definen como `routeRules`
+# en nuxt.config.ts (nitro los escribe en _redirects ANTES del catch-all) y la
+# semilla se guarda en seed/ (no en public/) para que no haya un fichero estático
+# del mismo nombre que las sombree. Detalle: nota en nuxt.config.ts.
 
 # ── Enlaces cortos de marca (campañas) ───────────────────────────────────────
 # Los links cortos (helpmiriam.com/3d…, /donar) NO viven aquí: se definen como

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -181,6 +181,15 @@ export default defineNuxtConfig({
     // (acceso para médicos) enlace corto SERIO para reenviar al equipo clínico (no de redes):
     // helpmiriam.com/caso → el panel del mapa. UTM «referral/medico» para distinguir el canal.
     '/caso': { redirect: { to: '/mapa-metastasis?utm_source=referral&utm_medium=medico&utm_campaign=equipo-clinico', statusCode: 302 } },
+    // Datos EN VIVO de GoFundMe: /fundraiser.json (total) y /donations.json (muro)
+    // se enrutan a las funciones de Netlify. Van AQUÍ y NO en netlify.toml por el
+    // MISMO motivo que los enlaces cortos de arriba: el catch-all de dist/_redirects
+    // se procesa ANTES que netlify.toml, así que un redirect allí (aun con force=true)
+    // nunca gana. Como routeRule, nitro escribe la regla ANTES del catch-all. Además
+    // la semilla de fallback se guarda en seed/ (no en public/, ver utils/fundraiser.ts)
+    // para que NO exista dist/fundraiser.json que sombree esta regla (nota «shadowing»).
+    '/fundraiser.json': { redirect: { to: '/.netlify/functions/fundraiser', statusCode: 302 } },
+    '/donations.json': { redirect: { to: '/.netlify/functions/donations', statusCode: 302 } },
   },
 
   nitro: {
@@ -199,6 +208,8 @@ export default defineNuxtConfig({
       ignore: [
         '/design-system', '/mapa-metastasis.md', '/en/mapa-metastasis.md',
         '/3d', '/3d-x', '/3d-in', '/3d-ig', '/donar', '/caso',
+        // datos en vivo: que nitro NO prerenderice un fichero que sombree el 302
+        '/fundraiser.json', '/donations.json',
       ],
       // URLs SIN barra final, coherentes con los links y el canonical del sitio
       // (que ya usan «/colabora», no «/colabora/»). Genera «colabora.html» en

--- a/utils/fundraiser.ts
+++ b/utils/fundraiser.ts
@@ -18,7 +18,10 @@ export interface GoFundMeResponse {
   }
 }
 
-const path = 'public/fundraiser.json'
+// Semilla FUERA de public/: si viviera en public/ se publicaría como
+// dist/fundraiser.json y SOMBREARÍA el routeRule que enruta /fundraiser.json a
+// la función viva (misma trampa que los enlaces cortos, ver nuxt.config.ts).
+const path = 'seed/fundraiser.json'
 const request = 'https://graphql.gofundme.com/graphql'
 const operationName = 'GetFundraiser'
 const query = `query GetFundraiser($slug: ID!) {
@@ -81,6 +84,7 @@ export async function saveFundraiser(overwrite = false) {
   }
   try {
     const fundraiser = await getFundraiser()
+    await fs.mkdir('seed', { recursive: true })
     await fs.writeFile(path, JSON.stringify(fundraiser))
     console.log(`✔ Fundraiser saved to: ${path}`)
   } catch (error) {
@@ -99,7 +103,7 @@ export async function saveFundraiser(overwrite = false) {
 // El feed público de GoFundMe ya muestra nombre + importe + anónimo + fecha.
 // Re-publicamos lo mismo. OPT_OUT: nombres (no anónimos) a excluir si alguien
 // pide quitarse (red de seguridad RGPD). Los anónimos salen como "Anónimo".
-const donationsPath = 'public/donations.json'
+const donationsPath = 'seed/donations.json'
 const donationsFeed = `https://gateway.gofundme.com/web-gateway/v1/feed/${variables.slug}/donations`
 const OPT_OUT: string[] = []
 
@@ -222,6 +226,7 @@ export async function saveDonations() {
       console.log('No donations fetched; keeping existing file.')
       return
     }
+    await fs.mkdir('seed', { recursive: true })
     await fs.writeFile(donationsPath, JSON.stringify(donations))
     console.log(`✔ Donations saved (${donations.length}) to: ${donationsPath}`)
   } catch (error) {

--- a/utils/seed.ts
+++ b/utils/seed.ts
@@ -2,13 +2,14 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 /**
- * Lee el JSON «semilla» generado en build (`public/<file>`) e incluido en el
+ * Lee el JSON «semilla» generado en build (`seed/<file>`) e incluido en el
  * bundle de las funciones vía `included_files` (netlify.toml). Es el fallback
  * cuando GoFundMe no responde: así el total y las estrellas nunca se quedan en
  * blanco. Best-effort: prueba varias rutas y devuelve null si no encuentra nada.
  */
 export async function readSeed<T>(file: string): Promise<T | null> {
   const candidates = [
+    path.resolve(process.cwd(), 'seed', file),
     path.resolve(process.cwd(), 'public', file),
     path.resolve(process.cwd(), file),
   ]


### PR DESCRIPTION
## Problema

`helpmiriam.com` mostraba una **foto congelada de junio** del recaudado y el muro de donantes:

| | Web (antes) | GoFundMe en vivo |
|---|---|---|
| Recaudado | 45.323 € | **63.159 €** |
| Donantes | 1.155 | **1.604** |

La función de Netlify que consulta GoFundMe **funciona** (`/.netlify/functions/fundraiser` devuelve el dato en vivo). El fallo era el **enrutado**: `/fundraiser.json` y `/donations.json` se servían como el **fichero estático (semilla)**, no desde la función.

## Causa raíz

El mapeo `/fundraiser.json` → función vivía **solo en `netlify.toml`** con `force=true`, que **pierde contra el catch-all `/* /404.html 404`** del `dist/_redirects` (Netlify lo procesa antes que `netlify.toml`) — **la misma trampa #117–#120 de los enlaces cortos**, que allí ya se resolvió con `routeRules`. Estos dos endpoints se quedaron sin migrar. Encima la semilla estática solo se refresca al desplegar (el build corre `update-fundraiser` sin `--force`), así que derivaba con cada donación.

## Arreglo (mismo patrón que los enlaces cortos)

- **`routeRules`** en `nuxt.config.ts` enrutan `/fundraiser.json` y `/donations.json` a las funciones (302) — nitro los escribe **antes** del catch-all, así ganan.
- La **semilla de fallback se mueve de `public/` a `seed/`** para que no exista un `dist/*.json` que **sombree** el routeRule; sigue en el bundle de las funciones vía `included_files`. `saveFundraiser/saveDonations` crean `seed/` con `mkdir`.
- Se **quitan los dos `[[redirects]]` inefectivos** de `netlify.toml`.
- `prerender.ignore` evita que nitro genere un fichero que sombree el 302.
- Ruta del seed actualizada en `SectionHero.vue` (lectura en prerender), `utils/seed.ts`, `.gitignore` y `AGENTS.md`.

## Verificación (en el Deploy Preview)

- [ ] `GET /fundraiser.json` en el preview devuelve el total en vivo (~63.159 €/1.604), no 45.323 €/1.155.
- [ ] `GET /donations.json` sirve la lista viva desde la función.
- [ ] No existe `dist/fundraiser.json` estático que sombree el redirect.
- [ ] Los enlaces cortos (`/3d`, `/donar`, …) siguen funcionando.

> ⚠️ Sin mergear a propósito: pendiente de revisar el Deploy Preview antes de pasar a producción.