### PR TITLE
Arreglar el acceso al modo clínico: ?nivel=pro no abría nada

### DIFF
--- a/app/components/CienciaSectionNav.vue
+++ b/app/components/CienciaSectionNav.vue
@@ -55,7 +55,7 @@ const chapters = computed(() =>
         { id: 'tejido-3veces', label: 'Anatomía patológica' },
         { id: 'molecular-profile-title', label: 'Perfil molecular' },
         { id: 'imaging-tissue-title', label: 'Imagen funcional' },
-        { id: 'mapa-acceso', label: 'Mapa de metástasis' },
+        { id: 'mapa-acceso', label: 'Mapa y biopsia' },
         { id: 'panel-title', label: 'El siguiente paso' },
         { id: 'treatment-title', label: 'Historia clínica' },
       ]
@@ -64,7 +64,7 @@ const chapters = computed(() =>
         { id: 'tejido-3veces', label: 'Pathology' },
         { id: 'molecular-profile-title', label: 'Molecular profile' },
         { id: 'imaging-tissue-title', label: 'Functional imaging' },
-        { id: 'mapa-acceso', label: 'Metastasis map' },
+        { id: 'mapa-acceso', label: 'Map & biopsy' },
         { id: 'panel-title', label: 'The next step' },
         { id: 'treatment-title', label: 'Clinical history' },
       ]

--- a/app/pages/ciencia/index.vue
+++ b/app/pages/ciencia/index.vue
@@ -750,7 +750,17 @@ const route = useRoute()
 const level = ref<ReadingLevel>(route.query.nivel === 'pro' ? 'pro' : 'simple')
 onMounted(() => {
   // La URL manda sobre lo recordado; sin ?nivel, recupera la última elección.
-  if (route.query.nivel === 'pro' || route.query.nivel === 'simple') return
+  // Hay que APLICARLA aquí, no solo al inicializar el ref: la página se sirve
+  // prerenderizada y al hidratar Vue restaura el estado del payload (siempre
+  // 'simple'), que pisaba el valor leído de la query. Por eso `?nivel=pro` no
+  // abría el modo clínico, y con él estaban rotos el botón «Medicina /
+  // investigación» del home y el enlace corto /caso. Verificado en producción
+  // el 5-sep-2026: con el parámetro puesto, el bloque clínico seguía oculto.
+  const q = route.query.nivel
+  if (q === 'pro' || q === 'simple') {
+    level.value = q
+    return
+  }
   try {
     const saved = localStorage.getItem('hm_ciencia_nivel')
     if (saved === 'pro' || saved === 'simple') level.value = saved as ReadingLevel

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -186,7 +186,10 @@ export default defineNuxtConfig({
     '/donar': { redirect: { to: 'https://www.gofundme.com/f/biopsia-molecular-que-puede-cambiar-su-tratamiento', statusCode: 302 } },
     // (acceso para médicos) enlace corto SERIO para reenviar al equipo clínico (no de redes):
     // helpmiriam.com/caso → el panel del mapa. UTM «referral/medico» para distinguir el canal.
-    '/caso': { redirect: { to: '/mapa-metastasis?utm_source=referral&utm_medium=medico&utm_campaign=equipo-clinico', statusCode: 302 } },
+    '/caso': { redirect: { to: '/ciencia?nivel=pro&utm_source=referral&utm_medium=medico&utm_campaign=equipo-clinico#mapa-acceso', statusCode: 302 } },
+    // Llevaba solo al mapa de metástasis. Desde que existe el visor de la biopsia son DOS
+    // herramientas en el mismo bloque, y este es el enlace que la propia página imprime para
+    // que un médico lo comparta con su equipo: tiene que abrirlas las dos.
     // Datos EN VIVO de GoFundMe: /fundraiser.json (total) y /donations.json (muro)
     // se enrutan a las funciones de Netlify. Van AQUÍ y NO en netlify.toml por el
     // MISMO motivo que los enlaces cortos de arriba: el catch-all de dist/_redirects


### PR DESCRIPTION
Al revisar cómo llega un médico al visor de la biopsia salieron tres cosas, y la primera invalidaba el arreglo que se iba a hacer encima.

## 1. `?nivel=pro` no abría el modo clínico

El `ref` se inicializaba leyendo la query, pero la página se sirve prerenderizada y **al hidratar Vue restauraba el estado del payload (`simple`), que pisaba ese valor**.

[verificado en producción] Con `?nivel=pro` en la URL, el bloque clínico seguía oculto.

Con él estaban rotas **las dos puertas** pensadas justo para ese público:
- el botón «Medicina / investigación» de la home
- el enlace corto `/caso`

Arreglo: aplicar la query también en `onMounted`, no solo al inicializar el `ref`.

## 2. `/caso` llevaba solo al mapa

Es el enlace que la propia página imprime para que un médico lo comparta con su equipo de tumores. Desde que existe el visor de la biopsia son **dos** herramientas en el mismo bloque, y el enlace tiene que abrirlas las dos.

## 3. El índice decía «Mapa de metástasis»

Y ya llevaba a dos herramientas. Pasa a «Mapa y biopsia» / «Map & biopsy».

## Lo que NO se toca

Decisión del comité de diseño, con su argumento:

- **El menú principal.** Sus cinco ítems son clústeres de contenido, no funciones sueltas, y la home ya tiene su propia puerta al modo clínico. Dos puertas para el mismo público es ruido.
- **El orden de `/ciencia`.** El bloque va después del PET por secuencia clínica (diagnóstico → patología → perfil molecular → imagen → extensión interactiva → ejes terapéuticos), no por descuido.

## Verificación

En local, con `?nivel=pro`: el conmutador queda en «Para profesionales» y mapa y biopsia visibles. Sin parámetro: se entra en el resumen llano, como antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)