### PR TITLE
content(cronología): jun–jul 2026 — vacuna, hígado, Roca Project y ensayo BG-75202

### DIFF
--- a/content/en/timeline.yml
+++ b/content/en/timeline.yml
@@ -229,3 +229,52 @@ entries:
     highlight: true
     link: https://x.com/miriamgonp/status/2068004136621109648
     linkLabel: 'See the announcement on X →'
+
+  - date: 'Jun 26–30, 2026'
+    tag: Clinical trials
+    title: The vaccine route closes
+    description: >
+      Both personalized vaccines under exploration fall through in the same week. Fred Hutch
+      (Seattle) replies that its neoantigen vaccine requires measurable disease —over 1 cm in the
+      breast or a lymph node over 1.5 cm in short axis—: with bone-only metastases, Miriam does
+      not meet the criterion, though they leave the door open should the situation change. Days
+      later, Moffitt (Tampa) answers that its ESR1-directed dendritic cell vaccine trial has just
+      filled its last slot.
+    highlight: true
+    link: https://clinicaltrials.gov/study/NCT05098210
+    linkLabel: 'See the Fred Hutch neoantigen vaccine →'
+
+  - date: 'Jul 10–13, 2026'
+    tag: Progression
+    title: 'The cancer leaves the bone: liver lesions appear'
+    description: >
+      The trial screening imaging —a PET-CT on 10 July and a chest, abdomen and pelvis CT on the
+      13th— shows lesions in the liver. Until now the disease had been bone-only, so the picture
+      changes. Liver function and bilirubin remain within normal range, but the tumour is no
+      longer confined to bone.
+    highlight: true
+
+  - date: 'Jul 15, 2026'
+    tag: Outreach
+    title: The case reaches episode 100 of Roca Project
+    description: >
+      Miriam's interview on Roca Project, Carlos Roca's podcast, is released as its special
+      100th episode, with her among the guests most voted for by the community. An hour and a
+      half on the road to diagnosis, what metastatic breast cancer with neuroendocrine
+      differentiation means, and why protocols don't cover all the genetics. Over the following
+      days the website's contact form fills up: engineers, researchers, patients, and people who
+      simply want to help.
+    highlight: true
+    link: https://www.youtube.com/watch?v=zVUECrux6zA
+    linkLabel: 'Watch the full interview →'
+
+  - date: 'Jul 22, 2026'
+    tag: Clinical trials
+    title: First treatment day on a phase 1 trial
+    description: >
+      Miriam starts the phase 1 trial of BG-75202 at Vall d'Hebron's Early Drug Development Unit
+      (UITM) in Barcelona, in cohort 1B: BG-75202 combined with fulvestrant. It comes after
+      months of closed doors and a long screening, with trips to Barcelona every few days.
+    highlight: true
+    link: https://clinicaltrials.gov/study/NCT07222267
+    linkLabel: 'See the BG-75202 trial →'

--- a/content/es/timeline.yml
+++ b/content/es/timeline.yml
@@ -231,3 +231,53 @@ entries:
     highlight: true
     link: https://x.com/miriamgonp/status/2068004136621109648
     linkLabel: 'Ver el anuncio en X →'
