### PR TITLE
content(cronologia): el elacestrant nunca llego a iniciarse

### DIFF
--- a/content/en/timeline.yml
+++ b/content/en/timeline.yml
@@ -153,8 +153,8 @@ entries:
     title: The third line is offered
     description: >
       With the ESR1 resistance mutation (D538G) confirmed in blood, elacestrant is offered
-      as a standard 3rd line (public funding approved), pending start. In parallel, clinical
-      trials and the radioligand route (PRRT) are evaluated.
+      as a standard 3rd line (public funding approved), though it is never started. In
+      parallel, clinical trials and the radioligand route (PRRT) are evaluated.
     highlight: false
   - date: 'May 17, 2026'
     tag: Outreach

--- a/content/es/timeline.yml
+++ b/content/es/timeline.yml
@@ -153,8 +153,8 @@ entries:
     title: Se ofrece la tercera línea
     description: >
       Con la mutación de resistencia ESR1 (D538G) confirmada en sangre, se ofrece como 3ª
-      línea estándar elacestrant (financiación pública aprobada), pendiente de inicio. En
-      paralelo se valoran ensayos clínicos y la vía de radioligandos (PRRT).
+      línea estándar elacestrant (financiación pública aprobada), que finalmente no llega a
+      iniciarse. En paralelo se valoran ensayos clínicos y la vía de radioligandos (PRRT).
     highlight: false
   - date: '17 may 2026'
     tag: Divulgación


### PR DESCRIPTION
Miriam (17-ago-26): «elacestrant no me lo han puesto», y no quiere que la web hable de planes B o C.

La entrada de mayo decia «pendiente de inicio», que era cierto entonces pero hoy se lee como un plan vivo esperando su turno. Pasa a «que finalmente no llega a iniciarse», que cierra el hilo sin dejarlo en el aire. Mismo cambio en ingles.

Ya no queda ninguna mencion al elacestrant como reserva: se retiro del estado del caso en #182.

Lo que si se mantiene, porque no son planes sino biologia:
- La definicion de SERD oral en el glosario (Term.vue).
- En el perfil molecular, que la mutacion ESR1 D538G es criterio de entrada a ensayos con elacestrant.

ECOG 1 confirmado por ella, sin cambios.