### PR TITLE
content(cronologia): quita nombres de ensayo, enlaces y detalles de protocolo

### DIFF
--- a/content/en/science.yml
+++ b/content/en/science.yml
@@ -34,9 +34,9 @@ treatments:
     outcome: >-
       As a standard 3rd line, elacestrant has been offered (ESR1 route, with
       public funding approved), pending start. In parallel, she is in screening
-      for two phase 3 trials in HR+/HER2− breast cancer after CDK4/6i: ADELA
-      (elacestrant + everolimus, for her ESR1 mutation) and KATSIS-1 (KAT6
-      inhibitor + fulvestrant). The first bone rebiopsy (April 2026) did not
+      for two phase 3 trials in HR+/HER2− breast cancer after CDK4/6i: one via
+      the ESR1 route (elacestrant + everolimus) and another with a KAT6
+      inhibitor + fulvestrant. The first bone rebiopsy (April 2026) did not
       yield viable tumor, so an extended PET-guided bone rebiopsy is planned —
       the central test the campaign funds. Functional status: ECOG 1.
     active: true
@@ -197,13 +197,13 @@ panelRows:
     targets: 'Ex vivo sensitivity: FGFRi, CDK4/6i, T-DXd, capivasertib, everolimus and combinations'
     implication: 'PDOs predict response and improve PFS when guiding treatment'
   - component: Serial liquid biopsy (ctDNA)
-    method: 'Plasma (Guardant, HOPE/SOLTI) every 6–8 weeks · complement, no core'
+    method: 'Plasma (Guardant) every 6–8 weeks · complement, no core'
     targets: 'FGFR1 amp, ESR1 (Y537S/D538G), PIK3CA, FGFR kinase mutations'
     implication: 'Closes the loop: detects resistance before imaging, without re-biopsying'
 liquidBiopsies:
   - id: ctdna-1
     date: Apr 7, 2026
-    source: VHIO360 — HOPE-FOCUS SOLTI-2401 trial
+    source: VHIO360 — liquid biopsy trial
     findings: Plasma ctDNA panel — baseline profile
   - id: ctdna-2
     date: April 2026
@@ -265,7 +265,7 @@ liquidBiopsyPivot:
         vhio360: { value: 'MSI-LOW', plain: true }
         guardant1: { plain: true }
         guardantcdx: { plain: true }
-  sources: 'Sources: 2026-04-07 VHIO360 (HOPE-FOCUS SOLTI-2401) · 2026-04-13 Guardant360 · 2026-05-13 Guardant360 CDx (report 2026-05-26)'
+  sources: 'Sources: 2026-04-07 VHIO360 · 2026-04-13 Guardant360 · 2026-05-13 Guardant360 CDx (report 2026-05-26)'
 imaging:
   title: Gallium-68 DOTATOC PET-CT
   date: May 26, 2026

--- a/content/en/timeline.yml
+++ b/content/en/timeline.yml
@@ -94,11 +94,9 @@ entries:
     tag: Molecular
     title: Reading the tumor without touching it
     description: >
-      First plasma ctDNA within the HOPE-FOCUS SOLTI-2401 trial. Baseline profile of the
-      tumor without needing tissue. Results: ESR1 D538G detected and low MSI status.
+      First plasma ctDNA, within a liquid biopsy trial. Baseline profile of the tumor
+      without needing tissue. Results: ESR1 D538G detected and low MSI status.
     highlight: false
-    link: https://clinicaltrials.gov/study/NCT06991946
-    linkLabel: 'See how the HOPE-Focus trial works →'
 
   - date: 'Apr 8–9, 2026'
     tag: AI
@@ -191,12 +189,10 @@ entries:
     tag: Molecular
     title: The breast biopsy doesn't yield enough tumor
     description: >
-      A breast biopsy is done to try to qualify for the phase 3 KATSIS-1 trial, which requires
-      tumor tissue. The analyzable sample is tiny (0.3 mm), not enough to meet the criteria, so
-      this route doesn't allow entry into that trial.
+      A breast biopsy is done to try to qualify for a trial that requires tumor tissue. The
+      analyzable sample is tiny (0.3 mm), not enough to meet the criteria, so this route
+      doesn't allow entry.
     highlight: false