+
+  - date: '26-30 jun 2026'
+    tag: Ensayos clínicos
+    title: Se cierra la vía de la vacuna
+    description: >
+      Las dos vacunas personalizadas que se estaban explorando se caen la misma semana. Desde el
+      Fred Hutch (Seattle) responden que su vacuna de neoantígenos exige enfermedad medible —más
+      de 1 cm en mama o un ganglio de más de 1,5 cm de eje corto—: con metástasis exclusivamente
+      óseas, Miriam no cumple el criterio, aunque dejan la puerta abierta por si la situación
+      cambia. Días después, el Moffitt (Tampa) contesta que su ensayo de vacuna de células
+      dendríticas dirigida a ESR1 acaba de cubrir la última plaza.
+    highlight: true
+    link: https://clinicaltrials.gov/study/NCT05098210
+    linkLabel: 'Ver la vacuna de neoantígenos del Fred Hutch →'
+
+  - date: '10-13 jul 2026'
+    tag: Progresión
+    title: 'El cáncer sale del hueso: aparecen lesiones en el hígado'
+    description: >
+      Las pruebas de imagen del screening del ensayo —PET-TC el 10 de julio y TC de tórax, abdomen
+      y pelvis el 13— muestran lesiones en el hígado. Hasta ahora la enfermedad había sido
+      exclusivamente ósea, así que cambia el escenario. La función hepática y la bilirrubina
+      siguen dentro de la normalidad, pero el tumor ya no está solo en el hueso.
+    highlight: true
+
+  - date: '15 jul 2026'
+    tag: Divulgación
+    title: El caso, en el programa 100 de Roca Project
+    description: >
+      Se publica la entrevista de Miriam en Roca Project, el podcast de Carlos Roca, como programa
+      especial número 100 y con ella entre las invitadas más votadas por la comunidad. Hora y
+      media contando el camino hasta el diagnóstico, qué significa un cáncer de mama metastásico
+      con diferenciación neuroendocrina y por qué los protocolos no cubren toda la genética. Los
+      días siguientes, el formulario de contacto de la web se llena: ingenieros, investigadoras,
+      pacientes y gente que solo quiere ayudar.
+    highlight: true
+    link: https://www.youtube.com/watch?v=zVUECrux6zA
+    linkLabel: 'Ver la entrevista completa →'
+
+  - date: '22 jul 2026'
+    tag: Ensayos clínicos
+    title: Primer día de tratamiento en un ensayo en fase 1
+    description: >
+      Miriam empieza el ensayo fase 1 de BG-75202 en la Unidad de Investigación de Terapia
+      Molecular del Cáncer (UITM) del Vall d'Hebron, en Barcelona, dentro de la cohorte 1B:
+      BG-75202 combinado con fulvestrant. Llega después de meses de puertas cerradas y de un
+      screening largo, con desplazamientos a Barcelona cada pocos días.
+    highlight: true
+    link: https://clinicaltrials.gov/study/NCT07222267
+    linkLabel: 'Ver el ensayo BG-75202 →'


### PR DESCRIPTION
Cuatro hitos que faltaban en la cronología desde el 19 de junio, en ES y EN.

| Fecha | Entrada | Fuente verificada en sesión |
|---|---|---|
| 26-30 jun | Se cierra la vía de la vacuna | Correos a VHIO (30-jun) con la respuesta literal de Fred Hutch; respuesta de Moffitt (30-jun) |
| 10-13 jul | Lesiones en el hígado | Citaciones de radiología de VHIO (PET-TC 10-jul, TC 13-jul) + correo del 28-jul |
| 15 jul | Programa 100 de Roca Project | Ficha del episodio (publicado el 15-jul-2026) |
| 22 jul | Primer día del ensayo BG-75202 | Analítica y visita del 22-jul; C2D1 verificado el 12-ago (ciclo de 21 días) |

Enlaces comprobados contra la API de ClinicalTrials.gov: NCT07222267 (BG-75202, fase 1, BeOne Medicines, reclutando), NCT05098210 (vacuna de neoantígenos, Fred Hutch), NCT06691035 (DC1-ESR1, Moffitt).

**Una fecha es inferida, no documental:** el 22 de julio como C1D1 sale de encajar la analítica y la visita de ese día con el C2D1 verificado del 12 de agosto (ciclo de 21 días). Si la fecha real de la primera dosis es otra, se cambia esa línea.

**Queda fuera de este PR, pero ahora contradice a la cronología:**
- `app/composables/useDaysWaiting.ts` — el contador «días sin tratamiento» sigue corriendo desde el 30-mar-2026; hoy muestra ~139 días, cuando el tratamiento empezó el 22 de julio.
- `i18n/locales/*.json` (`snapshot_status`) — «sin afectación visceral · ADELA y KATSIS-1 en cribado · elacestrant en reserva».
- `app/pages/ciencia/index.vue:883` — «Metástasis exclusivamente óseas».
- `content/*/science.yml` — las líneas de tratamiento no incluyen el ensayo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)