### PR TITLE
fix(fonts): quita la cursiva de Fraunces, que rompe todos los builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,5 @@
 [build]
-  # `rm -rf node_modules/.cache/nuxt` no es opcional: ahí vive la caché de
-  # @nuxt/fonts con las URLs de fonts.gstatic.com resueltas en el build anterior.
-  # Google rota esos hashes sin cambiar la versión de la familia (el 16-ago-2026
-  # cambió Fraunces manteniendo v38), así que una caché de semanas apunta a
-  # ficheros que ya devuelven 404 y el build entero cae con FetchError. Netlify
-  # restaura node_modules entre builds, de modo que la caché sobrevive a todo
-  # menos a un «Clear cache and deploy» manual: por eso se borra aquí.
-  command = "npm_config_build_from_source=true pnpm rebuild better-sqlite3 && rm -rf node_modules/.cache/nuxt && pnpm generate"
+  command = "npm_config_build_from_source=true pnpm rebuild better-sqlite3 && pnpm generate"
   publish = "dist"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,12 @@
 [build]
-  command = "npm_config_build_from_source=true pnpm rebuild better-sqlite3 && pnpm generate"
+  # `rm -rf node_modules/.cache/nuxt` no es opcional: ahí vive la caché de
+  # @nuxt/fonts con las URLs de fonts.gstatic.com resueltas en el build anterior.
+  # Google rota esos hashes sin cambiar la versión de la familia (el 16-ago-2026
+  # cambió Fraunces manteniendo v38), así que una caché de semanas apunta a
+  # ficheros que ya devuelven 404 y el build entero cae con FetchError. Netlify
+  # restaura node_modules entre builds, de modo que la caché sobrevive a todo
+  # menos a un «Clear cache and deploy» manual: por eso se borra aquí.
+  command = "npm_config_build_from_source=true pnpm rebuild better-sqlite3 && rm -rf node_modules/.cache/nuxt && pnpm generate"
   publish = "dist"
 
 [build.environment]

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,7 +23,12 @@ export default defineNuxtConfig({
   // de IP), con subsetting y font-display: swap. Sin <link> a Google Fonts.
   fonts: {
     families: [
-      { name: 'Fraunces', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal', 'italic'] },
+      // Fraunces va sin cursiva a propósito: desde el 16-ago-2026 Google Fonts
+      // devuelve 404 en el woff2 de la Fraunces itálica variable, y @nuxt/fonts
+      // aborta el build entero al descargarla. Reproducido en local con caché
+      // limpia y en los tres deploys de ese día. Las demás familias no están
+      // afectadas. Cuando Google lo arregle, devolver 'italic' aquí.
+      { name: 'Fraunces', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal'] },
       { name: 'Hanken Grotesk', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal', 'italic'] },
       { name: 'Source Sans 3', provider: 'google', weights: [400, 500, 600, 700], styles: ['normal', 'italic'] },
       { name: 'JetBrains Mono', provider: 'google', weights: [400, 500] },


### PR DESCRIPTION
Desbloquea los deploys. Ahora mismo **todo build falla**, incluido el de producción de `main`, así que la cronología mergeada en #177 no ha llegado a helpmiriam.com: la web sigue sirviendo `main@aeb5bee`, del 21 de julio.

## El error

```
FetchError: [GET] "https://fonts.gstatic.com/s/fraunces/v38/6NVS8Fy…woff2": 404 Not Found
  at @nuxt/fonts/dist/module.mjs
```

## La causa

El CSS que Google Fonts sirve hoy apunta, **en la variante itálica variable de Fraunces**, a un woff2 que ya no existe. `@nuxt/fonts` descarga cada URL durante el build (las fuentes son auto-alojadas, el cliente nunca contacta con Google) y aborta al primer 404, tumbando el build entero.

No es la caché de Netlify —esa fue mi primera hipótesis, y era falsa—. Reproducido **en local, con `node_modules/.cache/nuxt` borrada**: falla igual, y con una URL distinta de la del build de Netlify, lo que descarta caché rancia.

No es de una rama: cayeron con el mismo error el preview de #177, el de #178 (`feat/footer-logo-ucam`, que solo toca el footer) y el deploy de producción de `main@5ceb6fa`.

Las otras familias (Hanken Grotesk, Source Sans 3, JetBrains Mono, Caveat) resuelven sin problema.

## El arreglo

Quitar `italic` de Fraunces. Comprobado en local: el build termina con **exit 0**.

También probé servir Fraunces desde Bunny Fonts para conservar la cursiva: el build falla igual, así que se descarta.

**Efecto visible:** los textos en cursiva de la tipografía display pasan a cursiva sintética. Es reversible en una línea en cuanto Google restablezca el fichero, y el comentario en `nuxt.config.ts` lo deja indicado.

El deploy preview de este PR es la comprobación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)