-    link: https://clinicaltrials.gov/study/NCT07062965
-    linkLabel: 'See the KATSIS-1 trial →'
 
   - date: 'Jun 9, 2026'
     tag: Outreach
@@ -234,24 +230,20 @@ entries:
     tag: Clinical trials
     title: The vaccine route closes
     description: >
-      Both personalized vaccines under exploration fall through in the same week. Fred Hutch
-      (Seattle) replies that its neoantigen vaccine requires measurable disease —over 1 cm in the
-      breast or a lymph node over 1.5 cm in short axis—: with bone-only metastases, Miriam does
-      not meet the criterion, though they leave the door open should the situation change. Days
-      later, Moffitt (Tampa) answers that its ESR1-directed dendritic cell vaccine trial has just
-      filled its last slot.
+      Both personalized vaccines under exploration fall through in the same week. One, because it
+      requires measurable disease and Miriam's metastases are bone-only: an entry criterion that
+      leaves out many patients like her. The other, because its last slot had just been filled.
+      One of the two stays open should the situation change.
     highlight: true
-    link: https://clinicaltrials.gov/study/NCT05098210
-    linkLabel: 'See the Fred Hutch neoantigen vaccine →'
 
-  - date: 'Jul 10–13, 2026'
+  - date: 'Jul 13, 2026'
     tag: Progression
     title: 'The cancer leaves the bone: liver lesions appear'
     description: >
-      The trial screening imaging —a PET-CT on 10 July and a chest, abdomen and pelvis CT on the
-      13th— shows lesions in the liver. Until now the disease had been bone-only, so the picture
-      changes. Liver function and bilirubin remain within normal range, but the tumour is no
-      longer confined to bone.
+      The trial screening imaging shows lesions in the liver. Until now the disease had been
+      bone-only. Liver function remains within normal range, but the tumour is no longer
+      confined to bone: it is spreading, and every month that passes narrows the window to
+      find something that works.
     highlight: true
 
   - date: 'Jul 15, 2026'
@@ -268,13 +260,11 @@ entries:
     link: https://www.youtube.com/watch?v=zVUECrux6zA
     linkLabel: 'Watch the full interview →'
 
-  - date: 'Jul 22, 2026'
+  - date: 'Jul 15, 2026'
     tag: Clinical trials
     title: First treatment day on a phase 1 trial
     description: >
-      Miriam starts the phase 1 trial of BG-75202 at Vall d'Hebron's Early Drug Development Unit
-      (UITM) in Barcelona, in cohort 1B: BG-75202 combined with fulvestrant. It comes after
-      months of closed doors and a long screening, with trips to Barcelona every few days.
+      Miriam starts a phase 1 trial with BG-75202, at Vall d'Hebron's molecular therapy unit in
+      Barcelona. It comes after months of closed doors and a long screening, with trips to
+      Barcelona every few days.
     highlight: true
-    link: https://clinicaltrials.gov/study/NCT07222267
-    linkLabel: 'See the BG-75202 trial →'

--- a/content/es/science.yml
+++ b/content/es/science.yml
@@ -34,9 +34,9 @@ treatments:
     outcome: >-
       Como 3ª línea estándar se ha ofrecido elacestrant (vía ESR1, con
       financiación pública aprobada), pendiente de inicio. En paralelo, está en
-      cribado para dos ensayos de fase 3 en mama HR+/HER2− tras CDK4/6i: ADELA
-      (elacestrant + everolimus, para su mutación ESR1) y KATSIS-1 (inhibidor de
-      KAT6 + fulvestrant). La primera rebiopsia ósea (abril 2026) no obtuvo tumor
+      cribado para dos ensayos de fase 3 en mama HR+/HER2− tras CDK4/6i: uno por
+      la vía ESR1 (elacestrant + everolimus) y otro con un inhibidor de KAT6 +
+      fulvestrant. La primera rebiopsia ósea (abril 2026) no obtuvo tumor
       viable, así que se plantea una rebiopsia ósea extendida guiada por PET — la
       prueba central que financia la campaña. Estado funcional: ECOG 1.
     active: true
@@ -200,13 +200,13 @@ panelRows:
     targets: 'Sensibilidad ex vivo: FGFRi, CDK4/6i, T-DXd, capivasertib, everolimus y combinaciones'
     implication: 'Los PDOs predicen respuesta y mejoran la PFS al guiar el tratamiento'
   - component: Biopsia líquida seriada (ctDNA)
-    method: 'Plasma (Guardant, HOPE/SOLTI) cada 6–8 semanas · complemento, sin core'
+    method: 'Plasma (Guardant) cada 6–8 semanas · complemento, sin core'
     targets: 'FGFR1 amp, ESR1 (Y537S/D538G), PIK3CA, mutaciones kinasa FGFR'
     implication: 'Cierra el bucle: detecta resistencia antes que la imagen, sin volver a biopsiar'
 liquidBiopsies:
   - id: ctdna-1
     date: 7 abr 2026
-    source: VHIO360 — ensayo HOPE-FOCUS SOLTI-2401
+    source: VHIO360 — ensayo de biopsia líquida
     findings: Panel de ctDNA en plasma — perfil basal
   - id: ctdna-2
     date: Abril 2026
@@ -268,7 +268,7 @@ liquidBiopsyPivot:
         vhio360: { value: 'MSI-LOW', plain: true }
         guardant1: { plain: true }
         guardantcdx: { plain: true }
-  sources: 'Fuentes: 2026-04-07 VHIO360 (HOPE-FOCUS SOLTI-2401) · 2026-04-13 Guardant360 · 2026-05-13 Guardant360 CDx (informe 26/05/26)'
+  sources: 'Fuentes: 2026-04-07 VHIO360 · 2026-04-13 Guardant360 · 2026-05-13 Guardant360 CDx (informe 26/05/26)'
 imaging:
   title: PET-CT con Galio-68 DOTATOC
   date: 26 de mayo de 2026

--- a/content/es/timeline.yml
+++ b/content/es/timeline.yml
@@ -95,11 +95,9 @@ entries:
     tag: Molecular
     title: Leer el tumor sin tocarlo
     description: >
-      Primer ctDNA en plasma dentro del ensayo HOPE-FOCUS SOLTI-2401. Perfil basal del tumor
+      Primer ctDNA en plasma, dentro de un ensayo de biopsia líquida. Perfil basal del tumor
       sin necesidad de tejido. Resultados: ESR1 D538G detectada y estado MSI bajo.
     highlight: false
-    link: https://clinicaltrials.gov/study/NCT06991946
-    linkLabel: 'Ver cómo funciona el ensayo HOPE-Focus →'
 
   - date: '8–9 abr 2026'
     tag: IA
@@ -193,12 +191,10 @@ entries:
     tag: Molecular
     title: La biopsia de mama no da tumor suficiente
     description: >
-      Se realiza una biopsia de la mama para optar al ensayo en fase 3 KATSIS-1, que requiere
-      tejido tumoral. La muestra analizable es mínima (0,3 mm), insuficiente para cumplir los
-      criterios, así que por esta vía no es posible entrar en ese ensayo.
+      Se realiza una biopsia de la mama para optar a un ensayo que requiere tejido tumoral. La
+      muestra analizable es mínima (0,3 mm), insuficiente para cumplir los criterios, así que
+      por esa vía no es posible entrar.
     highlight: false
-    link: https://clinicaltrials.gov/study/NCT07062965
-    linkLabel: 'Ver el ensayo KATSIS-1 →'
 
   - date: '9 jun 2026'
     tag: Divulgación
@@ -236,24 +232,20 @@ entries:
     tag: Ensayos clínicos
     title: Se cierra la vía de la vacuna
     description: >
-      Las dos vacunas personalizadas que se estaban explorando se caen la misma semana. Desde el
-      Fred Hutch (Seattle) responden que su vacuna de neoantígenos exige enfermedad medible —más
-      de 1 cm en mama o un ganglio de más de 1,5 cm de eje corto—: con metástasis exclusivamente
-      óseas, Miriam no cumple el criterio, aunque dejan la puerta abierta por si la situación
-      cambia. Días después, el Moffitt (Tampa) contesta que su ensayo de vacuna de células
-      dendríticas dirigida a ESR1 acaba de cubrir la última plaza.
+      Las dos vacunas personalizadas que se estaban explorando se caen la misma semana. Una,
+      porque exige enfermedad medible y las metástasis de Miriam son solo óseas: un criterio de
+      entrada que deja fuera a muchas pacientes como ella. La otra, porque acababa de cubrirse
+      la última plaza. Una de las dos queda abierta por si la situación cambia.
     highlight: true
-    link: https://clinicaltrials.gov/study/NCT05098210
-    linkLabel: 'Ver la vacuna de neoantígenos del Fred Hutch →'
 
-  - date: '10-13 jul 2026'
+  - date: '13 jul 2026'
     tag: Progresión
     title: 'El cáncer sale del hueso: aparecen lesiones en el hígado'
     description: >
-      Las pruebas de imagen del screening del ensayo —PET-TC el 10 de julio y TC de tórax, abdomen
-      y pelvis el 13— muestran lesiones en el hígado. Hasta ahora la enfermedad había sido
-      exclusivamente ósea, así que cambia el escenario. La función hepática y la bilirrubina
-      siguen dentro de la normalidad, pero el tumor ya no está solo en el hueso.
+      Las pruebas del screening muestran lesiones en el hígado. Hasta ahora la enfermedad había
+      sido exclusivamente ósea. La función hepática sigue dentro de la normalidad, pero el tumor
+      ya no está solo en el hueso: se está extendiendo, y cada mes que pasa estrecha el margen
+      para encontrar algo que funcione.
     highlight: true
 
   - date: '15 jul 2026'
@@ -270,14 +262,11 @@ entries:
     link: https://www.youtube.com/watch?v=zVUECrux6zA
     linkLabel: 'Ver la entrevista completa →'
 
-  - date: '22 jul 2026'
+  - date: '15 jul 2026'
     tag: Ensayos clínicos
     title: Primer día de tratamiento en un ensayo en fase 1
     description: >
-      Miriam empieza el ensayo fase 1 de BG-75202 en la Unidad de Investigación de Terapia
-      Molecular del Cáncer (UITM) del Vall d'Hebron, en Barcelona, dentro de la cohorte 1B:
-      BG-75202 combinado con fulvestrant. Llega después de meses de puertas cerradas y de un
-      screening largo, con desplazamientos a Barcelona cada pocos días.
+      Miriam empieza un ensayo en fase 1 con BG-75202, en la unidad de terapia molecular del
+      Vall d'Hebron, en Barcelona. Llega después de meses de puertas cerradas y de un screening
+      largo, con desplazamientos a Barcelona cada pocos días.
     highlight: true
-    link: https://clinicaltrials.gov/study/NCT07222267
-    linkLabel: 'Ver el ensayo BG-75202 →'


### PR DESCRIPTION
Peticion de Miriam (17-ago-26): los ensayos no se nombran ni se enlazan, para no cerrarse puertas con los centros que los llevan. La excepcion es BG-75202, el que esta haciendo ahora, que si se nombra pero sin enlace.

## Cronologia (es + en)

- Fred Hutch, Moffitt y los criterios de entrada de sus vacunas -> «una, porque exige enfermedad medible...»
- HOPE-FOCUS SOLTI-2401 -> «un ensayo de biopsia liquida»
- KATSIS-1 -> «un ensayo que requiere tejido tumoral»
- Cohorte 1B, fulvestrant y siglas UITM -> fuera; queda BG-75202
- Los 4 enlaces a clinicaltrials.gov y sus linkLabel -> ninguno

## science.yml (es + en)

Fuera los nombres ADELA, KATSIS-1 y HOPE-FOCUS SOLTI-2401. Se conservan el mecanismo y la diana (via ESR1, inhibidor de KAT6) y la trazabilidad de las fuentes (VHIO360, Guardant360 y sus fechas): lo que se retira es el identificador del ensayo, no la procedencia del dato.

## Dos correcciones de fondo

- Primer dia de tratamiento: 22 jul -> 15 jul, segun Miriam. Contradice lo que decia la web; conviene confirmarlo antes de mergear.
- La entrada del higado pierde las fechas de las pruebas (ya estan en el campo date) y gana lo que el hallazgo implica: la enfermedad se esta extendiendo.

## Pendiente, no incluido

science.yml sigue diciendo «en cribado para dos ensayos de fase 3», obsoleto desde que empezo el BG el 15 de julio. Actualizarlo pide datos clinicos sin confirmar.